### PR TITLE
1.0.1

### DIFF
--- a/.github/workflows/format-and-deps.yml
+++ b/.github/workflows/format-and-deps.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: check
+name: format-and-deps
 
 on:
   pull_request:
@@ -8,23 +8,14 @@ on:
       - dev
 
 jobs:
-  check:
-    name: check
+  format-and-deps:
+    name: format-and-deps
     runs-on: ubuntu-latest
-
-    services:
-      timescaledb:
-        image: timescale/timescaledb-ha:pg14-latest
-        env:
-          POSTGRES_DB: ozds
-          POSTGRES_USER: ozds
-          POSTGRES_PASSWORD: ozds
-        ports:
-          - 5432:5432
-
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_HRVOJE }}
 
       - name: install-nix
         uses: cachix/install-nix-action@v30
@@ -34,8 +25,14 @@ jobs:
       - name: prepare
         run: nix develop .#check -c dotnet tool restore
 
-      - name: lint
-        run: nix develop .#check -c just lint
+      - name: deps
+        run: nix develop .#check -c just deps
 
-      - name: test
-        run: nix develop .#check -c just test
+      - name: format
+        run: nix develop .#check -c just format
+
+      - name: commit
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: format & deps.nix
+          branch: ${{ github.head_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] - 2025-03-5
+## [1.0.1] - 2025-03-07
+
+## Changed
+
+- Fix `quarter_hour_count` edge cases for daily, monthly aggregate mutations
+- Made buffer hint optional
+- Pass `CancellationToken.None` to `BeforeStopAsync` reactor handler for now
+- Rollback measurement transactions only when a transaction is present
+- Separate `check` workflow into `formant-and-deps` and `check` workflows to
+  allow `auto-commit-action` to trigger `check` workflow re-runs
+
+## Added
+
+- Build caching
+
+## [1.0.0] - 2025-03-05
 
 ### Added
 
 - init
 
+[1.0.1]: https://github.com/altibiz/ozds/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/altibiz/ozds/releases/tag/1.0.0

--- a/flake.nix
+++ b/flake.nix
@@ -26,4 +26,13 @@
       root = ./.;
       prefix = "scripts/flake";
     };
+
+  nixConfig = {
+    extra-substituters = [
+      "s3://nix-binary-cache?endpoint=s3.lvm.altibiz.com"
+    ];
+    extra-trusted-public-keys = [
+      "s3.lvm.altibiz.com:2joxncr8RIOfSZcVvt79MvvX3IA4ulUjdc2mkKUR1xc="
+    ];
+  };
 }

--- a/scripts/flake/dev.nix
+++ b/scripts/flake/dev.nix
@@ -106,6 +106,7 @@
             nodePackages.cspell
 
             # Scripts
+            s3cmd
             just
             nushell
             nix-bundle

--- a/scripts/flake/raspberryPi4.nix
+++ b/scripts/flake/raspberryPi4.nix
@@ -268,6 +268,9 @@ in
       services.ozds.enable = true;
       services.ozds.environmentFile =
         config.sops.secrets.${secretKeys.ozdsEnv}.path;
+      services.ozds.environment = {
+        Logging__LogLevel__Ozds = "debug";
+      };
       services.ozds.openFirewall = true;
       services.ozds.httpPort = 80;
       services.ozds.httpsPort = 443;

--- a/src/Ozds.Business/Reactors/Base/Reactor.cs
+++ b/src/Ozds.Business/Reactors/Base/Reactor.cs
@@ -7,6 +7,7 @@ namespace Ozds.Business.Reactors.Base;
 
 // TODO: preserve events in db on shutdown and restore on startup and do not
 // pass stopping token to handler
