### PR TITLE
quarter hour aggregates fix

### DIFF
--- a/.github/workflows/format-and-deps.yml
+++ b/.github/workflows/format-and-deps.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: check
+name: format-and-deps
 
 on:
   pull_request:
@@ -8,23 +8,14 @@ on:
       - dev
 
 jobs:
-  check:
-    name: check
+  format-and-deps:
+    name: format-and-deps
     runs-on: ubuntu-latest
-
-    services:
-      timescaledb:
-        image: timescale/timescaledb-ha:pg14-latest
-        env:
-          POSTGRES_DB: ozds
-          POSTGRES_USER: ozds
-          POSTGRES_PASSWORD: ozds
-        ports:
-          - 5432:5432
-
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_HRVOJE }}
 
       - name: install-nix
         uses: cachix/install-nix-action@v30
@@ -34,8 +25,14 @@ jobs:
       - name: prepare
         run: nix develop .#check -c dotnet tool restore
 
-      - name: lint
-        run: nix develop .#check -c just lint
+      - name: deps
+        run: nix develop .#check -c just deps
 
-      - name: test
-        run: nix develop .#check -c just test
+      - name: format
+        run: nix develop .#check -c just format
+
+      - name: commit
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: format & deps.nix
+          branch: ${{ github.head_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Pass `CancellationToken.None` to `BeforeStopAsync` reactor handler for now
 - Rollback measurement transactions only when a transaction is present
 - Separate `check` workflow into `formant-and-deps` and `check` workflows to
-  allow `auto-comit-action` to trigger `check` workflow re-runs
+  allow `auto-commit-action` to trigger `check` workflow re-runs
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Made buffer hint optional
 - Pass `CancellationToken.None` to `BeforeStopAsync` reactor handler for now
 - Rollback measurement transactions only when a transaction is present
+- Separate `check` workflow into `formant-and-deps` and `check` workflows to
+  allow `auto-comit-action` to trigger `check` workflow re-runs
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] - 2025-03-5
+## [1.0.1] - 2025-03-07
+
+## Changed
+
+- Fix `quarter_hour_count` edge cases for daily, monthly aggregate mutations
+- Made buffer hint optional
+- Pass `CancellationToken.None` to `BeforeStopAsync` reactor handler for now
+- Rollback measurement transactions only when a transaction is present
+
+## Added
+
+- Build caching
+
+## [1.0.0] - 2025-03-05
 
 ### Added
 
 - init
 
+[1.0.1]: https://github.com/altibiz/ozds/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/altibiz/ozds/releases/tag/1.0.0

--- a/flake.nix
+++ b/flake.nix
@@ -26,4 +26,13 @@
       root = ./.;
       prefix = "scripts/flake";
     };
+
+  nixConfig = {
+    extra-substituters = [
+      "s3://nix-binary-cache?endpoint=s3.lvm.altibiz.com"
+    ];
+    extra-trusted-public-keys = [
+      "s3.lvm.altibiz.com:2joxncr8RIOfSZcVvt79MvvX3IA4ulUjdc2mkKUR1xc="
+    ];
+  };
 }

--- a/scripts/flake/dev.nix
+++ b/scripts/flake/dev.nix
@@ -106,6 +106,7 @@
             nodePackages.cspell
 
             # Scripts
+            s3cmd
             just
             nushell
             nix-bundle

--- a/scripts/flake/raspberryPi4.nix
+++ b/scripts/flake/raspberryPi4.nix
@@ -268,6 +268,9 @@ in
       services.ozds.enable = true;
       services.ozds.environmentFile =
         config.sops.secrets.${secretKeys.ozdsEnv}.path;
+      services.ozds.environment = {
+        Logging__LogLevel__Ozds = "debug";
+      };
       services.ozds.openFirewall = true;
       services.ozds.httpPort = 80;
       services.ozds.httpsPort = 443;

--- a/src/Ozds.Business/Reactors/Base/Reactor.cs
+++ b/src/Ozds.Business/Reactors/Base/Reactor.cs
@@ -7,6 +7,7 @@ namespace Ozds.Business.Reactors.Base;
 
 // TODO: preserve events in db on shutdown and restore on startup and do not
 // pass stopping token to handler
+// TODO: pass a meaningful CancellationToken to BeforeStopAsync handlers
 
 public abstract class Reactor<TEventArgs, TSubscriber, THandler>(
   IServiceProvider serviceProvider
@@ -132,7 +133,7 @@ public abstract class Reactor<TEventArgs, TSubscriber, THandler>(
           handler.GetType().Name,
           GetType().Name
         );
-        await handler.BeforeStopAsync(stoppingToken);
+        await handler.BeforeStopAsync(CancellationToken.None);
       }
       catch (Exception ex)
       {

--- a/src/Ozds.Data/Mutations/MeasurementMutations.cs
+++ b/src/Ozds.Data/Mutations/MeasurementMutations.cs
@@ -149,6 +149,7 @@ public class MeasurementMutations(
           {
             await transaction.RollbackAsync(cancellationToken);
           }
+
           throw;
         }
       }
@@ -444,16 +445,16 @@ public class MeasurementMutations(
     var properties = entityType.GetScalarPropertiesRecursive().ToList();
 
     var values = $"({string.Join(
-        ", ", properties
-          .Select(
-            property =>
-            {
-              var columnName = property.GetColumnName(storeObjectIdentifier);
-              return $"@p{indexSubstitution}_{columnName}"
-                + (property.ClrType.IsEnum
-                  ? $"::{StringExtensions.ToSnakeCase(property.ClrType.Name)}"
-                  : "");
-            }))})";
+      ", ", properties
+        .Select(
+          property =>
+          {
+            var columnName = property.GetColumnName(storeObjectIdentifier);
+            return $"@p{indexSubstitution}_{columnName}"
+              + (property.ClrType.IsEnum
+                ? $"::{StringExtensions.ToSnakeCase(property.ClrType.Name)}"
+                : "");
+          }))})";
 
     return values;
   }