+// TODO: pass a meaningful CancellationToken to BeforeStopAsync handlers
 
 public abstract class Reactor<TEventArgs, TSubscriber, THandler>(
   IServiceProvider serviceProvider
@@ -132,7 +133,7 @@ public abstract class Reactor<TEventArgs, TSubscriber, THandler>(
           handler.GetType().Name,
           GetType().Name
         );
-        await handler.BeforeStopAsync(stoppingToken);
+        await handler.BeforeStopAsync(CancellationToken.None);
       }
       catch (Exception ex)
       {

--- a/src/Ozds.Data/Mutations/MeasurementMutations.cs
+++ b/src/Ozds.Data/Mutations/MeasurementMutations.cs
@@ -124,7 +124,11 @@ public class MeasurementMutations(
         }
         catch (PostgresException ex)
         {
-          await context.Database.RollbackTransactionAsync(cancellationToken);
+          if (context.Database.CurrentTransaction is { } transaction)
+          {
+            await transaction.RollbackAsync(cancellationToken);
+          }
+
           // NOTE: 40001 = could not serialize access due to
           // read/write dependencies among transactions
           // NOTE: 40P01 = deadlock detected
@@ -141,7 +145,11 @@ public class MeasurementMutations(
         }
         catch (Exception)
         {
-          await context.Database.RollbackTransactionAsync(cancellationToken);
+          if (context.Database.CurrentTransaction is { } transaction)
+          {
+            await transaction.RollbackAsync(cancellationToken);
+          }
+
           throw;
         }
       }
@@ -274,12 +282,8 @@ public class MeasurementMutations(
       if (withClauses.Count > 0)
       {
         sql = $@"
-          WITH {
-            string.Join(",\n", withClauses)
-          }
-          {
-            sql
-          }
+          WITH {string.Join(",\n", withClauses)}
+          {sql}
         ";
       }
 
@@ -440,19 +444,17 @@ public class MeasurementMutations(
         $"No store object identifier found for {type}.");
     var properties = entityType.GetScalarPropertiesRecursive().ToList();
 
-    var values = $"({
-      string.Join(
-        ", ", properties
-          .Select(
-            property =>
-            {
-              var columnName = property.GetColumnName(storeObjectIdentifier);
-              return $"@p{indexSubstitution}_{columnName}"
-                + (property.ClrType.IsEnum
-                  ? $"::{StringExtensions.ToSnakeCase(property.ClrType.Name)}"
-                  : "");
-            }))
-    })";
+    var values = $"({string.Join(
+      ", ", properties
+        .Select(
+          property =>
+          {
+            var columnName = property.GetColumnName(storeObjectIdentifier);
+            return $"@p{indexSubstitution}_{columnName}"
+              + (property.ClrType.IsEnum
+                ? $"::{StringExtensions.ToSnakeCase(property.ClrType.Name)}"
+                : "");
+          }))})";
 
     return values;
   }
@@ -498,22 +500,10 @@ public class MeasurementMutations(
 
     return new UpsertTemplate(
       null, $@"
-      INSERT INTO {
-        tableName
-      } ({
-        columns
-      })
-      VALUES {
-        values
-      }
-      ON CONFLICT ({
-        conflict
-      }) {
-        updateClause
-      }
-      RETURNING {
-        tableName
-      }.*
+      INSERT INTO {tableName} ({columns})
+      VALUES {values}
+      ON CONFLICT ({conflict}) {updateClause}
+      RETURNING {tableName}.*
     ");
   }
 
@@ -596,8 +586,9 @@ public class MeasurementMutations(
         setClauses.Add($"{quarterHourCountColumn} = 1");
 
         deltaUpsertClauses.Add(
-          $"{quarterHourCountColumn} = {tableName}.{quarterHourCountColumn}"
-          + $" + delta{indexSubstitution}.new_count"
+          $"{quarterHourCountColumn} = GREATEST(1, ("
+          + $" {tableName}.{quarterHourCountColumn}"
+          + $" + delta{indexSubstitution}.new_count))"
         );
       }
 
@@ -649,8 +640,9 @@ public class MeasurementMutations(
             $"{col} = ({tableName}.{col}"
             + $" * {tableName}.{quarterHourCountColumn}"
             + $" + delta{indexSubstitution}.{col})"
-            + $" / ({tableName}.{quarterHourCountColumn}"
-            + $" + delta{indexSubstitution}.new_count)"
+            + $" / GREATEST(1,"
+            + $" ({tableName}.{quarterHourCountColumn}"
+            + $" + delta{indexSubstitution}.new_count))"
           );
         }
         else if (col.Contains("min"))