@@ -795,14 +796,14 @@ public class MeasurementMutations(
           SELECT {tableName}.*
           FROM {tableName}
           WHERE {string.Join(
-              " AND ",
-              primaryKeyColumns.Select(
-                c =>
-                  $"{tableName}.{c.ColumnName}"
-                  + $" = @p{indexSubstitution}_{c.ColumnName}"
-                  + (c.Property.ClrType.IsEnum
-                    ? $"::{StringExtensions.ToSnakeCase(c.Property.ClrType.Name)}"
-                    : "")))}
+            " AND ",
+            primaryKeyColumns.Select(
+              c =>
+                $"{tableName}.{c.ColumnName}"
+                + $" = @p{indexSubstitution}_{c.ColumnName}"
+                + (c.Property.ClrType.IsEnum
+                  ? $"::{StringExtensions.ToSnakeCase(c.Property.ClrType.Name)}"
+                  : "")))}
         ), new{indexSubstitution} AS (
           INSERT INTO {tableName} ({columns})
           VALUES {values}
@@ -823,10 +824,10 @@ public class MeasurementMutations(
               AT TIME ZONE 'Europe/Zagreb'
               monthly_timestamp,
               {string.Join(
-                  ", ",
-                  primaryKeyColumns.Select(
-                    c =>
-                      $"new{indexSubstitution}.{c.ColumnName}"))},
+                ", ",
+                primaryKeyColumns.Select(
+                  c =>
+                    $"new{indexSubstitution}.{c.ColumnName}"))},
             CASE
               WHEN old{indexSubstitution}.{timestampColumn} is null then 1
               ELSE 0
@@ -835,10 +836,10 @@ public class MeasurementMutations(
           FROM new{indexSubstitution}
           LEFT JOIN old{indexSubstitution} ON
             {string.Join(
-                " AND ",
-                primaryKeyColumns.Select(
-                  c => $"old{indexSubstitution}.{c.ColumnName}"
-                    + $" = new{indexSubstitution}.{c.ColumnName}"))}
+              " AND ",
+              primaryKeyColumns.Select(
+                c => $"old{indexSubstitution}.{c.ColumnName}"
+                  + $" = new{indexSubstitution}.{c.ColumnName}"))}
         ), daily{indexSubstitution} AS (
           UPDATE {tableName} SET
             {string.Join(", ", deltaUpsertClauses)}
@@ -849,16 +850,16 @@ public class MeasurementMutations(
             AND {tableName}.{intervalColumn}
               = '{dayIntervalValue}'::{intervalTypeName}
             AND {string.Join(
-                " AND ",
-                primaryKeyColumns
-                  .Where(
-                    c =>
-                      c.ColumnName != timestampColumn
-                      && c.ColumnName != intervalColumn)
-                  .Select(
-                    c =>
-                      $"{tableName}.{c.ColumnName}"
-                      + $" = delta{indexSubstitution}.{c.ColumnName}"))}
+              " AND ",
+              primaryKeyColumns
+                .Where(
+                  c =>
+                    c.ColumnName != timestampColumn
+                    && c.ColumnName != intervalColumn)
+                .Select(
+                  c =>
+                    $"{tableName}.{c.ColumnName}"
+                    + $" = delta{indexSubstitution}.{c.ColumnName}"))}
           RETURNING {tableName}.*
         ), monthly{indexSubstitution} AS (
           UPDATE {tableName} SET
@@ -870,16 +871,16 @@ public class MeasurementMutations(
             AND {tableName}.{intervalColumn}
               = '{monthIntervalValue}'::{intervalTypeName}
             AND {string.Join(
-                " AND ",
-                primaryKeyColumns
-                  .Where(
-                    c =>
-                      c.ColumnName != timestampColumn
-                      && c.ColumnName != intervalColumn)
-                  .Select(
-                    c =>
-                      $"{tableName}.{c.ColumnName}"
-                      + $" = delta{indexSubstitution}.{c.ColumnName}"))}
+              " AND ",
+              primaryKeyColumns
+                .Where(
+                  c =>
+                    c.ColumnName != timestampColumn
+                    && c.ColumnName != intervalColumn)
+                .Select(
+                  c =>
+                    $"{tableName}.{c.ColumnName}"
+                    + $" = delta{indexSubstitution}.{c.ColumnName}"))}
           RETURNING {tableName}.*
         )
       ",

--- a/src/Ozds.Server/Controllers/IotController.cs
+++ b/src/Ozds.Server/Controllers/IotController.cs
@@ -20,7 +20,7 @@ public class IotController(IPushPublisher publisher) : Controller
   public async Task<IActionResult> Push(
     string id,
     [FromHeader(Name = "X-Buffer-Behavior")]
-    string bufferBehavior = "buffer"
+    string? bufferBehavior = "buffer"
   )
   {
     IMessengerPushRequestEntity? request;


### PR DESCRIPTION
# Task

Fixes #138 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Rollback transactions only when a transaction was present.

Fix division by zero with `GREATEST(, 1, ...` when `quareter_hour_count` is 0 on derived average measure calculation for daily and monthly aggregates.

Added build caching which enabled faster testing.

Made buffer behavior hint optional.

Pass `CancellationToken.None` on `BeforeStopAsync` reactor handlers for now. The previous behavior caused exceptions because the cancellation token was already cancelled.

Separated `check` workflow into `formant-and-deps` and `check` workflows to allow `auto-comit-action` to trigger `check` workflow re-runs

## Testing

Tested on staging environment manually.

## Documentation

None needed since it is a bug fix.