@@ -779,31 +771,15 @@ public class MeasurementMutations(
     {
       return new UpsertTemplate(
         $@"
-          value{
-            indexSubstitution
-          } AS (
-            INSERT INTO {
-              tableName
-            } ({
-              columns
-            })
-            VALUES {
-              values
-            }
-            ON CONFLICT ({
-              conflict
-            }) {
-              updateClause
-            }
-            RETURNING {
-              tableName
-            }.*
+          value{indexSubstitution} AS (
+            INSERT INTO {tableName} ({columns})
+            VALUES {values}
+            ON CONFLICT ({conflict}) {updateClause}
+            RETURNING {tableName}.*
           )
         ",
         $@"
-          SELECT * FROM value{
-            indexSubstitution
-          }
+          SELECT * FROM value{indexSubstitution}
         "
       );
     }
@@ -816,210 +792,104 @@ public class MeasurementMutations(
 
     return new UpsertTemplate(
       $@"
-        old{
-          indexSubstitution
-        } AS (
-          SELECT {
-            tableName
-          }.*
-          FROM {
-            tableName
-          }
-          WHERE {
-            string.Join(
-              " AND ",
-              primaryKeyColumns.Select(
-                c =>
-                  $"{tableName}.{c.ColumnName}"
-                  + $" = @p{indexSubstitution}_{c.ColumnName}"
-                  + (c.Property.ClrType.IsEnum
-                    ? $"::{
-                      StringExtensions.ToSnakeCase(c.Property.ClrType.Name)
-                    }"
-                    : "")))
-          }
-        ), new{
-          indexSubstitution
-        } AS (
-          INSERT INTO {
-            tableName
-          } ({
-            columns
-          })
-          VALUES {
-            values
-          }
-          ON CONFLICT ({
-            conflict
-          }) {
-            updateClause
-          }
-          RETURNING {
-            tableName
-          }.*
-        ), delta{
-          indexSubstitution
-        } AS (
+        old{indexSubstitution} AS (
+          SELECT {tableName}.*
+          FROM {tableName}
+          WHERE {string.Join(
+            " AND ",
+            primaryKeyColumns.Select(
+              c =>
+                $"{tableName}.{c.ColumnName}"
+                + $" = @p{indexSubstitution}_{c.ColumnName}"
+                + (c.Property.ClrType.IsEnum
+                  ? $"::{StringExtensions.ToSnakeCase(c.Property.ClrType.Name)}"
+                  : "")))}
+        ), new{indexSubstitution} AS (
+          INSERT INTO {tableName} ({columns})
+          VALUES {values}
+          ON CONFLICT ({conflict}) {updateClause}
+          RETURNING {tableName}.*
+        ), delta{indexSubstitution} AS (
           SELECT
             date_trunc(
               'day',
-              new{
-                indexSubstitution
-              }.{
-                timestampColumn
-              }
+              new{indexSubstitution}.{timestampColumn}
                 AT TIME ZONE 'Europe/Zagreb')
               AT TIME ZONE 'Europe/Zagreb'
               daily_timestamp,
             date_trunc(
               'month',
-              new{
-                indexSubstitution
-              }.{
-                timestampColumn
-              }
+              new{indexSubstitution}.{timestampColumn}
                 AT TIME ZONE 'Europe/Zagreb')
               AT TIME ZONE 'Europe/Zagreb'
               monthly_timestamp,
-              {
-                string.Join(
-                  ", ",
-                  primaryKeyColumns.Select(
-                    c =>
-                      $"new{indexSubstitution}.{c.ColumnName}"))
-              },
+              {string.Join(
+                ", ",
+                primaryKeyColumns.Select(
+                  c =>
+                    $"new{indexSubstitution}.{c.ColumnName}"))},
             CASE
-              WHEN old{
-                indexSubstitution
-              }.{
-                timestampColumn
-              } is null then 1
+              WHEN old{indexSubstitution}.{timestampColumn} is null then 1
               ELSE 0
             END new_count,
-            {
-              string.Join(", ", deltaClauses)
-            }
-          FROM new{
-            indexSubstitution
-          }
-          LEFT JOIN old{
-            indexSubstitution
-          } ON
-            {
-              string.Join(
-                " AND ",
-                primaryKeyColumns.Select(
-                  c => $"old{indexSubstitution}.{c.ColumnName}"
-                    + $" = new{indexSubstitution}.{c.ColumnName}"))
-            }
-        ), daily{
-          indexSubstitution
-        } AS (
-          UPDATE {
-            tableName
-          } SET
-            {
-              string.Join(", ", deltaUpsertClauses)
-            }
-          FROM delta{
-            indexSubstitution
-          }
+            {string.Join(", ", deltaClauses)}
+          FROM new{indexSubstitution}
+          LEFT JOIN old{indexSubstitution} ON
+            {string.Join(
+              " AND ",
+              primaryKeyColumns.Select(
+                c => $"old{indexSubstitution}.{c.ColumnName}"
+                  + $" = new{indexSubstitution}.{c.ColumnName}"))}
+        ), daily{indexSubstitution} AS (
+          UPDATE {tableName} SET
+            {string.Join(", ", deltaUpsertClauses)}
+          FROM delta{indexSubstitution}
           WHERE
-            {
-              tableName
-            }.{
-              timestampColumn
-            }
-              = delta{
-                indexSubstitution
-              }.daily_timestamp
-            AND {
-              tableName
-            }.{
-              intervalColumn
-            }
-              = '{
-                dayIntervalValue
-              }'::{
-                intervalTypeName
-              }
-            AND {
-              string.Join(
-                " AND ",
-                primaryKeyColumns
-                  .Where(
-                    c =>
-                      c.ColumnName != timestampColumn
-                      && c.ColumnName != intervalColumn)
-                  .Select(
-                    c =>
-                      $"{tableName}.{c.ColumnName}"
-                      + $" = delta{indexSubstitution}.{c.ColumnName}"))
-            }
-          RETURNING {
-            tableName
-          }.*
-        ), monthly{
-          indexSubstitution
-        } AS (
-          UPDATE {
-            tableName
-          } SET
-            {
-              string.Join(", ", deltaUpsertClauses)
-            }
-          FROM delta{
-            indexSubstitution
-          }
+            {tableName}.{timestampColumn}
+              = delta{indexSubstitution}.daily_timestamp
+            AND {tableName}.{intervalColumn}
+              = '{dayIntervalValue}'::{intervalTypeName}
+            AND {string.Join(
+              " AND ",
+              primaryKeyColumns
+                .Where(
+                  c =>
+                    c.ColumnName != timestampColumn
+                    && c.ColumnName != intervalColumn)
+                .Select(
+                  c =>
+                    $"{tableName}.{c.ColumnName}"
+                    + $" = delta{indexSubstitution}.{c.ColumnName}"))}
+          RETURNING {tableName}.*
+        ), monthly{indexSubstitution} AS (
+          UPDATE {tableName} SET
+            {string.Join(", ", deltaUpsertClauses)}
+          FROM delta{indexSubstitution}
           WHERE
-            {
-              tableName
-            }.{
-              timestampColumn
-            }
-              = delta{
-                indexSubstitution
-              }.monthly_timestamp
-            AND {
-              tableName
-            }.{
-              intervalColumn
-            }
-              = '{
-                monthIntervalValue
-              }'::{
-                intervalTypeName
-              }
-            AND {
-              string.Join(
-                " AND ",
-                primaryKeyColumns
-                  .Where(
-                    c =>
-                      c.ColumnName != timestampColumn
-                      && c.ColumnName != intervalColumn)
-                  .Select(
-                    c =>
-                      $"{tableName}.{c.ColumnName}"
-                      + $" = delta{indexSubstitution}.{c.ColumnName}"))
-            }
-          RETURNING {
-            tableName
-          }.*
+            {tableName}.{timestampColumn}
+              = delta{indexSubstitution}.monthly_timestamp
+            AND {tableName}.{intervalColumn}
+              = '{monthIntervalValue}'::{intervalTypeName}
+            AND {string.Join(
+              " AND ",
+              primaryKeyColumns
+                .Where(
+                  c =>
+                    c.ColumnName != timestampColumn
+                    && c.ColumnName != intervalColumn)
+                .Select(
+                  c =>
+                    $"{tableName}.{c.ColumnName}"
+                    + $" = delta{indexSubstitution}.{c.ColumnName}"))}
+          RETURNING {tableName}.*
         )
       ",
       $@"
-        SELECT * FROM new{
-          indexSubstitution
-        }
+        SELECT * FROM new{indexSubstitution}
         UNION ALL
-        SELECT * FROM daily{
-          indexSubstitution
-        }
+        SELECT * FROM daily{indexSubstitution}
         UNION ALL
-        SELECT * FROM monthly{
-          indexSubstitution
-        }
+        SELECT * FROM monthly{indexSubstitution}
       "
     );
   }

--- a/src/Ozds.Server/Controllers/IotController.cs
+++ b/src/Ozds.Server/Controllers/IotController.cs
@@ -20,7 +20,7 @@ public class IotController(IPushPublisher publisher) : Controller
   public async Task<IActionResult> Push(
     string id,
     [FromHeader(Name = "X-Buffer-Behavior")]
-    string bufferBehavior = "buffer"
+    string? bufferBehavior = "buffer"
   )
   {
     IMessengerPushRequestEntity? request;


### PR DESCRIPTION
# 1.0.1

## Changed

- Fix `quarter_hour_count` edge cases for daily, monthly aggregate mutations
- Made buffer hint optional
- Pass `CancellationToken.None` to `BeforeStopAsync` reactor handler for now
- Rollback measurement transactions only when a transaction is present
- Separate `check` workflow into `formant-and-deps` and `check` workflows to
  allow `auto-commit-action` to trigger `check` workflow re-runs

## Added

- Build caching