### PR TITLE
precision of numeric values in db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Remarks on network user invoice documents
 - Support for collocated JS scripts in `AppController`
 - `DownloadController` for network user invoices (previews)
+- Migration to use correct column types for numeric values
+- `DerivedAggregateMeasureModel` and `DerivedAggregateMeasureEntity` that better
+  represent derived power measures on aggregate measurements
+- Added new primitive conversion functions for floats and longs
 
 ### Changed
 
@@ -37,7 +41,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Moved `link` tags to `ThemeStateProvider` since the `Ozds.Server` shouldn't
   care about the different libraries present
 - Removed `MudBlazor` from `ErrorBoundary`
-- Layout issues on network user invoice PDF-s
+- Changed types of numeric properties in `Ozds.Data` to more precise ones
+  (`decimal(19, 4)` for monetary values, `bigint` for cumulative measurement
+  values, `float` for instantaneous measurement values)
+- Fix support for collocated JS scripts in `AppController`
 
 ### Removed
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -67,26 +67,26 @@ erDiagram
     }
 
     abb_b2x_aggregates {
-        real active_energy_l1_export_t0_max_wh
-        real active_energy_l1_export_t0_min_wh
-        real active_energy_l1_import_t0_max_wh
-        real active_energy_l1_import_t0_min_wh
-        real active_energy_l2_export_t0_max_wh
-        real active_energy_l2_export_t0_min_wh
-        real active_energy_l2_import_t0_max_wh
-        real active_energy_l2_import_t0_min_wh
-        real active_energy_l3_export_t0_max_wh
-        real active_energy_l3_export_t0_min_wh
-        real active_energy_l3_import_t0_max_wh
-        real active_energy_l3_import_t0_min_wh
-        real active_energy_total_export_t0_max_wh
-        real active_energy_total_export_t0_min_wh
-        real active_energy_total_import_t0_max_wh
-        real active_energy_total_import_t0_min_wh
-        real active_energy_total_import_t1_max_wh
-        real active_energy_total_import_t1_min_wh
-        real active_energy_total_import_t2_max_wh
-        real active_energy_total_import_t2_min_wh
+        bigint active_energy_l1_export_t0_max_wh
+        bigint active_energy_l1_export_t0_min_wh
+        bigint active_energy_l1_import_t0_max_wh
+        bigint active_energy_l1_import_t0_min_wh
+        bigint active_energy_l2_export_t0_max_wh
+        bigint active_energy_l2_export_t0_min_wh
+        bigint active_energy_l2_import_t0_max_wh
+        bigint active_energy_l2_import_t0_min_wh
+        bigint active_energy_l3_export_t0_max_wh
+        bigint active_energy_l3_export_t0_min_wh
+        bigint active_energy_l3_import_t0_max_wh
+        bigint active_energy_l3_import_t0_min_wh
+        bigint active_energy_total_export_t0_max_wh
+        bigint active_energy_total_export_t0_min_wh
+        bigint active_energy_total_import_t0_max_wh
+        bigint active_energy_total_import_t0_min_wh
+        bigint active_energy_total_import_t1_max_wh
+        bigint active_energy_total_import_t1_min_wh
+        bigint active_energy_total_import_t2_max_wh
+        bigint active_energy_total_import_t2_min_wh
         real active_power_l1_net_t0_avg_w
         timestamp_with_time_zone active_power_l1_net_t0_max_timestamp
         real active_power_l1_net_t0_max_w
@@ -118,116 +118,116 @@ erDiagram
         timestamp_with_time_zone current_l3_any_t0_max_timestamp
         real current_l3_any_t0_min_a
         timestamp_with_time_zone current_l3_any_t0_min_timestamp
-        real derived_active_power_l1_export_t0_avg_w
+        double_precision derived_active_power_l1_export_t0_avg_w
         timestamp_with_time_zone derived_active_power_l1_export_t0_max_timestamp
-        real derived_active_power_l1_export_t0_max_w
+        bigint derived_active_power_l1_export_t0_max_w
         timestamp_with_time_zone derived_active_power_l1_export_t0_min_timestamp
-        real derived_active_power_l1_export_t0_min_w
-        real derived_active_power_l1_import_t0_avg_w
+        bigint derived_active_power_l1_export_t0_min_w
+        double_precision derived_active_power_l1_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_l1_import_t0_max_timestamp
-        real derived_active_power_l1_import_t0_max_w
+        bigint derived_active_power_l1_import_t0_max_w
         timestamp_with_time_zone derived_active_power_l1_import_t0_min_timestamp
-        real derived_active_power_l1_import_t0_min_w
-        real derived_active_power_l2_export_t0_avg_w
+        bigint derived_active_power_l1_import_t0_min_w
+        double_precision derived_active_power_l2_export_t0_avg_w
         timestamp_with_time_zone derived_active_power_l2_export_t0_max_timestamp
-        real derived_active_power_l2_export_t0_max_w
+        bigint derived_active_power_l2_export_t0_max_w
         timestamp_with_time_zone derived_active_power_l2_export_t0_min_timestamp
-        real derived_active_power_l2_export_t0_min_w
-        real derived_active_power_l2_import_t0_avg_w
+        bigint derived_active_power_l2_export_t0_min_w
+        double_precision derived_active_power_l2_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_l2_import_t0_max_timestamp
-        real derived_active_power_l2_import_t0_max_w
+        bigint derived_active_power_l2_import_t0_max_w
         timestamp_with_time_zone derived_active_power_l2_import_t0_min_timestamp
-        real derived_active_power_l2_import_t0_min_w
-        real derived_active_power_l3_export_t0_avg_w
+        bigint derived_active_power_l2_import_t0_min_w
+        double_precision derived_active_power_l3_export_t0_avg_w
         timestamp_with_time_zone derived_active_power_l3_export_t0_max_timestamp
-        real derived_active_power_l3_export_t0_max_w
+        bigint derived_active_power_l3_export_t0_max_w
         timestamp_with_time_zone derived_active_power_l3_export_t0_min_timestamp
-        real derived_active_power_l3_export_t0_min_w
-        real derived_active_power_l3_import_t0_avg_w
+        bigint derived_active_power_l3_export_t0_min_w
+        double_precision derived_active_power_l3_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_l3_import_t0_max_timestamp
-        real derived_active_power_l3_import_t0_max_w
+        bigint derived_active_power_l3_import_t0_max_w
         timestamp_with_time_zone derived_active_power_l3_import_t0_min_timestamp
-        real derived_active_power_l3_import_t0_min_w
-        real derived_active_power_total_export_t0_avg_w
+        bigint derived_active_power_l3_import_t0_min_w
+        double_precision derived_active_power_total_export_t0_avg_w
         timestamp_with_time_zone derived_active_power_total_export_t0_max_timestamp
-        real derived_active_power_total_export_t0_max_w
+        bigint derived_active_power_total_export_t0_max_w
         timestamp_with_time_zone derived_active_power_total_export_t0_min_timestamp
-        real derived_active_power_total_export_t0_min_w
-        real derived_active_power_total_import_t0_avg_w
+        bigint derived_active_power_total_export_t0_min_w
+        double_precision derived_active_power_total_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_total_import_t0_max_timestamp
-        real derived_active_power_total_import_t0_max_w
+        bigint derived_active_power_total_import_t0_max_w
         timestamp_with_time_zone derived_active_power_total_import_t0_min_timestamp
-        real derived_active_power_total_import_t0_min_w
-        real derived_active_power_total_import_t1_avg_w
+        bigint derived_active_power_total_import_t0_min_w
+        double_precision derived_active_power_total_import_t1_avg_w
         timestamp_with_time_zone derived_active_power_total_import_t1_max_timestamp
-        real derived_active_power_total_import_t1_max_w
+        bigint derived_active_power_total_import_t1_max_w
         timestamp_with_time_zone derived_active_power_total_import_t1_min_timestamp
-        real derived_active_power_total_import_t1_min_w
-        real derived_active_power_total_import_t2_avg_w
+        bigint derived_active_power_total_import_t1_min_w
+        double_precision derived_active_power_total_import_t2_avg_w
         timestamp_with_time_zone derived_active_power_total_import_t2_max_timestamp
-        real derived_active_power_total_import_t2_max_w
+        bigint derived_active_power_total_import_t2_max_w
         timestamp_with_time_zone derived_active_power_total_import_t2_min_timestamp
-        real derived_active_power_total_import_t2_min_w
-        real derived_reactive_power_l1_export_t0_avg_var
+        bigint derived_active_power_total_import_t2_min_w
+        double_precision derived_reactive_power_l1_export_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_l1_export_t0_max_timestamp
-        real derived_reactive_power_l1_export_t0_max_var
+        bigint derived_reactive_power_l1_export_t0_max_var
         timestamp_with_time_zone derived_reactive_power_l1_export_t0_min_timestamp
-        real derived_reactive_power_l1_export_t0_min_var
-        real derived_reactive_power_l1_import_t0_avg_var
+        bigint derived_reactive_power_l1_export_t0_min_var
+        double_precision derived_reactive_power_l1_import_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_l1_import_t0_max_timestamp
-        real derived_reactive_power_l1_import_t0_max_var
+        bigint derived_reactive_power_l1_import_t0_max_var
         timestamp_with_time_zone derived_reactive_power_l1_import_t0_min_timestamp
-        real derived_reactive_power_l1_import_t0_min_var
-        real derived_reactive_power_l2_export_t0_avg_var
+        bigint derived_reactive_power_l1_import_t0_min_var
+        double_precision derived_reactive_power_l2_export_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_l2_export_t0_max_timestamp
-        real derived_reactive_power_l2_export_t0_max_var
+        bigint derived_reactive_power_l2_export_t0_max_var
         timestamp_with_time_zone derived_reactive_power_l2_export_t0_min_timestamp
-        real derived_reactive_power_l2_export_t0_min_var
-        real derived_reactive_power_l2_import_t0_avg_var
+        bigint derived_reactive_power_l2_export_t0_min_var
+        double_precision derived_reactive_power_l2_import_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_l2_import_t0_max_timestamp
-        real derived_reactive_power_l2_import_t0_max_var
+        bigint derived_reactive_power_l2_import_t0_max_var
         timestamp_with_time_zone derived_reactive_power_l2_import_t0_min_timestamp
-        real derived_reactive_power_l2_import_t0_min_var
-        real derived_reactive_power_l3_export_t0_avg_var
+        bigint derived_reactive_power_l2_import_t0_min_var
+        double_precision derived_reactive_power_l3_export_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_l3_export_t0_max_timestamp
-        real derived_reactive_power_l3_export_t0_max_var
+        bigint derived_reactive_power_l3_export_t0_max_var
         timestamp_with_time_zone derived_reactive_power_l3_export_t0_min_timestamp
-        real derived_reactive_power_l3_export_t0_min_var
-        real derived_reactive_power_l3_import_t0_avg_var
+        bigint derived_reactive_power_l3_export_t0_min_var
+        double_precision derived_reactive_power_l3_import_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_l3_import_t0_max_timestamp
-        real derived_reactive_power_l3_import_t0_max_var
+        bigint derived_reactive_power_l3_import_t0_max_var
         timestamp_with_time_zone derived_reactive_power_l3_import_t0_min_timestamp
-        real derived_reactive_power_l3_import_t0_min_var
-        real derived_reactive_power_total_export_t0_avg_var
+        bigint derived_reactive_power_l3_import_t0_min_var
+        double_precision derived_reactive_power_total_export_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_total_export_t0_max_timestamp
-        real derived_reactive_power_total_export_t0_max_var
+        bigint derived_reactive_power_total_export_t0_max_var
         timestamp_with_time_zone derived_reactive_power_total_export_t0_min_timestamp
-        real derived_reactive_power_total_export_t0_min_var
-        real derived_reactive_power_total_import_t0_avg_var
+        bigint derived_reactive_power_total_export_t0_min_var
+        double_precision derived_reactive_power_total_import_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_total_import_t0_max_timestamp
-        real derived_reactive_power_total_import_t0_max_var
+        bigint derived_reactive_power_total_import_t0_max_var
         timestamp_with_time_zone derived_reactive_power_total_import_t0_min_timestamp
-        real derived_reactive_power_total_import_t0_min_var
+        bigint derived_reactive_power_total_import_t0_min_var
         interval_entity interval PK
         bigint measurement_location_id PK,FK
         text meter_id PK,FK
         bigint quarter_hour_count
-        real reactive_energy_l1_export_t0_max_varh
-        real reactive_energy_l1_export_t0_min_varh
-        real reactive_energy_l1_import_t0_max_varh
-        real reactive_energy_l1_import_t0_min_varh
-        real reactive_energy_l2_export_t0_max_varh
-        real reactive_energy_l2_export_t0_min_varh
-        real reactive_energy_l2_import_t0_max_varh
-        real reactive_energy_l2_import_t0_min_varh
-        real reactive_energy_l3_export_t0_max_varh
-        real reactive_energy_l3_export_t0_min_varh
-        real reactive_energy_l3_import_t0_max_varh
-        real reactive_energy_l3_import_t0_min_varh
-        real reactive_energy_total_export_t0_max_varh
-        real reactive_energy_total_export_t0_min_varh
-        real reactive_energy_total_import_t0_max_varh
-        real reactive_energy_total_import_t0_min_varh
+        bigint reactive_energy_l1_export_t0_max_varh
+        bigint reactive_energy_l1_export_t0_min_varh
+        bigint reactive_energy_l1_import_t0_max_varh
+        bigint reactive_energy_l1_import_t0_min_varh
+        bigint reactive_energy_l2_export_t0_max_varh
+        bigint reactive_energy_l2_export_t0_min_varh
+        bigint reactive_energy_l2_import_t0_max_varh
+        bigint reactive_energy_l2_import_t0_min_varh
+        bigint reactive_energy_l3_export_t0_max_varh
+        bigint reactive_energy_l3_export_t0_min_varh
+        bigint reactive_energy_l3_import_t0_max_varh
+        bigint reactive_energy_l3_import_t0_min_varh
+        bigint reactive_energy_total_export_t0_max_varh
+        bigint reactive_energy_total_export_t0_min_varh
+        bigint reactive_energy_total_import_t0_max_varh
+        bigint reactive_energy_total_import_t0_min_varh
         real reactive_power_l1_net_t0_avg_var
         timestamp_with_time_zone reactive_power_l1_net_t0_max_timestamp
         real reactive_power_l1_net_t0_max_var
@@ -262,16 +262,16 @@ erDiagram
     }
 
     abb_b2x_measurements {
-        real active_energy_l1_export_t0_wh
-        real active_energy_l1_import_t0_wh
-        real active_energy_l2_export_t0_wh
-        real active_energy_l2_import_t0_wh
-        real active_energy_l3_export_t0_wh
-        real active_energy_l3_import_t0_wh
-        real active_energy_total_export_t0_wh
-        real active_energy_total_import_t0_wh
-        real active_energy_total_import_t1_wh
-        real active_energy_total_import_t2_wh
+        bigint active_energy_l1_export_t0_wh
+        bigint active_energy_l1_import_t0_wh
+        bigint active_energy_l2_export_t0_wh
+        bigint active_energy_l2_import_t0_wh
+        bigint active_energy_l3_export_t0_wh
+        bigint active_energy_l3_import_t0_wh
+        bigint active_energy_total_export_t0_wh
+        bigint active_energy_total_import_t0_wh
+        bigint active_energy_total_import_t1_wh
+        bigint active_energy_total_import_t2_wh
         real active_power_l1_net_t0_w
         real active_power_l2_net_t0_w
         real active_power_l3_net_t0_w
@@ -280,14 +280,14 @@ erDiagram
         real current_l3_any_t0_a
         bigint measurement_location_id PK,FK
         text meter_id PK,FK
-        real reactive_energy_l1_export_t0_varh
-        real reactive_energy_l1_import_t0_varh
-        real reactive_energy_l2_export_t0_varh
-        real reactive_energy_l2_import_t0_varh
-        real reactive_energy_l3_export_t0_varh
-        real reactive_energy_l3_import_t0_varh
-        real reactive_energy_total_export_t0_varh
-        real reactive_energy_total_import_t0_varh
+        bigint reactive_energy_l1_export_t0_varh
+        bigint reactive_energy_l1_import_t0_varh
+        bigint reactive_energy_l2_export_t0_varh
+        bigint reactive_energy_l2_import_t0_varh
+        bigint reactive_energy_l3_export_t0_varh
+        bigint reactive_energy_l3_import_t0_varh
+        bigint reactive_energy_total_export_t0_varh
+        bigint reactive_energy_total_import_t0_varh
         real reactive_power_l1_net_t0_var
         real reactive_power_l2_net_t0_var
         real reactive_power_l3_net_t0_var
@@ -642,8 +642,8 @@ erDiagram
         timestamp_with_time_zone issued_on
         bigint network_user_id FK
         text remark
-        numeric supply_active_energy_total_import_t1fee_eur
-        numeric supply_active_energy_total_import_t2fee_eur
+        numeric supply_active_energy_total_import_t1_fee_eur
+        numeric supply_active_energy_total_import_t2_fee_eur
         numeric supply_business_usage_fee_eur
         numeric supply_fee_total_eur
         numeric supply_renewable_energy_fee_eur
@@ -653,13 +653,13 @@ erDiagram
         timestamp_with_time_zone to_date
         numeric total_eur
         numeric total_with_tax_eur
-        numeric usage_active_energy_total_import_t0fee_eur
-        numeric usage_active_energy_total_import_t1fee_eur
-        numeric usage_active_energy_total_import_t2fee_eur
-        numeric usage_active_power_total_import_t1peak_fee_eur
+        numeric usage_active_energy_total_import_t0_fee_eur
+        numeric usage_active_energy_total_import_t1_fee_eur
+        numeric usage_active_energy_total_import_t2_fee_eur
+        numeric usage_active_power_total_import_t1_peak_fee_eur
         numeric usage_fee_total_eur
         numeric usage_meter_fee_eur
-        numeric usage_reactive_energy_total_ramped_t0fee_eur
+        numeric usage_reactive_energy_total_ramped_t0_fee_eur
     }
 
     network_user_representatives {
@@ -891,20 +891,20 @@ erDiagram
     }
 
     schneider_iem3xxx_aggregates {
-        real active_energy_l1_import_t0_max_wh
-        real active_energy_l1_import_t0_min_wh
-        real active_energy_l2_import_t0_max_wh
-        real active_energy_l2_import_t0_min_wh
-        real active_energy_l3_import_t0_max_wh
-        real active_energy_l3_import_t0_min_wh
-        real active_energy_total_export_t0_max_wh
-        real active_energy_total_export_t0_min_wh
-        real active_energy_total_import_t0_max_wh
-        real active_energy_total_import_t0_min_wh
-        real active_energy_total_import_t1_max_wh
-        real active_energy_total_import_t1_min_wh
-        real active_energy_total_import_t2_max_wh
-        real active_energy_total_import_t2_min_wh
+        bigint active_energy_l1_import_t0_max_wh
+        bigint active_energy_l1_import_t0_min_wh
+        bigint active_energy_l2_import_t0_max_wh
+        bigint active_energy_l2_import_t0_min_wh
+        bigint active_energy_l3_import_t0_max_wh
+        bigint active_energy_l3_import_t0_min_wh
+        bigint active_energy_total_export_t0_max_wh
+        bigint active_energy_total_export_t0_min_wh
+        bigint active_energy_total_import_t0_max_wh
+        bigint active_energy_total_import_t0_min_wh
+        bigint active_energy_total_import_t1_max_wh
+        bigint active_energy_total_import_t1_min_wh
+        bigint active_energy_total_import_t2_max_wh
+        bigint active_energy_total_import_t2_min_wh
         real active_power_l1_net_t0_avg_w
         timestamp_with_time_zone active_power_l1_net_t0_max_timestamp
         real active_power_l1_net_t0_max_w
@@ -941,59 +941,59 @@ erDiagram
         timestamp_with_time_zone current_l3_any_t0_max_timestamp
         real current_l3_any_t0_min_a
         timestamp_with_time_zone current_l3_any_t0_min_timestamp
-        real derived_active_power_l1_import_t0_avg_w
+        double_precision derived_active_power_l1_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_l1_import_t0_max_timestamp
-        real derived_active_power_l1_import_t0_max_w
+        bigint derived_active_power_l1_import_t0_max_w
         timestamp_with_time_zone derived_active_power_l1_import_t0_min_timestamp
-        real derived_active_power_l1_import_t0_min_w
-        real derived_active_power_l2_import_t0_avg_w
+        bigint derived_active_power_l1_import_t0_min_w
+        double_precision derived_active_power_l2_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_l2_import_t0_max_timestamp
-        real derived_active_power_l2_import_t0_max_w
+        bigint derived_active_power_l2_import_t0_max_w
         timestamp_with_time_zone derived_active_power_l2_import_t0_min_timestamp
-        real derived_active_power_l2_import_t0_min_w
-        real derived_active_power_l3_import_t0_avg_w
+        bigint derived_active_power_l2_import_t0_min_w
+        double_precision derived_active_power_l3_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_l3_import_t0_max_timestamp
-        real derived_active_power_l3_import_t0_max_w
+        bigint derived_active_power_l3_import_t0_max_w
         timestamp_with_time_zone derived_active_power_l3_import_t0_min_timestamp
-        real derived_active_power_l3_import_t0_min_w
-        real derived_active_power_total_export_t0_avg_w
+        bigint derived_active_power_l3_import_t0_min_w
+        double_precision derived_active_power_total_export_t0_avg_w
         timestamp_with_time_zone derived_active_power_total_export_t0_max_timestamp
-        real derived_active_power_total_export_t0_max_w
+        bigint derived_active_power_total_export_t0_max_w
         timestamp_with_time_zone derived_active_power_total_export_t0_min_timestamp
-        real derived_active_power_total_export_t0_min_w
-        real derived_active_power_total_import_t0_avg_w
+        bigint derived_active_power_total_export_t0_min_w
+        double_precision derived_active_power_total_import_t0_avg_w
         timestamp_with_time_zone derived_active_power_total_import_t0_max_timestamp
-        real derived_active_power_total_import_t0_max_w
+        bigint derived_active_power_total_import_t0_max_w
         timestamp_with_time_zone derived_active_power_total_import_t0_min_timestamp
-        real derived_active_power_total_import_t0_min_w
-        real derived_active_power_total_import_t1_avg_w
+        bigint derived_active_power_total_import_t0_min_w
+        double_precision derived_active_power_total_import_t1_avg_w
         timestamp_with_time_zone derived_active_power_total_import_t1_max_timestamp
-        real derived_active_power_total_import_t1_max_w
+        bigint derived_active_power_total_import_t1_max_w
         timestamp_with_time_zone derived_active_power_total_import_t1_min_timestamp
-        real derived_active_power_total_import_t1_min_w
-        real derived_active_power_total_import_t2_avg_w
+        bigint derived_active_power_total_import_t1_min_w
+        double_precision derived_active_power_total_import_t2_avg_w
         timestamp_with_time_zone derived_active_power_total_import_t2_max_timestamp
-        real derived_active_power_total_import_t2_max_w
+        bigint derived_active_power_total_import_t2_max_w
         timestamp_with_time_zone derived_active_power_total_import_t2_min_timestamp
-        real derived_active_power_total_import_t2_min_w
-        real derived_reactive_power_total_export_t0_avg_var
+        bigint derived_active_power_total_import_t2_min_w
+        double_precision derived_reactive_power_total_export_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_total_export_t0_max_timestamp
-        real derived_reactive_power_total_export_t0_max_var
+        bigint derived_reactive_power_total_export_t0_max_var
         timestamp_with_time_zone derived_reactive_power_total_export_t0_min_timestamp
-        real derived_reactive_power_total_export_t0_min_var
-        real derived_reactive_power_total_import_t0_avg_var
+        bigint derived_reactive_power_total_export_t0_min_var
+        double_precision derived_reactive_power_total_import_t0_avg_var
         timestamp_with_time_zone derived_reactive_power_total_import_t0_max_timestamp
-        real derived_reactive_power_total_import_t0_max_var
+        bigint derived_reactive_power_total_import_t0_max_var
         timestamp_with_time_zone derived_reactive_power_total_import_t0_min_timestamp
-        real derived_reactive_power_total_import_t0_min_var
+        bigint derived_reactive_power_total_import_t0_min_var
         interval_entity interval PK
         bigint measurement_location_id PK,FK
         text meter_id PK,FK
         bigint quarter_hour_count
-        real reactive_energy_total_export_t0_max_varh
-        real reactive_energy_total_export_t0_min_varh
-        real reactive_energy_total_import_t0_max_varh
-        real reactive_energy_total_import_t0_min_varh
+        bigint reactive_energy_total_export_t0_max_varh
+        bigint reactive_energy_total_export_t0_min_varh
+        bigint reactive_energy_total_import_t0_max_varh
+        bigint reactive_energy_total_import_t0_min_varh
         real reactive_power_total_net_t0_avg_var
         timestamp_with_time_zone reactive_power_total_net_t0_max_timestamp
         real reactive_power_total_net_t0_max_var
@@ -1018,13 +1018,13 @@ erDiagram
     }
 
     schneider_iem3xxx_measurements {
-        real active_energy_l1_import_t0_wh
-        real active_energy_l2_import_t0_wh
-        real active_energy_l3_import_t0_wh
-        real active_energy_total_export_t0_wh
-        real active_energy_total_import_t0_wh
-        real active_energy_total_import_t1_wh
-        real active_energy_total_import_t2_wh
+        bigint active_energy_l1_import_t0_wh
+        bigint active_energy_l2_import_t0_wh
+        bigint active_energy_l3_import_t0_wh
+        bigint active_energy_total_export_t0_wh
+        bigint active_energy_total_import_t0_wh
+        bigint active_energy_total_import_t1_wh
+        bigint active_energy_total_import_t2_wh
         real active_power_l1_net_t0_w
         real active_power_l2_net_t0_w
         real active_power_l3_net_t0_w
@@ -1034,8 +1034,8 @@ erDiagram
         real current_l3_any_t0_a
         bigint measurement_location_id PK,FK
         text meter_id PK,FK
-        real reactive_energy_total_export_t0_varh
-        real reactive_energy_total_import_t0_varh
+        bigint reactive_energy_total_export_t0_varh
+        bigint reactive_energy_total_import_t0_varh
         real reactive_power_total_net_t0_var
         timestamp_with_time_zone timestamp PK
         real voltage_l1_any_t0_v

--- a/scripts/migrations/.gitignore
+++ b/scripts/migrations/.gitignore
@@ -187,3 +187,6 @@
 /20250312102659-Ozds.Data-FinancialRemark-hypertables.sql
 /20250312102659-Ozds.Data-FinancialRemark-orchard.sql
 /20250312102659-Ozds.Data-FinancialRemark.sql
+/20250313085413-Ozds.Data-NumericValues-hypertables.sql
+/20250313085413-Ozds.Data-NumericValues-orchard.sql
+/20250313085413-Ozds.Data-NumericValues.sql

--- a/scripts/migrations/20250313085413-Ozds.Data-NumericValues-hypertables.sql.dvc
+++ b/scripts/migrations/20250313085413-Ozds.Data-NumericValues-hypertables.sql.dvc
@@ -2,4 +2,4 @@ outs:
 - md5: be9030ef8d62e9867d11fca8e37f3b51
   size: 350084
   hash: md5
-  path: current-hypertables.sql
+  path: 20250313085413-Ozds.Data-NumericValues-hypertables.sql

--- a/scripts/migrations/20250313085413-Ozds.Data-NumericValues-orchard.sql.dvc
+++ b/scripts/migrations/20250313085413-Ozds.Data-NumericValues-orchard.sql.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 262928c9726fd06a30e2c47997a87af4
+  size: 17004
+  hash: md5
+  path: 20250313085413-Ozds.Data-NumericValues-orchard.sql

--- a/scripts/migrations/20250313085413-Ozds.Data-NumericValues.sql.dvc
+++ b/scripts/migrations/20250313085413-Ozds.Data-NumericValues.sql.dvc
@@ -2,4 +2,4 @@ outs:
 - md5: 9398b6015e31c1f4fca349c8bcefc17a
   size: 41349
   hash: md5
-  path: current.sql
+  path: 20250313085413-Ozds.Data-NumericValues.sql

--- a/src/Ozds.Business/Activation/Implementations/Measurements/AbbB2xAggregateModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Measurements/AbbB2xAggregateModelActivator.cs
@@ -45,74 +45,74 @@ public class AbbB2xAggregateModelActivator(
     model.ActiveEnergyL1ImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL1ImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL2ImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL2ImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL3ImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL3ImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL1ExportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL1ExportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL2ExportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL2ExportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL3ExportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL3ExportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyL1ImportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerL1ImportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyL2ImportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerL2ImportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyL3ImportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerL3ImportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyL1ExportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerL1ExportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyL2ExportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerL2ExportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyL3ExportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerL3ExportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalExportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalExportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyTotalImportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerTotalImportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyTotalExportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerTotalExportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalImportT1_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalImportT1_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalImportT2_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalImportT2_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
   }
 }

--- a/src/Ozds.Business/Activation/Implementations/Measurements/DerivedAggregateMeasureModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Measurements/DerivedAggregateMeasureModelActivator.cs
@@ -1,0 +1,23 @@
+using Ozds.Business.Activation.Base;
+using Ozds.Business.Models.Complex;
+
+namespace Ozds.Business.Activation.Implementations.Measurements;
+
+public class DerivedAggregateMeasureModelActivator
+  : ConcreteModelActivator<DerivedAggregateMeasureModel>
+{
+  public override void Initialize(
+    DerivedAggregateMeasureModel model
+  )
+  {
+    base.Initialize(model);
+
+    var now = DateTimeOffset.UtcNow;
+
+    model.Avg = 0;
+    model.Min = 0;
+    model.Max = 0;
+    model.MinTimestamp = now;
+    model.MaxTimestamp = now;
+  }
+}

--- a/src/Ozds.Business/Activation/Implementations/Measurements/SchneideriEM3xxxAggregateModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Measurements/SchneideriEM3xxxAggregateModelActivator.cs
@@ -43,38 +43,38 @@ public class SchneideriEM3xxxAggregateModelActivator(
     model.ActiveEnergyL1ImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL1ImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL2ImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL2ImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyL3ImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerL3ImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalImportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalImportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalExportT0_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalExportT0_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyTotalImportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerTotalImportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ReactiveEnergyTotalExportT0_VARh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedReactivePowerTotalExportT0_VAR = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalImportT1_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalImportT1_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
     model.ActiveEnergyTotalImportT2_Wh = modelActivator
       .Activate<CumulativeAggregateMeasureModel>();
     model.DerivedActivePowerTotalImportT2_W = modelActivator
-      .Activate<InstantaneousAggregateMeasureModel>();
+      .Activate<DerivedAggregateMeasureModel>();
   }
 }

--- a/src/Ozds.Business/Aggregation/Implementations/DerivedAggregateMeasureUpserter.cs
+++ b/src/Ozds.Business/Aggregation/Implementations/DerivedAggregateMeasureUpserter.cs
@@ -1,0 +1,82 @@
+using Ozds.Business.Aggregation.Base;
+using Ozds.Business.Models.Complex;
+using Ozds.Business.Models.Enums;
+
+namespace Ozds.Business.Aggregation.Implementations;
+
+public class DerivedAggregateMeasureUpserter :
+  ConcreteAggregateMeasureUpserter<DerivedAggregateMeasureModel>
+{
+  protected override DerivedAggregateMeasureModel UpsertConcreteModel(
+    DerivedAggregateMeasureModel lhs,
+    long lhsCount,
+    DerivedAggregateMeasureModel rhs,
+    long rhsCount
+  )
+  {
+    return lhs.Upsert(
+      lhsCount,
+      rhs,
+      rhsCount
+    );
+  }
+}
+
+public static class DerivedAggregateMeasureUpserterExtensions
+{
+  public static DerivedAggregateMeasureModel Upsert(
+    this DerivedAggregateMeasureModel lhs,
+    long lhsCount,
+    DerivedAggregateMeasureModel rhs,
+    long rhsCount
+  )
+  {
+    return new DerivedAggregateMeasureModel
+    {
+      Avg = lhsCount + rhsCount == 0
+        ? 0
+        : (lhs.Avg * lhsCount + rhs.Avg * rhsCount) / (lhsCount + rhsCount),
+      Min = lhs.Min < rhs.Min ? lhs.Min : rhs.Min,
+      Max = lhs.Max > rhs.Max ? lhs.Max : rhs.Max,
+      MinTimestamp = lhs.Min < rhs.Min ? lhs.MinTimestamp : rhs.MinTimestamp,
+      MaxTimestamp = lhs.Max > rhs.Max ? lhs.MaxTimestamp : rhs.MaxTimestamp
+    };
+  }
+
+  public static DerivedAggregateMeasureModel UpsertDerivedPowerFromEnergy(
+    this DerivedAggregateMeasureModel lhsDerivedPower,
+    long lhsQuarterHourCount,
+    DerivedAggregateMeasureModel rhsDerivedPower,
+    long rhsQuarterHourCount,
+    CumulativeAggregateMeasureModel lhsEnergy,
+    CumulativeAggregateMeasureModel rhsEnergy,
+    DateTimeOffset timestamp,
+    IntervalModel interval
+  )
+  {
+    if (interval is not IntervalModel.QuarterHour)
+    {
+      return lhsDerivedPower.Upsert(
+        lhsQuarterHourCount,
+        rhsDerivedPower,
+        rhsQuarterHourCount
+      );
+    }
+
+    var minEnergy =
+      lhsEnergy.Min < rhsEnergy.Min ? lhsEnergy.Min : rhsEnergy.Min;
+    var maxEnergy =
+      lhsEnergy.Max > rhsEnergy.Max ? lhsEnergy.Max : rhsEnergy.Max;
+    var power = (maxEnergy - minEnergy)
+      / (decimal)interval.ToTimeSpan(timestamp).TotalHours;
+
+    return new DerivedAggregateMeasureModel
+    {
+      Avg = power,
+      Max = power,
+      Min = power,
+      MinTimestamp = timestamp,
+      MaxTimestamp = timestamp
+    };
+  }
+}

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/AbbB2xAggregateModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/AbbB2xAggregateModelEntityConverter.cs
@@ -107,7 +107,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerL1ImportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL1ImportT0_W);
     entity.ActiveEnergyL2ImportT0_Wh =
       model.ActiveEnergyL2ImportT0_Wh is null
@@ -119,7 +119,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerL2ImportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL2ImportT0_W);
     entity.ActiveEnergyL3ImportT0_Wh =
       model.ActiveEnergyL3ImportT0_Wh is null
@@ -131,7 +131,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerL3ImportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL3ImportT0_W);
     entity.ActiveEnergyTotalImportT0_Wh =
       model.ActiveEnergyTotalImportT0_Wh is null
@@ -143,7 +143,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerTotalImportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalImportT0_W);
     entity.ActiveEnergyL1ExportT0_Wh =
       model.ActiveEnergyL1ExportT0_Wh is null
@@ -155,7 +155,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerL1ExportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL1ExportT0_W);
     entity.ActiveEnergyL2ExportT0_Wh =
       model.ActiveEnergyL2ExportT0_Wh is null
@@ -167,7 +167,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerL2ExportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL2ExportT0_W);
     entity.ActiveEnergyL3ExportT0_Wh =
       model.ActiveEnergyL3ExportT0_Wh is null
@@ -179,7 +179,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerL3ExportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL3ExportT0_W);
     entity.ActiveEnergyTotalExportT0_Wh =
       model.ActiveEnergyTotalExportT0_Wh is null
@@ -191,7 +191,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerTotalExportT0_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalExportT0_W);
     entity.ActiveEnergyTotalImportT1_Wh =
       model.ActiveEnergyTotalImportT1_Wh is null
@@ -203,7 +203,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerTotalImportT1_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalImportT1_W);
     entity.ActiveEnergyTotalImportT2_Wh =
       model.ActiveEnergyTotalImportT2_Wh is null
@@ -215,7 +215,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedActivePowerTotalImportT2_W is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalImportT2_W);
     entity.ReactiveEnergyL1ImportT0_VARh =
       model.ReactiveEnergyL1ImportT0_VARh is null
@@ -227,7 +227,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerL1ImportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerL1ImportT0_VAR);
     entity.ReactiveEnergyL2ImportT0_VARh =
       model.ReactiveEnergyL2ImportT0_VARh is null
@@ -239,7 +239,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerL2ImportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerL2ImportT0_VAR);
     entity.ReactiveEnergyL3ImportT0_VARh =
       model.ReactiveEnergyL3ImportT0_VARh is null
@@ -251,7 +251,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerL3ImportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerL3ImportT0_VAR);
     entity.ReactiveEnergyTotalImportT0_VARh =
       model.ReactiveEnergyTotalImportT0_VARh is null
@@ -263,7 +263,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerTotalImportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerTotalImportT0_VAR);
     entity.ReactiveEnergyL1ExportT0_VARh =
       model.ReactiveEnergyL1ExportT0_VARh is null
@@ -275,7 +275,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerL1ExportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerL1ExportT0_VAR);
     entity.ReactiveEnergyL2ExportT0_VARh =
       model.ReactiveEnergyL2ExportT0_VARh is null
@@ -287,7 +287,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerL2ExportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerL2ExportT0_VAR);
     entity.ReactiveEnergyL3ExportT0_VARh =
       model.ReactiveEnergyL3ExportT0_VARh is null
@@ -299,7 +299,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerL3ExportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerL3ExportT0_VAR);
     entity.ReactiveEnergyTotalExportT0_VARh =
       model.ReactiveEnergyTotalExportT0_VARh is null
@@ -311,7 +311,7 @@ public class AbbB2xAggregateModelEntityConverter(
       model.DerivedReactivePowerTotalExportT0_VAR is null
         ? null!
         : modelEntityConverter.ToEntity<
-          InstantaneousAggregateMeasureEntity>(
+          DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerTotalExportT0_VAR);
   }
 
@@ -389,7 +389,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerL1ImportT0_W =
       entity.DerivedActivePowerL1ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL1ImportT0_W);
     model.ActiveEnergyL2ImportT0_Wh =
       entity.ActiveEnergyL2ImportT0_Wh is null
@@ -399,7 +399,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerL2ImportT0_W =
       entity.DerivedActivePowerL2ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL2ImportT0_W);
     model.ActiveEnergyL3ImportT0_Wh =
       entity.ActiveEnergyL3ImportT0_Wh is null
@@ -409,7 +409,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerL3ImportT0_W =
       entity.DerivedActivePowerL3ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL3ImportT0_W);
     model.ActiveEnergyTotalImportT0_Wh =
       entity.ActiveEnergyTotalImportT0_Wh is null
@@ -419,7 +419,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerTotalImportT0_W =
       entity.DerivedActivePowerTotalImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalImportT0_W);
     model.ActiveEnergyL1ExportT0_Wh =
       entity.ActiveEnergyL1ExportT0_Wh is null
@@ -429,7 +429,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerL1ExportT0_W =
       entity.DerivedActivePowerL1ExportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL1ExportT0_W);
     model.ActiveEnergyL2ExportT0_Wh =
       entity.ActiveEnergyL2ExportT0_Wh is null
@@ -439,7 +439,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerL2ExportT0_W =
       entity.DerivedActivePowerL2ExportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL2ExportT0_W);
     model.ActiveEnergyL3ExportT0_Wh =
       entity.ActiveEnergyL3ExportT0_Wh is null
@@ -449,7 +449,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerL3ExportT0_W =
       entity.DerivedActivePowerL3ExportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL3ExportT0_W);
     model.ActiveEnergyTotalExportT0_Wh =
       entity.ActiveEnergyTotalExportT0_Wh is null
@@ -459,7 +459,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerTotalExportT0_W =
       entity.DerivedActivePowerTotalExportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalExportT0_W);
     model.ActiveEnergyTotalImportT1_Wh =
       entity.ActiveEnergyTotalImportT1_Wh is null
@@ -469,7 +469,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerTotalImportT1_W =
       entity.DerivedActivePowerTotalImportT1_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalImportT1_W);
     model.ActiveEnergyTotalImportT2_Wh =
       entity.ActiveEnergyTotalImportT2_Wh is null
@@ -479,7 +479,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedActivePowerTotalImportT2_W =
       entity.DerivedActivePowerTotalImportT2_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalImportT2_W);
     model.ReactiveEnergyL1ImportT0_VARh =
       entity.ReactiveEnergyL1ImportT0_VARh is null
@@ -489,7 +489,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerL1ImportT0_VAR =
       entity.DerivedReactivePowerL1ImportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerL1ImportT0_VAR);
     model.ReactiveEnergyL2ImportT0_VARh =
       entity.ReactiveEnergyL2ImportT0_VARh is null
@@ -499,7 +499,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerL2ImportT0_VAR =
       entity.DerivedReactivePowerL2ImportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerL2ImportT0_VAR);
     model.ReactiveEnergyL3ImportT0_VARh =
       entity.ReactiveEnergyL3ImportT0_VARh is null
@@ -509,7 +509,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerL3ImportT0_VAR =
       entity.DerivedReactivePowerL3ImportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerL3ImportT0_VAR);
     model.ReactiveEnergyTotalImportT0_VARh =
       entity.ReactiveEnergyTotalImportT0_VARh is null
@@ -519,7 +519,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerTotalImportT0_VAR =
       entity.DerivedReactivePowerTotalImportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerTotalImportT0_VAR);
     model.ReactiveEnergyL1ExportT0_VARh =
       entity.ReactiveEnergyL1ExportT0_VARh is null
@@ -529,7 +529,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerL1ExportT0_VAR =
       entity.DerivedReactivePowerL1ExportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerL1ExportT0_VAR);
     model.ReactiveEnergyL2ExportT0_VARh =
       entity.ReactiveEnergyL2ExportT0_VARh is null
@@ -539,7 +539,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerL2ExportT0_VAR =
       entity.DerivedReactivePowerL2ExportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerL2ExportT0_VAR);
     model.ReactiveEnergyL3ExportT0_VARh =
       entity.ReactiveEnergyL3ExportT0_VARh is null
@@ -549,7 +549,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerL3ExportT0_VAR =
       entity.DerivedReactivePowerL3ExportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerL3ExportT0_VAR);
     model.ReactiveEnergyTotalExportT0_VARh =
       entity.ReactiveEnergyTotalExportT0_VARh is null
@@ -559,7 +559,7 @@ public class AbbB2xAggregateModelEntityConverter(
     model.DerivedReactivePowerTotalExportT0_VAR =
       entity.DerivedReactivePowerTotalExportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerTotalExportT0_VAR);
   }
 }

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/AbbB2xMeasurementAggregateConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/AbbB2xMeasurementAggregateConverter.cs
@@ -123,7 +123,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL1ImportT0_Wh
     };
     aggregate.DerivedActivePowerL1ImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -137,7 +137,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL2ImportT0_Wh
     };
     aggregate.DerivedActivePowerL2ImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -151,7 +151,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL3ImportT0_Wh
     };
     aggregate.DerivedActivePowerL3ImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -165,7 +165,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalImportT0_Wh
     };
     aggregate.DerivedActivePowerTotalImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -179,7 +179,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL1ExportT0_Wh
     };
     aggregate.DerivedActivePowerL1ExportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -193,7 +193,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL2ExportT0_Wh
     };
     aggregate.DerivedActivePowerL2ExportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -207,7 +207,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL3ExportT0_Wh
     };
     aggregate.DerivedActivePowerL3ExportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -222,7 +222,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL1ImportT0_VARh
       };
     aggregate.DerivedReactivePowerL1ImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -237,7 +237,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL2ImportT0_VARh
       };
     aggregate.DerivedReactivePowerL2ImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -252,7 +252,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL3ImportT0_VARh
       };
     aggregate.DerivedReactivePowerL3ImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -267,7 +267,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL1ExportT0_VARh
       };
     aggregate.DerivedReactivePowerL1ExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -282,7 +282,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL2ExportT0_VARh
       };
     aggregate.DerivedReactivePowerL2ExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -297,7 +297,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL3ExportT0_VARh
       };
     aggregate.DerivedReactivePowerL3ExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -311,7 +311,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalExportT0_Wh
     };
     aggregate.DerivedActivePowerTotalExportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -325,7 +325,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalImportT1_Wh
     };
     aggregate.DerivedActivePowerTotalImportT1_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -339,7 +339,7 @@ public class AbbB2xMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalImportT2_Wh
     };
     aggregate.DerivedActivePowerTotalImportT2_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -354,7 +354,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL1ImportT0_VARh
       };
     aggregate.DerivedReactivePowerL1ImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -369,7 +369,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL2ImportT0_VARh
       };
     aggregate.DerivedReactivePowerL2ImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -384,7 +384,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL3ImportT0_VARh
       };
     aggregate.DerivedReactivePowerL3ImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -399,7 +399,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyTotalImportT0_VARh
       };
     aggregate.DerivedReactivePowerTotalImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -414,7 +414,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL1ExportT0_VARh
       };
     aggregate.DerivedReactivePowerL1ExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -429,7 +429,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL2ExportT0_VARh
       };
     aggregate.DerivedReactivePowerL2ExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -444,7 +444,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyL3ExportT0_VARh
       };
     aggregate.DerivedReactivePowerL3ExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,
@@ -459,7 +459,7 @@ public class AbbB2xMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyTotalExportT0_VARh
       };
     aggregate.DerivedReactivePowerTotalExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = decimal.MaxValue,

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/AbbB2xMeasurementModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/AbbB2xMeasurementModelEntityConverter.cs
@@ -34,41 +34,41 @@ public class AbbB2xMeasurementModelEntityConverter(
     entity.ReactivePowerL2NetT0_VAR = model.ReactivePowerL2NetT0_VAR.ToFloat();
     entity.ReactivePowerL3NetT0_VAR = model.ReactivePowerL3NetT0_VAR.ToFloat();
     entity.ActiveEnergyL1ImportT0_Wh =
-      model.ActiveEnergyL1ImportT0_Wh.ToFloat();
+      model.ActiveEnergyL1ImportT0_Wh.ToLong();
     entity.ActiveEnergyL2ImportT0_Wh =
-      model.ActiveEnergyL2ImportT0_Wh.ToFloat();
+      model.ActiveEnergyL2ImportT0_Wh.ToLong();
     entity.ActiveEnergyL3ImportT0_Wh =
-      model.ActiveEnergyL3ImportT0_Wh.ToFloat();
+      model.ActiveEnergyL3ImportT0_Wh.ToLong();
     entity.ActiveEnergyL1ExportT0_Wh =
-      model.ActiveEnergyL1ExportT0_Wh.ToFloat();
+      model.ActiveEnergyL1ExportT0_Wh.ToLong();
     entity.ActiveEnergyL2ExportT0_Wh =
-      model.ActiveEnergyL2ExportT0_Wh.ToFloat();
+      model.ActiveEnergyL2ExportT0_Wh.ToLong();
     entity.ActiveEnergyL3ExportT0_Wh =
-      model.ActiveEnergyL3ExportT0_Wh.ToFloat();
+      model.ActiveEnergyL3ExportT0_Wh.ToLong();
     entity.ReactiveEnergyL1ImportT0_VARh =
-      model.ReactiveEnergyL1ImportT0_VARh.ToFloat();
+      model.ReactiveEnergyL1ImportT0_VARh.ToLong();
     entity.ReactiveEnergyL2ImportT0_VARh =
-      model.ReactiveEnergyL2ImportT0_VARh.ToFloat();
+      model.ReactiveEnergyL2ImportT0_VARh.ToLong();
     entity.ReactiveEnergyL3ImportT0_VARh =
-      model.ReactiveEnergyL3ImportT0_VARh.ToFloat();
+      model.ReactiveEnergyL3ImportT0_VARh.ToLong();
     entity.ReactiveEnergyL1ExportT0_VARh =
-      model.ReactiveEnergyL1ExportT0_VARh.ToFloat();
+      model.ReactiveEnergyL1ExportT0_VARh.ToLong();
     entity.ReactiveEnergyL2ExportT0_VARh =
-      model.ReactiveEnergyL2ExportT0_VARh.ToFloat();
+      model.ReactiveEnergyL2ExportT0_VARh.ToLong();
     entity.ReactiveEnergyL3ExportT0_VARh =
-      model.ReactiveEnergyL3ExportT0_VARh.ToFloat();
+      model.ReactiveEnergyL3ExportT0_VARh.ToLong();
     entity.ActiveEnergyTotalImportT0_Wh =
-      model.ActiveEnergyTotalImportT0_Wh.ToFloat();
+      model.ActiveEnergyTotalImportT0_Wh.ToLong();
     entity.ActiveEnergyTotalExportT0_Wh =
-      model.ActiveEnergyTotalExportT0_Wh.ToFloat();
+      model.ActiveEnergyTotalExportT0_Wh.ToLong();
     entity.ReactiveEnergyTotalImportT0_VARh =
-      model.ReactiveEnergyTotalImportT0_VARh.ToFloat();
+      model.ReactiveEnergyTotalImportT0_VARh.ToLong();
     entity.ReactiveEnergyTotalExportT0_VARh =
-      model.ReactiveEnergyTotalExportT0_VARh.ToFloat();
+      model.ReactiveEnergyTotalExportT0_VARh.ToLong();
     entity.ActiveEnergyTotalImportT1_Wh =
-      model.ActiveEnergyTotalImportT1_Wh.ToFloat();
+      model.ActiveEnergyTotalImportT1_Wh.ToLong();
     entity.ActiveEnergyTotalImportT2_Wh =
-      model.ActiveEnergyTotalImportT2_Wh.ToFloat();
+      model.ActiveEnergyTotalImportT2_Wh.ToLong();
   }
 
   public override void InitializeModel(

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/AggregateMeasureModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/AggregateMeasureModelEntityConverter.cs
@@ -1,5 +1,4 @@
 using Ozds.Business.Conversion.Base;
-using Ozds.Business.Extensions;
 using Ozds.Business.Models.Complex;
 using Ozds.Data.Entities.Complex;
 
@@ -10,14 +9,13 @@ public class AggregateMeasureModelEntityConverter
     AggregateMeasureModel,
     AggregateMeasureEntity>
 {
+#pragma warning disable S1185 // Overriding members should do more than simply call the same member in the base class
   public override void InitializeEntity(
     AggregateMeasureModel model,
     AggregateMeasureEntity entity
   )
   {
     base.InitializeEntity(model, entity);
-    entity.Min = model.Min.ToFloat();
-    entity.Max = model.Max.ToFloat();
   }
 
   public override void InitializeModel(
@@ -26,7 +24,6 @@ public class AggregateMeasureModelEntityConverter
   )
   {
     base.InitializeModel(entity, model);
-    model.Min = entity.Min.ToDecimal();
-    model.Max = entity.Max.ToDecimal();
   }
+#pragma warning restore S1185 // Overriding members should do more than simply call the same member in the base class
 }

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/CumulativeAggregateMeasureModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/CumulativeAggregateMeasureModelEntityConverter.cs
@@ -1,4 +1,5 @@
 using Ozds.Business.Conversion.Base;
+using Ozds.Business.Extensions;
 using Ozds.Business.Models.Complex;
 using Ozds.Data.Entities.Complex;
 
@@ -12,4 +13,23 @@ public class CumulativeAggregateMeasureEntityConverter(
   CumulativeAggregateMeasureEntity,
   AggregateMeasureEntity>(serviceProvider)
 {
+  public override void InitializeEntity(
+    CumulativeAggregateMeasureModel model,
+    CumulativeAggregateMeasureEntity entity
+  )
+  {
+    base.InitializeEntity(model, entity);
+    entity.Min = model.Min.ToLong();
+    entity.Max = model.Max.ToLong();
+  }
+
+  public override void InitializeModel(
+    CumulativeAggregateMeasureEntity entity,
+    CumulativeAggregateMeasureModel model
+  )
+  {
+    base.InitializeModel(entity, model);
+    model.Min = entity.Min.ToDecimal();
+    model.Max = entity.Max.ToDecimal();
+  }
 }

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/DerivedAggregateMeasureModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/DerivedAggregateMeasureModelEntityConverter.cs
@@ -5,30 +5,30 @@ using Ozds.Data.Entities.Complex;
 
 namespace Ozds.Business.Conversion.Implementations.Measurements;
 
-public class InstantaneousAggregateMeasureEntityConverter(
+public class DerivedAggregateMeasureEntityConverter(
   IServiceProvider serviceProvider
 ) : InheritingModelEntityConverter<
-  InstantaneousAggregateMeasureModel,
+  DerivedAggregateMeasureModel,
   AggregateMeasureModel,
-  InstantaneousAggregateMeasureEntity,
+  DerivedAggregateMeasureEntity,
   AggregateMeasureEntity>(serviceProvider)
 {
   public override void InitializeEntity(
-    InstantaneousAggregateMeasureModel model,
-    InstantaneousAggregateMeasureEntity entity
+    DerivedAggregateMeasureModel model,
+    DerivedAggregateMeasureEntity entity
   )
   {
     base.InitializeEntity(model, entity);
-    entity.Min = model.Min.ToFloat();
-    entity.Max = model.Max.ToFloat();
-    entity.Avg = model.Avg.ToFloat();
+    entity.Min = model.Min.ToLong();
+    entity.Max = model.Max.ToLong();
+    entity.Avg = model.Avg.ToDouble();
     entity.MinTimestamp = model.MinTimestamp;
     entity.MaxTimestamp = model.MaxTimestamp;
   }
 
   public override void InitializeModel(
-    InstantaneousAggregateMeasureEntity entity,
-    InstantaneousAggregateMeasureModel model
+    DerivedAggregateMeasureEntity entity,
+    DerivedAggregateMeasureModel model
   )
   {
     base.InitializeModel(entity, model);

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/SchneideriEM3xxxAggregateModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/SchneideriEM3xxxAggregateModelEntityConverter.cs
@@ -88,7 +88,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerL1ImportT0_W =
       model.DerivedActivePowerL1ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL1ImportT0_W);
     entity.ActiveEnergyL2ImportT0_Wh =
       model.ActiveEnergyL2ImportT0_Wh is null
@@ -98,7 +98,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerL2ImportT0_W =
       model.DerivedActivePowerL2ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL2ImportT0_W);
     entity.ActiveEnergyL3ImportT0_Wh =
       model.ActiveEnergyL3ImportT0_Wh is null
@@ -108,7 +108,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerL3ImportT0_W =
       model.DerivedActivePowerL3ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerL3ImportT0_W);
     entity.ActiveEnergyTotalImportT0_Wh =
       model.ActiveEnergyTotalImportT0_Wh is null
@@ -118,7 +118,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerTotalImportT0_W =
       model.DerivedActivePowerTotalImportT0_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalImportT0_W);
     entity.ActiveEnergyTotalExportT0_Wh =
       model.ActiveEnergyTotalExportT0_Wh is null
@@ -128,7 +128,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerTotalExportT0_W =
       model.DerivedActivePowerTotalExportT0_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalExportT0_W);
     entity.ReactiveEnergyTotalImportT0_VARh =
       model.ReactiveEnergyTotalImportT0_VARh is null
@@ -138,7 +138,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedReactivePowerTotalImportT0_VAR =
       model.DerivedReactivePowerTotalImportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerTotalImportT0_VAR);
     entity.ReactiveEnergyTotalExportT0_VARh =
       model.ReactiveEnergyTotalExportT0_VARh is null
@@ -148,7 +148,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedReactivePowerTotalExportT0_VAR =
       model.DerivedReactivePowerTotalExportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedReactivePowerTotalExportT0_VAR);
     entity.ActiveEnergyTotalImportT1_Wh =
       model.ActiveEnergyTotalImportT1_Wh is null
@@ -158,7 +158,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerTotalImportT1_W =
       model.DerivedActivePowerTotalImportT1_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalImportT1_W);
     entity.ActiveEnergyTotalImportT2_Wh =
       model.ActiveEnergyTotalImportT2_Wh is null
@@ -168,7 +168,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     entity.DerivedActivePowerTotalImportT2_W =
       model.DerivedActivePowerTotalImportT2_W is null
         ? null!
-        : modelEntityConverter.ToEntity<InstantaneousAggregateMeasureEntity>(
+        : modelEntityConverter.ToEntity<DerivedAggregateMeasureEntity>(
           model.DerivedActivePowerTotalImportT2_W);
   }
 
@@ -241,7 +241,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerL1ImportT0_W =
       entity.DerivedActivePowerL1ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL1ImportT0_W);
     model.ActiveEnergyL2ImportT0_Wh =
       entity.ActiveEnergyL2ImportT0_Wh is null
@@ -251,7 +251,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerL2ImportT0_W =
       entity.DerivedActivePowerL2ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL2ImportT0_W);
     model.ActiveEnergyL3ImportT0_Wh =
       entity.ActiveEnergyL3ImportT0_Wh is null
@@ -261,7 +261,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerL3ImportT0_W =
       entity.DerivedActivePowerL3ImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerL3ImportT0_W);
     model.ActiveEnergyTotalImportT0_Wh =
       entity.ActiveEnergyTotalImportT0_Wh is null
@@ -271,7 +271,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerTotalImportT0_W =
       entity.DerivedActivePowerTotalImportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalImportT0_W);
     model.ActiveEnergyTotalExportT0_Wh =
       entity.ActiveEnergyTotalExportT0_Wh is null
@@ -281,7 +281,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerTotalExportT0_W =
       entity.DerivedActivePowerTotalExportT0_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalExportT0_W);
     model.ReactiveEnergyTotalImportT0_VARh =
       entity.ReactiveEnergyTotalImportT0_VARh is null
@@ -291,7 +291,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedReactivePowerTotalImportT0_VAR =
       entity.DerivedReactivePowerTotalImportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerTotalImportT0_VAR);
     model.ReactiveEnergyTotalExportT0_VARh =
       entity.ReactiveEnergyTotalExportT0_VARh is null
@@ -301,7 +301,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedReactivePowerTotalExportT0_VAR =
       entity.DerivedReactivePowerTotalExportT0_VAR is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedReactivePowerTotalExportT0_VAR);
     model.ActiveEnergyTotalImportT1_Wh =
       entity.ActiveEnergyTotalImportT1_Wh is null
@@ -311,7 +311,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerTotalImportT1_W =
       entity.DerivedActivePowerTotalImportT1_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalImportT1_W);
     model.ActiveEnergyTotalImportT2_Wh =
       entity.ActiveEnergyTotalImportT2_Wh is null
@@ -321,7 +321,7 @@ public class SchneideriEM3xxxAggregateModelEntityConverter(
     model.DerivedActivePowerTotalImportT2_W =
       entity.DerivedActivePowerTotalImportT2_W is null
         ? null!
-        : modelEntityConverter.ToModel<InstantaneousAggregateMeasureModel>(
+        : modelEntityConverter.ToModel<DerivedAggregateMeasureModel>(
           entity.DerivedActivePowerTotalImportT2_W);
   }
 }

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/SchneideriEM3xxxMeasurementAggregateConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/SchneideriEM3xxxMeasurementAggregateConverter.cs
@@ -117,7 +117,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL1ImportT0_Wh
     };
     aggregate.DerivedActivePowerL1ImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = measurement.ActiveEnergyL1ImportT0_Wh,
         Min = 0M,
@@ -131,7 +131,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL2ImportT0_Wh
     };
     aggregate.DerivedActivePowerL2ImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = measurement.ActiveEnergyL2ImportT0_Wh,
         Min = 0M,
@@ -145,7 +145,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyL3ImportT0_Wh
     };
     aggregate.DerivedActivePowerL3ImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = measurement.ActiveEnergyL3ImportT0_Wh,
         Min = 0M,
@@ -159,7 +159,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalImportT0_Wh
     };
     aggregate.DerivedActivePowerTotalImportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = measurement.ActiveEnergyTotalImportT0_Wh,
         Min = 0M,
@@ -173,7 +173,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalExportT0_Wh
     };
     aggregate.DerivedActivePowerTotalExportT0_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = 0M,
@@ -188,7 +188,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyTotalImportT0_VARh
       };
     aggregate.DerivedReactivePowerTotalImportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = 0M,
@@ -203,7 +203,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
         Max = measurement.ReactiveEnergyTotalExportT0_VARh
       };
     aggregate.DerivedReactivePowerTotalExportT0_VAR =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = 0M,
@@ -217,7 +217,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalImportT1_Wh
     };
     aggregate.DerivedActivePowerTotalImportT1_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = 0M,
@@ -231,7 +231,7 @@ public class SchneideriEM3xxxMeasurementAggregateConverter
       Max = measurement.ActiveEnergyTotalImportT2_Wh
     };
     aggregate.DerivedActivePowerTotalImportT2_W =
-      new InstantaneousAggregateMeasureModel
+      new DerivedAggregateMeasureModel
       {
         Avg = 0M,
         Min = 0M,

--- a/src/Ozds.Business/Conversion/Implementations/Measurements/SchneideriEM3xxxMeasurementModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Measurements/SchneideriEM3xxxMeasurementModelEntityConverter.cs
@@ -37,23 +37,23 @@ public class SchneideriEM3xxxMeasurementModelEntityConverter(
     entity.ApparentPowerTotalNetT0_VA =
       model.ApparentPowerTotalNetT0_VA.ToFloat();
     entity.ActiveEnergyL1ImportT0_Wh =
-      model.ActiveEnergyL1ImportT0_Wh.ToFloat();
+      model.ActiveEnergyL1ImportT0_Wh.ToLong();
     entity.ActiveEnergyL2ImportT0_Wh =
-      model.ActiveEnergyL2ImportT0_Wh.ToFloat();
+      model.ActiveEnergyL2ImportT0_Wh.ToLong();
     entity.ActiveEnergyL3ImportT0_Wh =
-      model.ActiveEnergyL3ImportT0_Wh.ToFloat();
+      model.ActiveEnergyL3ImportT0_Wh.ToLong();
     entity.ActiveEnergyTotalImportT0_Wh =
-      model.ActiveEnergyTotalImportT0_Wh.ToFloat();
+      model.ActiveEnergyTotalImportT0_Wh.ToLong();
     entity.ActiveEnergyTotalExportT0_Wh =
-      model.ActiveEnergyTotalExportT0_Wh.ToFloat();
+      model.ActiveEnergyTotalExportT0_Wh.ToLong();
     entity.ReactiveEnergyTotalImportT0_VARh =
-      model.ReactiveEnergyTotalImportT0_VARh.ToFloat();
+      model.ReactiveEnergyTotalImportT0_VARh.ToLong();
     entity.ReactiveEnergyTotalExportT0_VARh =
-      model.ReactiveEnergyTotalExportT0_VARh.ToFloat();
+      model.ReactiveEnergyTotalExportT0_VARh.ToLong();
     entity.ActiveEnergyTotalImportT1_Wh =
-      model.ActiveEnergyTotalImportT1_Wh.ToFloat();
+      model.ActiveEnergyTotalImportT1_Wh.ToLong();
     entity.ActiveEnergyTotalImportT2_Wh =
-      model.ActiveEnergyTotalImportT2_Wh.ToFloat();
+      model.ActiveEnergyTotalImportT2_Wh.ToLong();
   }
 
   public override void InitializeModel(

--- a/src/Ozds.Business/Extensions/PrimitiveConversionExtensions.cs
+++ b/src/Ozds.Business/Extensions/PrimitiveConversionExtensions.cs
@@ -14,11 +14,61 @@ public static class PrimitiveConversionExtensions
     }
   }
 
+  public static double ToDouble(this decimal value)
+  {
+    try
+    {
+      return (long)value;
+    }
+    catch (OverflowException)
+    {
+      return 0;
+    }
+  }
+
+  public static long ToLong(this decimal value)
+  {
+    try
+    {
+      return (long)value;
+    }
+    catch (OverflowException)
+    {
+      return 0;
+    }
+  }
+
   public static decimal ToDecimal(this float value)
   {
     try
     {
       return (decimal)value;
+    }
+    catch (OverflowException)
+    {
+      return 0;
+    }
+  }
+
+  public static decimal ToDecimal(this double value)
+  {
+    try
+    {
+      return (decimal)value;
+    }
+    catch (OverflowException)
+    {
+      return 0;
+    }
+  }
+
+  public static decimal ToDecimal(this long value)
+  {
+    try
+    {
+#pragma warning disable IDE0004
+      return value;
+#pragma warning restore IDE0004
     }
     catch (OverflowException)
     {

--- a/src/Ozds.Business/Models/AbbB2xAggregateModel.cs
+++ b/src/Ozds.Business/Models/AbbB2xAggregateModel.cs
@@ -99,7 +99,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL1ImportT0_W { get; set; } = default!;
 
   [Required]
@@ -110,7 +110,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL2ImportT0_W { get; set; } = default!;
 
   [Required]
@@ -121,7 +121,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL3ImportT0_W { get; set; } = default!;
 
   [Required]
@@ -132,7 +132,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL1ExportT0_W { get; set; } = default!;
 
   [Required]
@@ -143,7 +143,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL2ExportT0_W { get; set; } = default!;
 
   [Required]
@@ -154,7 +154,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL3ExportT0_W { get; set; } = default!;
 
   [Required]
@@ -165,7 +165,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerL1ImportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -176,7 +176,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerL2ImportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -187,7 +187,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerL3ImportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -198,7 +198,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerL1ExportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -209,7 +209,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerL2ExportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -220,7 +220,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerL3ExportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -231,7 +231,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalImportT0_W { get; set; } = default!;
 
   [Required]
@@ -242,7 +242,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalExportT0_W { get; set; } = default!;
 
   [Required]
@@ -250,7 +250,7 @@ public class AbbB2xAggregateModel : AggregateModel
     ReactiveEnergyTotalImportT0_VARh { get; set; } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerTotalImportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -258,7 +258,7 @@ public class AbbB2xAggregateModel : AggregateModel
     ReactiveEnergyTotalExportT0_VARh { get; set; } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerTotalExportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -269,7 +269,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalImportT1_W { get; set; } = default!;
 
   [Required]
@@ -280,7 +280,7 @@ public class AbbB2xAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalImportT2_W { get; set; } = default!;
 
   public override TariffMeasure<decimal> Current_A

--- a/src/Ozds.Business/Models/Abstractions/IAggregateMeasure.cs
+++ b/src/Ozds.Business/Models/Abstractions/IAggregateMeasure.cs
@@ -2,7 +2,4 @@ namespace Ozds.Business.Models.Abstractions;
 
 public interface IAggregateMeasure
 {
-  decimal Min { get; }
-
-  decimal Max { get; }
 }

--- a/src/Ozds.Business/Models/Complex/AggregateMeasureModel.cs
+++ b/src/Ozds.Business/Models/Complex/AggregateMeasureModel.cs
@@ -1,13 +1,7 @@
-using System.ComponentModel.DataAnnotations;
 using Ozds.Business.Models.Abstractions;
 
 namespace Ozds.Business.Models.Complex;
 
 public class AggregateMeasureModel : IAggregateMeasure
 {
-  [Required]
-  public decimal Min { get; set; } = default!;
-
-  [Required]
-  public decimal Max { get; set; } = default!;
 }

--- a/src/Ozds.Business/Models/Complex/CumulativeAggregateMeasureModel.cs
+++ b/src/Ozds.Business/Models/Complex/CumulativeAggregateMeasureModel.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Ozds.Business.Models.Complex;
 
-#pragma warning disable S2094 // Classes should not be empty
 public class CumulativeAggregateMeasureModel : AggregateMeasureModel
-#pragma warning restore S2094 // Classes should not be empty
 {
+  [Required]
+  public decimal Min { get; set; } = default!;
+
+  [Required]
+  public decimal Max { get; set; } = default!;
 }

--- a/src/Ozds.Business/Models/Complex/DerivedAggregateMeasureModel.cs
+++ b/src/Ozds.Business/Models/Complex/DerivedAggregateMeasureModel.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Ozds.Business.Models.Complex;
 
-public class InstantaneousAggregateMeasureModel : AggregateMeasureModel
+public class DerivedAggregateMeasureModel : AggregateMeasureModel
 {
   [Required]
   public decimal Min { get; set; } = default!;

--- a/src/Ozds.Business/Models/SchneideriEM3xxxAggregateModel.cs
+++ b/src/Ozds.Business/Models/SchneideriEM3xxxAggregateModel.cs
@@ -92,7 +92,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL1ImportT0_W { get; set; } = default!;
 
   [Required]
@@ -103,7 +103,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL2ImportT0_W { get; set; } = default!;
 
   [Required]
@@ -114,7 +114,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerL3ImportT0_W { get; set; } = default!;
 
   [Required]
@@ -125,7 +125,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalImportT0_W { get; set; } = default!;
 
   [Required]
@@ -136,7 +136,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalExportT0_W { get; set; } = default!;
 
   [Required]
@@ -144,7 +144,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
     ReactiveEnergyTotalImportT0_VARh { get; set; } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerTotalImportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -152,7 +152,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
     ReactiveEnergyTotalExportT0_VARh { get; set; } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedReactivePowerTotalExportT0_VAR { get; set; } = default!;
 
   [Required]
@@ -163,7 +163,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalImportT1_W { get; set; } = default!;
 
   [Required]
@@ -174,7 +174,7 @@ public class SchneideriEM3xxxAggregateModel : AggregateModel
   } = default!;
 
   [Required]
-  public required InstantaneousAggregateMeasureModel
+  public required DerivedAggregateMeasureModel
     DerivedActivePowerTotalImportT2_W { get; set; } = default!;
 
   public override TariffMeasure<decimal> Current_A

--- a/src/Ozds.Data/Entities/AbbB2xAggregateEntity.cs
+++ b/src/Ozds.Data/Entities/AbbB2xAggregateEntity.cs
@@ -60,7 +60,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL1ImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL1ImportT0_W
   {
     get;
     set;
@@ -72,7 +72,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL2ImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL2ImportT0_W
   {
     get;
     set;
@@ -84,7 +84,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL3ImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL3ImportT0_W
   {
     get;
     set;
@@ -96,7 +96,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL1ExportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL1ExportT0_W
   {
     get;
     set;
@@ -108,7 +108,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL2ExportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL2ExportT0_W
   {
     get;
     set;
@@ -120,7 +120,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL3ExportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL3ExportT0_W
   {
     get;
     set;
@@ -132,7 +132,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedReactivePowerL1ImportT0_VAR
+  public DerivedAggregateMeasureEntity DerivedReactivePowerL1ImportT0_VAR
   {
     get;
     set;
@@ -144,7 +144,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedReactivePowerL2ImportT0_VAR
+  public DerivedAggregateMeasureEntity DerivedReactivePowerL2ImportT0_VAR
   {
     get;
     set;
@@ -156,7 +156,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedReactivePowerL3ImportT0_VAR
+  public DerivedAggregateMeasureEntity DerivedReactivePowerL3ImportT0_VAR
   {
     get;
     set;
@@ -168,7 +168,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedReactivePowerL1ExportT0_VAR
+  public DerivedAggregateMeasureEntity DerivedReactivePowerL1ExportT0_VAR
   {
     get;
     set;
@@ -180,7 +180,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedReactivePowerL2ExportT0_VAR
+  public DerivedAggregateMeasureEntity DerivedReactivePowerL2ExportT0_VAR
   {
     get;
     set;
@@ -192,7 +192,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedReactivePowerL3ExportT0_VAR
+  public DerivedAggregateMeasureEntity DerivedReactivePowerL3ExportT0_VAR
   {
     get;
     set;
@@ -204,7 +204,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalImportT0_W
   {
     get;
     set;
@@ -216,7 +216,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalExportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalExportT0_W
   {
     get;
     set;
@@ -228,7 +228,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity
+  public DerivedAggregateMeasureEntity
     DerivedReactivePowerTotalImportT0_VAR { get; set; } = default!;
 
   public CumulativeAggregateMeasureEntity ReactiveEnergyTotalExportT0_VARh
@@ -237,7 +237,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity
+  public DerivedAggregateMeasureEntity
     DerivedReactivePowerTotalExportT0_VAR { get; set; } = default!;
 
   public CumulativeAggregateMeasureEntity ActiveEnergyTotalImportT1_Wh
@@ -246,7 +246,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalImportT1_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalImportT1_W
   {
     get;
     set;
@@ -258,7 +258,7 @@ public class AbbB2xAggregateEntity : AggregateEntity<AbbB2xMeterEntity>
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalImportT2_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalImportT2_W
   {
     get;
     set;
@@ -330,7 +330,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerL1ImportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l1_import_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l1_import_t0", "w");
 
     builder
       .ComplexProperty(nameof(AbbB2xAggregateEntity.ActiveEnergyL2ImportT0_Wh))
@@ -339,7 +339,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerL2ImportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l2_import_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l2_import_t0", "w");
 
     builder
       .ComplexProperty(nameof(AbbB2xAggregateEntity.ActiveEnergyL3ImportT0_Wh))
@@ -348,7 +348,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerL3ImportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l3_import_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l3_import_t0", "w");
 
     builder
       .ComplexProperty(nameof(AbbB2xAggregateEntity.ActiveEnergyL1ExportT0_Wh))
@@ -357,7 +357,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerL1ExportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l1_export_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l1_export_t0", "w");
 
     builder
       .ComplexProperty(nameof(AbbB2xAggregateEntity.ActiveEnergyL2ExportT0_Wh))
@@ -366,7 +366,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerL2ExportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l2_export_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l2_export_t0", "w");
 
     builder
       .ComplexProperty(nameof(AbbB2xAggregateEntity.ActiveEnergyL3ExportT0_Wh))
@@ -375,7 +375,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerL3ExportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l3_export_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l3_export_t0", "w");
 
     builder
       .ComplexProperty(
@@ -385,7 +385,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerL1ImportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_l1_import_t0", "var");
 
     builder
@@ -396,7 +396,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerL2ImportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_l2_import_t0", "var");
 
     builder
@@ -407,7 +407,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerL3ImportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_l3_import_t0", "var");
 
     builder
@@ -418,7 +418,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerL1ExportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_l1_export_t0", "var");
 
     builder
@@ -429,7 +429,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerL2ExportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_l2_export_t0", "var");
 
     builder
@@ -440,7 +440,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerL3ExportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_l3_export_t0", "var");
 
     builder
@@ -451,7 +451,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerTotalImportT0_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_import_t0", "w");
 
     builder
@@ -462,7 +462,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerTotalExportT0_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_export_t0", "w");
 
     builder
@@ -473,7 +473,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerTotalImportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_total_import_t0", "var");
 
     builder
@@ -484,7 +484,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedReactivePowerTotalExportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_total_export_t0", "var");
 
     builder
@@ -495,7 +495,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerTotalImportT1_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_import_t1", "w");
 
     builder
@@ -506,7 +506,7 @@ public class
     builder
       .ComplexProperty(
         nameof(AbbB2xAggregateEntity.DerivedActivePowerTotalImportT2_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_import_t2", "w");
   }
 }

--- a/src/Ozds.Data/Entities/AbbB2xMeasurementEntity.cs
+++ b/src/Ozds.Data/Entities/AbbB2xMeasurementEntity.cs
@@ -20,24 +20,24 @@ public class AbbB2xMeasurementEntity : MeasurementEntity<AbbB2xMeterEntity>
   public float ReactivePowerL1NetT0_VAR { get; set; }
   public float ReactivePowerL2NetT0_VAR { get; set; }
   public float ReactivePowerL3NetT0_VAR { get; set; }
-  public float ActiveEnergyL1ImportT0_Wh { get; set; }
-  public float ActiveEnergyL2ImportT0_Wh { get; set; }
-  public float ActiveEnergyL3ImportT0_Wh { get; set; }
-  public float ActiveEnergyL1ExportT0_Wh { get; set; }
-  public float ActiveEnergyL2ExportT0_Wh { get; set; }
-  public float ActiveEnergyL3ExportT0_Wh { get; set; }
-  public float ReactiveEnergyL1ImportT0_VARh { get; set; }
-  public float ReactiveEnergyL2ImportT0_VARh { get; set; }
-  public float ReactiveEnergyL3ImportT0_VARh { get; set; }
-  public float ReactiveEnergyL1ExportT0_VARh { get; set; }
-  public float ReactiveEnergyL2ExportT0_VARh { get; set; }
-  public float ReactiveEnergyL3ExportT0_VARh { get; set; }
-  public float ActiveEnergyTotalImportT0_Wh { get; set; }
-  public float ActiveEnergyTotalExportT0_Wh { get; set; }
-  public float ReactiveEnergyTotalImportT0_VARh { get; set; }
-  public float ReactiveEnergyTotalExportT0_VARh { get; set; }
-  public float ActiveEnergyTotalImportT1_Wh { get; set; }
-  public float ActiveEnergyTotalImportT2_Wh { get; set; }
+  public long ActiveEnergyL1ImportT0_Wh { get; set; }
+  public long ActiveEnergyL2ImportT0_Wh { get; set; }
+  public long ActiveEnergyL3ImportT0_Wh { get; set; }
+  public long ActiveEnergyL1ExportT0_Wh { get; set; }
+  public long ActiveEnergyL2ExportT0_Wh { get; set; }
+  public long ActiveEnergyL3ExportT0_Wh { get; set; }
+  public long ReactiveEnergyL1ImportT0_VARh { get; set; }
+  public long ReactiveEnergyL2ImportT0_VARh { get; set; }
+  public long ReactiveEnergyL3ImportT0_VARh { get; set; }
+  public long ReactiveEnergyL1ExportT0_VARh { get; set; }
+  public long ReactiveEnergyL2ExportT0_VARh { get; set; }
+  public long ReactiveEnergyL3ExportT0_VARh { get; set; }
+  public long ActiveEnergyTotalImportT0_Wh { get; set; }
+  public long ActiveEnergyTotalExportT0_Wh { get; set; }
+  public long ReactiveEnergyTotalImportT0_VARh { get; set; }
+  public long ReactiveEnergyTotalExportT0_VARh { get; set; }
+  public long ActiveEnergyTotalImportT1_Wh { get; set; }
+  public long ActiveEnergyTotalImportT2_Wh { get; set; }
 #pragma warning restore CA1707
 }
 
@@ -51,125 +51,183 @@ public class
     builder.ToTable("abb_b2x_measurements");
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.VoltageL1AnyT0_V))
-      .HasColumnName("voltage_l1_any_t0_v");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.VoltageL1AnyT0_V),
+        "voltage_l1_any_t0_v"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.VoltageL2AnyT0_V))
-      .HasColumnName("voltage_l2_any_t0_v");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.VoltageL2AnyT0_V),
+        "voltage_l2_any_t0_v"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.VoltageL3AnyT0_V))
-      .HasColumnName("voltage_l3_any_t0_v");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.VoltageL3AnyT0_V),
+        "voltage_l3_any_t0_v"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.CurrentL1AnyT0_A))
-      .HasColumnName("current_l1_any_t0_a");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.CurrentL1AnyT0_A),
+        "current_l1_any_t0_a"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.CurrentL2AnyT0_A))
-      .HasColumnName("current_l2_any_t0_a");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.CurrentL2AnyT0_A),
+        "current_l2_any_t0_a"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.CurrentL3AnyT0_A))
-      .HasColumnName("current_l3_any_t0_a");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.CurrentL3AnyT0_A),
+        "current_l3_any_t0_a"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActivePowerL1NetT0_W))
-      .HasColumnName("active_power_l1_net_t0_w");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActivePowerL1NetT0_W),
+        "active_power_l1_net_t0_w"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActivePowerL2NetT0_W))
-      .HasColumnName("active_power_l2_net_t0_w");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActivePowerL2NetT0_W),
+        "active_power_l2_net_t0_w"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActivePowerL3NetT0_W))
-      .HasColumnName("active_power_l3_net_t0_w");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActivePowerL3NetT0_W),
+        "active_power_l3_net_t0_w"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactivePowerL1NetT0_VAR))
-      .HasColumnName("reactive_power_l1_net_t0_var");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactivePowerL1NetT0_VAR),
+        "reactive_power_l1_net_t0_var"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactivePowerL2NetT0_VAR))
-      .HasColumnName("reactive_power_l2_net_t0_var");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactivePowerL2NetT0_VAR),
+        "reactive_power_l2_net_t0_var"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactivePowerL3NetT0_VAR))
-      .HasColumnName("reactive_power_l3_net_t0_var");
+      .InstantaneousMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactivePowerL3NetT0_VAR),
+        "reactive_power_l3_net_t0_var"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyL1ImportT0_Wh))
-      .HasColumnName("active_energy_l1_import_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyL1ImportT0_Wh),
+        "active_energy_l1_import_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyL2ImportT0_Wh))
-      .HasColumnName("active_energy_l2_import_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyL2ImportT0_Wh),
+        "active_energy_l2_import_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyL3ImportT0_Wh))
-      .HasColumnName("active_energy_l3_import_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyL3ImportT0_Wh),
+        "active_energy_l3_import_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyL1ExportT0_Wh))
-      .HasColumnName("active_energy_l1_export_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyL1ExportT0_Wh),
+        "active_energy_l1_export_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyL2ExportT0_Wh))
-      .HasColumnName("active_energy_l2_export_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyL2ExportT0_Wh),
+        "active_energy_l2_export_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyL3ExportT0_Wh))
-      .HasColumnName("active_energy_l3_export_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyL3ExportT0_Wh),
+        "active_energy_l3_export_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactiveEnergyL1ImportT0_VARh))
-      .HasColumnName("reactive_energy_l1_import_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyL1ImportT0_VARh),
+        "reactive_energy_l1_import_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactiveEnergyL2ImportT0_VARh))
-      .HasColumnName("reactive_energy_l2_import_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyL2ImportT0_VARh),
+        "reactive_energy_l2_import_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactiveEnergyL3ImportT0_VARh))
-      .HasColumnName("reactive_energy_l3_import_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyL3ImportT0_VARh),
+        "reactive_energy_l3_import_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactiveEnergyL1ExportT0_VARh))
-      .HasColumnName("reactive_energy_l1_export_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyL1ExportT0_VARh),
+        "reactive_energy_l1_export_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactiveEnergyL2ExportT0_VARh))
-      .HasColumnName("reactive_energy_l2_export_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyL2ExportT0_VARh),
+        "reactive_energy_l2_export_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ReactiveEnergyL3ExportT0_VARh))
-      .HasColumnName("reactive_energy_l3_export_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyL3ExportT0_VARh),
+        "reactive_energy_l3_export_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalImportT0_Wh))
-      .HasColumnName("active_energy_total_import_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalImportT0_Wh),
+        "active_energy_total_import_t0_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalExportT0_Wh))
-      .HasColumnName("active_energy_total_export_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalExportT0_Wh),
+        "active_energy_total_export_t0_wh"
+      );
 
     builder
-      .Property(
-        nameof(AbbB2xMeasurementEntity.ReactiveEnergyTotalImportT0_VARh))
-      .HasColumnName("reactive_energy_total_import_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyTotalImportT0_VARh),
+        "reactive_energy_total_import_t0_varh"
+      );
 
     builder
-      .Property(
-        nameof(AbbB2xMeasurementEntity.ReactiveEnergyTotalExportT0_VARh))
-      .HasColumnName("reactive_energy_total_export_t0_varh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ReactiveEnergyTotalExportT0_VARh),
+        "reactive_energy_total_export_t0_varh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalImportT1_Wh))
-      .HasColumnName("active_energy_total_import_t1_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalImportT1_Wh),
+        "active_energy_total_import_t1_wh"
+      );
 
     builder
-      .Property(nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalImportT2_Wh))
-      .HasColumnName("active_energy_total_import_t2_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(AbbB2xMeasurementEntity.ActiveEnergyTotalImportT2_Wh),
+        "active_energy_total_import_t2_wh"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/Abstractions/IAggregateMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Abstractions/IAggregateMeasureEntity.cs
@@ -2,7 +2,4 @@ namespace Ozds.Data.Entities.Abstractions;
 
 public interface IAggregateMeasureEntity
 {
-  public float Min { get; }
-
-  public float Max { get; }
 }

--- a/src/Ozds.Data/Entities/Abstractions/ICumulativeMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Abstractions/ICumulativeMeasureEntity.cs
@@ -1,0 +1,8 @@
+namespace Ozds.Data.Entities.Abstractions;
+
+public interface ICumulativeMeasureEntity : IAggregateMeasureEntity
+{
+  public long Min { get; }
+
+  public long Max { get; }
+}

--- a/src/Ozds.Data/Entities/Abstractions/IDerivedMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Abstractions/IDerivedMeasureEntity.cs
@@ -1,0 +1,10 @@
+namespace Ozds.Data.Entities.Abstractions;
+
+public interface IDerivedMeasureEntity : IAggregateMeasureEntity
+{
+  public long Min { get; }
+
+  public long Max { get; }
+
+  public double Avg { get; }
+}

--- a/src/Ozds.Data/Entities/Abstractions/IInstantaneousMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Abstractions/IInstantaneousMeasureEntity.cs
@@ -1,0 +1,10 @@
+namespace Ozds.Data.Entities.Abstractions;
+
+public interface IInstantaneousMeasureEntity : IAggregateMeasureEntity
+{
+  public float Min { get; }
+
+  public float Max { get; }
+
+  public float Avg { get; }
+}

--- a/src/Ozds.Data/Entities/Base/CalculationItemEntity.cs
+++ b/src/Ozds.Data/Entities/Base/CalculationItemEntity.cs
@@ -1,6 +1,6 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ozds.Data.Entities.Abstractions;
+using Ozds.Data.Extensions;
 
 namespace Ozds.Data.Entities.Base;
 
@@ -19,11 +19,15 @@ public static class CalculationItemEntityExtensions
   )
   {
     builder
-      .Property(nameof(CalculationItemEntity.Price_EUR))
-      .HasColumnName($"{prefix}_price_eur");
+      .MonetaryValue(
+        nameof(CalculationItemEntity.Price_EUR),
+        $"{prefix}_price_eur"
+      );
 
     builder
-      .Property(nameof(CalculationItemEntity.Total_EUR))
-      .HasColumnName($"{prefix}_total_eur");
+      .MonetaryValue(
+        nameof(CalculationItemEntity.Total_EUR),
+        $"{prefix}_total_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/Base/FinancialEntity.cs
+++ b/src/Ozds.Data/Entities/Base/FinancialEntity.cs
@@ -68,8 +68,10 @@ public class FinancialEntityTypeHierarchyConfiguration
       .HasForeignKey(nameof(CalculationEntity.IssuedById));
 
     builder
-      .Property(nameof(FinancialEntity.Total_EUR))
-      .HasColumnName("total_eur");
+      .MonetaryValue(
+        nameof(FinancialEntity.Total_EUR),
+        "total_eur"
+      );
 
     builder.Ignore(nameof(FinancialEntity.RepresentativeId));
   }

--- a/src/Ozds.Data/Entities/Base/InvoiceEntity.cs
+++ b/src/Ozds.Data/Entities/Base/InvoiceEntity.cs
@@ -37,15 +37,21 @@ public class
     var builder = modelBuilder.Entity(entity);
 
     builder
-      .Property(nameof(InvoiceEntity.InvoiceTaxRate_Percent))
-      .HasColumnName("tax_rate_percent");
+      .MonetaryValue(
+        nameof(InvoiceEntity.InvoiceTaxRate_Percent),
+        "tax_rate_percent"
+      );
 
     builder
-      .Property(nameof(InvoiceEntity.InvoiceTax_EUR))
-      .HasColumnName("tax_eur");
+      .MonetaryValue(
+        nameof(InvoiceEntity.InvoiceTax_EUR),
+        "tax_eur"
+      );
 
     builder
-      .Property(nameof(InvoiceEntity.InvoiceTotalWithTax_EUR))
-      .HasColumnName("total_with_tax_eur");
+      .MonetaryValue(
+        nameof(InvoiceEntity.InvoiceTotalWithTax_EUR),
+        "total_with_tax_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/Base/NetworkUserCalculationEntity.cs
+++ b/src/Ozds.Data/Entities/Base/NetworkUserCalculationEntity.cs
@@ -210,6 +210,19 @@ public class
     builder
       .ArchivedProperty(nameof(NetworkUserCalculationEntity.ArchivedMeter));
 
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserCalculationEntity.UsageFeeTotal_EUR),
+        "usage_fee_total_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserCalculationEntity
+          .SupplyFeeTotal_EUR),
+        "supply_fee_total_eur"
+      );
+
     if (entity != typeof(NetworkUserCalculationEntity))
     {
       builder

--- a/src/Ozds.Data/Entities/Base/NetworkUserCatalogueEntity.cs
+++ b/src/Ozds.Data/Entities/Base/NetworkUserCatalogueEntity.cs
@@ -40,7 +40,9 @@ public class
       .HasDiscriminator<string>(nameof(NetworkUserCatalogueEntity.Kind));
 
     builder
-      .Property(nameof(BlueLowNetworkUserCatalogueEntity.MeterFeePrice_EUR))
-      .HasColumnName("meter_fee_price_eur");
+      .MonetaryValue(
+        nameof(NetworkUserCatalogueEntity.MeterFeePrice_EUR),
+        "meter_fee_price_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/BlueLowNetworkUserCatalogueEntity.cs
+++ b/src/Ozds.Data/Entities/BlueLowNetworkUserCatalogueEntity.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ozds.Data.Entities.Base;
 using Ozds.Data.Extensions;
@@ -22,15 +21,17 @@ public class
     EntityTypeBuilder<BlueLowNetworkUserCatalogueEntity> builder)
   {
     builder
-      .Property(
+      .MonetaryValue(
         nameof(BlueLowNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT0Price_EUR))
-      .HasColumnName("active_energy_total_import_t0_price_eur");
+          .ActiveEnergyTotalImportT0Price_EUR),
+        "active_energy_total_import_t0_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(BlueLowNetworkUserCatalogueEntity
-          .ReactiveEnergyTotalRampedT0Price_EUR))
-      .HasColumnName("reactive_energy_total_ramped_t0_price_eur");
+          .ReactiveEnergyTotalRampedT0Price_EUR),
+        "reactive_energy_total_ramped_t0_price_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/Complex/AggregateMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Complex/AggregateMeasureEntity.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ozds.Data.Entities.Abstractions;
 
@@ -6,9 +5,6 @@ namespace Ozds.Data.Entities.Complex;
 
 public class AggregateMeasureEntity : IAggregateMeasureEntity
 {
-  public float Min { get; set; } = default!;
-
-  public float Max { get; set; } = default!;
 }
 
 public static class AggregateMeasureEntityExtensions
@@ -19,12 +15,6 @@ public static class AggregateMeasureEntityExtensions
     string unit
   )
   {
-    builder
-      .Property(nameof(CumulativeAggregateMeasureEntity.Min))
-      .HasColumnName($"{name}_min_{unit}");
-
-    builder
-      .Property(nameof(CumulativeAggregateMeasureEntity.Max))
-      .HasColumnName($"{name}_max_{unit}");
+    // NOTE: left here for reference
   }
 }

--- a/src/Ozds.Data/Entities/Complex/CumulativeAggregateMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Complex/CumulativeAggregateMeasureEntity.cs
@@ -1,9 +1,15 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ozds.Data.Entities.Abstractions;
+using Ozds.Data.Extensions;
 
 namespace Ozds.Data.Entities.Complex;
 
-public class CumulativeAggregateMeasureEntity : AggregateMeasureEntity
+public class CumulativeAggregateMeasureEntity : AggregateMeasureEntity,
+  ICumulativeMeasureEntity
 {
+  public long Min { get; set; } = default!;
+
+  public long Max { get; set; } = default!;
 }
 
 public static class CumulativeAggregateMeasureEntityExtensions
@@ -15,5 +21,17 @@ public static class CumulativeAggregateMeasureEntityExtensions
   )
   {
     builder.AggregateMeasure(name, unit);
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(InstantaneousAggregateMeasureEntity.Min),
+        $"{name}_min_{unit}"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(InstantaneousAggregateMeasureEntity.Max),
+        $"{name}_max_{unit}"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/Complex/DerivedAggregateMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Complex/DerivedAggregateMeasureEntity.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ozds.Data.Entities.Abstractions;
+
+namespace Ozds.Data.Entities.Complex;
+
+public class DerivedAggregateMeasureEntity
+  : AggregateMeasureEntity, IDerivedMeasureEntity
+{
+  public DateTimeOffset MinTimestamp { get; set; } = default!;
+
+  public DateTimeOffset MaxTimestamp { get; set; } = default!;
+  public long Min { get; set; } = default!;
+
+  public long Max { get; set; } = default!;
+
+  public double Avg { get; set; } = default!;
+}
+
+public static class DerivedAggregateMeasureEntityExtensions
+{
+  public static void DerivedAggregateMeasure(
+    this ComplexPropertyBuilder builder,
+    string name,
+    string unit
+  )
+  {
+    builder.AggregateMeasure(name, unit);
+
+    builder
+      .Property(nameof(DerivedAggregateMeasureEntity.Min))
+      .HasColumnName($"{name}_min_{unit}")
+      .HasColumnType("bigint");
+
+    builder
+      .Property(nameof(DerivedAggregateMeasureEntity.Max))
+      .HasColumnName($"{name}_max_{unit}")
+      .HasColumnType("bigint");
+
+    builder
+      .Property(nameof(DerivedAggregateMeasureEntity.Avg))
+      .HasColumnName($"{name}_avg_{unit}")
+      .HasColumnType("double precision");
+
+    builder
+      .Property(nameof(DerivedAggregateMeasureEntity.MinTimestamp))
+      .HasColumnName($"{name}_min_timestamp");
+
+    builder
+      .Property(nameof(DerivedAggregateMeasureEntity.MaxTimestamp))
+      .HasColumnName($"{name}_max_timestamp");
+  }
+}

--- a/src/Ozds.Data/Entities/Complex/InstantaneousAggregateMeasureEntity.cs
+++ b/src/Ozds.Data/Entities/Complex/InstantaneousAggregateMeasureEntity.cs
@@ -1,15 +1,21 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Ozds.Data.Entities.Abstractions;
+using Ozds.Data.Extensions;
 
 namespace Ozds.Data.Entities.Complex;
 
-public class InstantaneousAggregateMeasureEntity : AggregateMeasureEntity
+public class InstantaneousAggregateMeasureEntity
+  : AggregateMeasureEntity, IInstantaneousMeasureEntity
 {
-  public float Avg { get; set; } = default!;
-
   public DateTimeOffset MinTimestamp { get; set; } = default!;
 
   public DateTimeOffset MaxTimestamp { get; set; } = default!;
+  public float Min { get; set; } = default!;
+
+  public float Max { get; set; } = default!;
+
+  public float Avg { get; set; } = default!;
 }
 
 public static class InstantaneousAggregateMeasureEntityExtensions
@@ -23,8 +29,22 @@ public static class InstantaneousAggregateMeasureEntityExtensions
     builder.AggregateMeasure(name, unit);
 
     builder
-      .Property(nameof(InstantaneousAggregateMeasureEntity.Avg))
-      .HasColumnName($"{name}_avg_{unit}");
+      .InstantaneousMeasurementMeasure(
+        nameof(InstantaneousAggregateMeasureEntity.Min),
+        $"{name}_min_{unit}"
+      );
+
+    builder
+      .InstantaneousMeasurementMeasure(
+        nameof(InstantaneousAggregateMeasureEntity.Max),
+        $"{name}_max_{unit}"
+      );
+
+    builder
+      .InstantaneousMeasurementMeasure(
+        nameof(InstantaneousAggregateMeasureEntity.Avg),
+        $"{name}_avg_{unit}"
+      );
 
     builder
       .Property(nameof(InstantaneousAggregateMeasureEntity.MinTimestamp))

--- a/src/Ozds.Data/Entities/NetworkUserInvoiceEntity.cs
+++ b/src/Ozds.Data/Entities/NetworkUserInvoiceEntity.cs
@@ -86,5 +86,83 @@ public class
       .ArchivedProperty(
         nameof(NetworkUserInvoiceEntity
           .ArchivedRegulatoryCatalogue));
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity.UsageActiveEnergyTotalImportT0Fee_EUR),
+        "usage_active_energy_total_import_t0_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity
+          .UsageActiveEnergyTotalImportT1Fee_EUR),
+        "usage_active_energy_total_import_t1_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity
+          .UsageActiveEnergyTotalImportT2Fee_EUR),
+        "usage_active_energy_total_import_t2_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity
+          .UsageActivePowerTotalImportT1PeakFee_EUR),
+        "usage_active_power_total_import_t1_peak_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity
+          .UsageReactiveEnergyTotalRampedT0Fee_EUR),
+        "usage_reactive_energy_total_ramped_t0_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity.UsageMeterFee_EUR),
+        "usage_meter_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity.UsageFeeTotal_EUR),
+        "usage_fee_total_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity
+          .SupplyActiveEnergyTotalImportT1Fee_EUR),
+        "supply_active_energy_total_import_t1_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity
+          .SupplyActiveEnergyTotalImportT2Fee_EUR),
+        "supply_active_energy_total_import_t2_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity.SupplyBusinessUsageFee_EUR),
+        "supply_business_usage_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity.SupplyRenewableEnergyFee_EUR),
+        "supply_renewable_energy_fee_eur"
+      );
+
+    builder
+      .MonetaryValue(
+        nameof(NetworkUserInvoiceEntity.SupplyFeeTotal_EUR),
+        "supply_fee_total_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/RedLowNetworkUserCatalogueEntity.cs
+++ b/src/Ozds.Data/Entities/RedLowNetworkUserCatalogueEntity.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ozds.Data.Entities.Base;
 using Ozds.Data.Extensions;
@@ -24,27 +23,31 @@ public class
     EntityTypeBuilder<RedLowNetworkUserCatalogueEntity> builder)
   {
     builder
-      .Property(
+      .MonetaryValue(
         nameof(RedLowNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT1Price_EUR))
-      .HasColumnName("active_energy_total_import_t1_price_eur");
+          .ActiveEnergyTotalImportT1Price_EUR),
+        "active_energy_total_import_t1_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(RedLowNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT2Price_EUR))
-      .HasColumnName("active_energy_total_import_t2_price_eur");
+          .ActiveEnergyTotalImportT2Price_EUR),
+        "active_energy_total_import_t2_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(RedLowNetworkUserCatalogueEntity
-          .ActivePowerTotalImportT1Price_EUR))
-      .HasColumnName("active_power_total_import_t1_price_eur");
+          .ActivePowerTotalImportT1Price_EUR),
+        "active_power_total_import_t1_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(RedLowNetworkUserCatalogueEntity
-          .ReactiveEnergyTotalRampedT0Price_EUR))
-      .HasColumnName("reactive_energy_total_ramped_t0_price_eur");
+          .ReactiveEnergyTotalRampedT0Price_EUR),
+        "reactive_energy_total_ramped_t0_price_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/SchneideriEM3xxxAggregateEntity.cs
+++ b/src/Ozds.Data/Entities/SchneideriEM3xxxAggregateEntity.cs
@@ -55,7 +55,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL1ImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL1ImportT0_W
   {
     get;
     set;
@@ -67,7 +67,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL2ImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL2ImportT0_W
   {
     get;
     set;
@@ -79,7 +79,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerL3ImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerL3ImportT0_W
   {
     get;
     set;
@@ -91,7 +91,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalImportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalImportT0_W
   {
     get;
     set;
@@ -103,7 +103,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalExportT0_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalExportT0_W
   {
     get;
     set;
@@ -115,7 +115,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity
+  public DerivedAggregateMeasureEntity
     DerivedReactivePowerTotalImportT0_VAR { get; set; } = default!;
 
   public CumulativeAggregateMeasureEntity ReactiveEnergyTotalExportT0_VARh
@@ -124,7 +124,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity
+  public DerivedAggregateMeasureEntity
     DerivedReactivePowerTotalExportT0_VAR { get; set; } = default!;
 
   public CumulativeAggregateMeasureEntity ActiveEnergyTotalImportT1_Wh
@@ -133,7 +133,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalImportT1_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalImportT1_W
   {
     get;
     set;
@@ -145,7 +145,7 @@ public class
     set;
   } = default!;
 
-  public InstantaneousAggregateMeasureEntity DerivedActivePowerTotalImportT2_W
+  public DerivedAggregateMeasureEntity DerivedActivePowerTotalImportT2_W
   {
     get;
     set;
@@ -219,7 +219,7 @@ public class
     builder
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity.DerivedActivePowerL1ImportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l1_import_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l1_import_t0", "w");
 
     builder
       .ComplexProperty(
@@ -229,7 +229,7 @@ public class
     builder
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity.DerivedActivePowerL2ImportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l2_import_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l2_import_t0", "w");
 
     builder
       .ComplexProperty(
@@ -239,7 +239,7 @@ public class
     builder
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity.DerivedActivePowerL3ImportT0_W))
-      .InstantaneousAggregateMeasure("derived_active_power_l3_import_t0", "w");
+      .DerivedAggregateMeasure("derived_active_power_l3_import_t0", "w");
 
     builder
       .ComplexProperty(
@@ -250,7 +250,7 @@ public class
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity
           .DerivedActivePowerTotalImportT0_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_import_t0", "w");
 
     builder
@@ -262,7 +262,7 @@ public class
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity
           .DerivedActivePowerTotalExportT0_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_export_t0", "w");
 
     builder
@@ -275,7 +275,7 @@ public class
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity
           .DerivedReactivePowerTotalImportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_total_import_t0", "var");
 
     builder
@@ -288,7 +288,7 @@ public class
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity
           .DerivedReactivePowerTotalExportT0_VAR))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_reactive_power_total_export_t0", "var");
 
     builder
@@ -300,7 +300,7 @@ public class
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity
           .DerivedActivePowerTotalImportT1_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_import_t1", "w");
 
     builder
@@ -312,7 +312,7 @@ public class
       .ComplexProperty(
         nameof(SchneideriEM3xxxAggregateEntity
           .DerivedActivePowerTotalImportT2_W))
-      .InstantaneousAggregateMeasure(
+      .DerivedAggregateMeasure(
         "derived_active_power_total_import_t2", "w");
   }
 }

--- a/src/Ozds.Data/Entities/SchneideriEM3xxxMeasurementEntity.cs
+++ b/src/Ozds.Data/Entities/SchneideriEM3xxxMeasurementEntity.cs
@@ -21,15 +21,15 @@ public class
   public float ActivePowerL3NetT0_W { get; set; }
   public float ReactivePowerTotalNetT0_VAR { get; set; }
   public float ApparentPowerTotalNetT0_VA { get; set; }
-  public float ActiveEnergyL1ImportT0_Wh { get; set; }
-  public float ActiveEnergyL2ImportT0_Wh { get; set; }
-  public float ActiveEnergyL3ImportT0_Wh { get; set; }
-  public float ActiveEnergyTotalImportT0_Wh { get; set; }
-  public float ActiveEnergyTotalExportT0_Wh { get; set; }
-  public float ReactiveEnergyTotalImportT0_VARh { get; set; }
-  public float ReactiveEnergyTotalExportT0_VARh { get; set; }
-  public float ActiveEnergyTotalImportT1_Wh { get; set; }
-  public float ActiveEnergyTotalImportT2_Wh { get; set; }
+  public long ActiveEnergyL1ImportT0_Wh { get; set; }
+  public long ActiveEnergyL2ImportT0_Wh { get; set; }
+  public long ActiveEnergyL3ImportT0_Wh { get; set; }
+  public long ActiveEnergyTotalImportT0_Wh { get; set; }
+  public long ActiveEnergyTotalExportT0_Wh { get; set; }
+  public long ReactiveEnergyTotalImportT0_VARh { get; set; }
+  public long ReactiveEnergyTotalExportT0_VARh { get; set; }
+  public long ActiveEnergyTotalImportT1_Wh { get; set; }
+  public long ActiveEnergyTotalImportT2_Wh { get; set; }
 #pragma warning restore CA1707
 }
 
@@ -43,105 +43,125 @@ public class
     builder.ToTable("schneider_iem3xxx_measurements");
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.VoltageL1AnyT0_V))
-      .HasColumnName("voltage_l1_any_t0_v");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.VoltageL1AnyT0_V),
+        "voltage_l1_any_t0_v"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.VoltageL2AnyT0_V))
-      .HasColumnName("voltage_l2_any_t0_v");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.VoltageL2AnyT0_V),
+        "voltage_l2_any_t0_v"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.VoltageL3AnyT0_V))
-      .HasColumnName("voltage_l3_any_t0_v");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.VoltageL3AnyT0_V),
+        "voltage_l3_any_t0_v"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.CurrentL1AnyT0_A))
-      .HasColumnName("current_l1_any_t0_a");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.CurrentL1AnyT0_A),
+        "current_l1_any_t0_a"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.CurrentL2AnyT0_A))
-      .HasColumnName("current_l2_any_t0_a");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.CurrentL2AnyT0_A),
+        "current_l2_any_t0_a"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.CurrentL3AnyT0_A))
-      .HasColumnName("current_l3_any_t0_a");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.CurrentL3AnyT0_A),
+        "current_l3_any_t0_a"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.ActivePowerL1NetT0_W))
-      .HasColumnName("active_power_l1_net_t0_w");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActivePowerL1NetT0_W),
+        "active_power_l1_net_t0_w"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.ActivePowerL2NetT0_W))
-      .HasColumnName("active_power_l2_net_t0_w");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActivePowerL2NetT0_W),
+        "active_power_l2_net_t0_w"
+      );
 
     builder
-      .Property(nameof(SchneideriEM3xxxMeasurementEntity.ActivePowerL3NetT0_W))
-      .HasColumnName("active_power_l3_net_t0_w");
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActivePowerL3NetT0_W),
+        "active_power_l3_net_t0_w"
+      );
 
     builder
-      .Property(
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ReactivePowerTotalNetT0_VAR),
+        "reactive_power_total_net_t0_var"
+      );
+
+    builder
+      .InstantaneousMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ApparentPowerTotalNetT0_VA),
+        "apparent_power_total_net_t0_va"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyL1ImportT0_Wh),
+        "active_energy_l1_import_t0_wh"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyL2ImportT0_Wh),
+        "active_energy_l2_import_t0_wh"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyL3ImportT0_Wh),
+        "active_energy_l3_import_t0_wh"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyTotalImportT0_Wh),
+        "active_energy_total_import_t0_wh"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyTotalExportT0_Wh),
+        "active_energy_total_export_t0_wh"
+      );
+
+    builder
+      .CumulativeMeasurementMeasure(
         nameof(SchneideriEM3xxxMeasurementEntity
-          .ReactivePowerTotalNetT0_VAR))
-      .HasColumnName("reactive_power_total_net_t0_var");
+          .ReactiveEnergyTotalImportT0_VARh),
+        "reactive_energy_total_import_t0_varh"
+      );
 
     builder
-      .Property(
+      .CumulativeMeasurementMeasure(
         nameof(SchneideriEM3xxxMeasurementEntity
-          .ApparentPowerTotalNetT0_VA))
-      .HasColumnName("apparent_power_total_net_t0_va");
+          .ReactiveEnergyTotalExportT0_VARh),
+        "reactive_energy_total_export_t0_varh"
+      );
 
     builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyL1ImportT0_Wh))
-      .HasColumnName("active_energy_l1_import_t0_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyTotalImportT1_Wh),
+        "active_energy_total_import_t1_wh"
+      );
 
     builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyL2ImportT0_Wh))
-      .HasColumnName("active_energy_l2_import_t0_wh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyL3ImportT0_Wh))
-      .HasColumnName("active_energy_l3_import_t0_wh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyTotalImportT0_Wh))
-      .HasColumnName("active_energy_total_import_t0_wh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyTotalExportT0_Wh))
-      .HasColumnName("active_energy_total_export_t0_wh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ReactiveEnergyTotalImportT0_VARh))
-      .HasColumnName("reactive_energy_total_import_t0_varh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ReactiveEnergyTotalExportT0_VARh))
-      .HasColumnName("reactive_energy_total_export_t0_varh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyTotalImportT1_Wh))
-      .HasColumnName("active_energy_total_import_t1_wh");
-
-    builder
-      .Property(
-        nameof(SchneideriEM3xxxMeasurementEntity
-          .ActiveEnergyTotalImportT2_Wh))
-      .HasColumnName("active_energy_total_import_t2_wh");
+      .CumulativeMeasurementMeasure(
+        nameof(SchneideriEM3xxxMeasurementEntity.ActiveEnergyTotalImportT2_Wh),
+        "active_energy_total_import_t2_wh"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/WhiteLowNetworkUserCatalogueEntity.cs
+++ b/src/Ozds.Data/Entities/WhiteLowNetworkUserCatalogueEntity.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ozds.Data.Entities.Base;
 using Ozds.Data.Extensions;
@@ -23,21 +22,24 @@ public class
     EntityTypeBuilder<WhiteLowNetworkUserCatalogueEntity> builder)
   {
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteLowNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT1Price_EUR))
-      .HasColumnName("active_energy_total_import_t1_price_eur");
+          .ActiveEnergyTotalImportT1Price_EUR),
+        "active_energy_total_import_t1_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteLowNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT2Price_EUR))
-      .HasColumnName("active_energy_total_import_t2_price_eur");
+          .ActiveEnergyTotalImportT2Price_EUR),
+        "active_energy_total_import_t2_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteLowNetworkUserCatalogueEntity
-          .ReactiveEnergyTotalRampedT0Price_EUR))
-      .HasColumnName("reactive_energy_total_ramped_t0_price_eur");
+          .ReactiveEnergyTotalRampedT0Price_EUR),
+        "reactive_energy_total_ramped_t0_price_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Entities/WhiteMediumNetworkUserCatalogueEntity.cs
+++ b/src/Ozds.Data/Entities/WhiteMediumNetworkUserCatalogueEntity.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ozds.Data.Entities.Base;
 using Ozds.Data.Extensions;
@@ -25,27 +24,31 @@ public class
     EntityTypeBuilder<WhiteMediumNetworkUserCatalogueEntity> builder)
   {
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteMediumNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT1Price_EUR))
-      .HasColumnName("active_energy_total_import_t1_price_eur");
+          .ActiveEnergyTotalImportT1Price_EUR),
+        "active_energy_total_import_t1_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteMediumNetworkUserCatalogueEntity
-          .ActiveEnergyTotalImportT2Price_EUR))
-      .HasColumnName("active_energy_total_import_t2_price_eur");
+          .ActiveEnergyTotalImportT2Price_EUR),
+        "active_energy_total_import_t2_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteMediumNetworkUserCatalogueEntity
-          .ActivePowerTotalImportT1Price_EUR))
-      .HasColumnName("active_power_total_import_t1_price_eur");
+          .ActivePowerTotalImportT1Price_EUR),
+        "active_power_total_import_t1_price_eur"
+      );
 
     builder
-      .Property(
+      .MonetaryValue(
         nameof(WhiteMediumNetworkUserCatalogueEntity
-          .ReactiveEnergyTotalRampedT0Price_EUR))
-      .HasColumnName("reactive_energy_total_ramped_t0_price_eur");
+          .ReactiveEnergyTotalRampedT0Price_EUR),
+        "reactive_energy_total_ramped_t0_price_eur"
+      );
   }
 }

--- a/src/Ozds.Data/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Ozds.Data/Extensions/EntityTypeBuilderExtensions.cs
@@ -4,11 +4,92 @@ using Ozds.Data.Entities.Abstractions;
 
 namespace Ozds.Data.Extensions;
 
-// TODO: forget and entity properties are flakey because
-// they depend on the name of the property
-
 public static class EntityTypeBuilderExtensions
 {
+  public static void InstantaneousMeasurementMeasure(
+    this EntityTypeBuilder builder,
+    string propertyName,
+    string columnName
+  )
+  {
+    builder
+      .Property(propertyName)
+      .HasColumnName(columnName)
+      // NOTE: we are not using these for any further calculation
+      // and it would be more beneficial to save space on these
+      // rather than to make them more precise
+      .HasColumnType("real");
+  }
+
+  public static void CumulativeMeasurementMeasure(
+    this EntityTypeBuilder builder,
+    string propertyName,
+    string columnName
+  )
+  {
+    builder
+      .Property(propertyName)
+      .HasColumnName(columnName)
+      // NOTE: used for calculations
+      .HasColumnType("bigint");
+  }
+
+  public static void MonetaryValue(
+    this EntityTypeBuilder builder,
+    string propertyName,
+    string columnName
+  )
+  {
+    builder
+      .Property(propertyName)
+      .HasColumnName(columnName)
+      // NOTE: https://stackoverflow.com/a/27328409
+      .HasColumnType("decimal(19, 4)");
+  }
+
+  public static void InstantaneousMeasurementMeasure(
+    this ComplexPropertyBuilder builder,
+    string propertyName,
+    string columnName
+  )
+  {
+    builder
+      .Property(propertyName)
+      .HasColumnName(columnName)
+      // NOTE: we are not using these for any further calculation
+      // and it would be more beneficial to save space on these
+      // rather than to make them more precise
+      .HasColumnType("real");
+  }
+
+  public static void CumulativeMeasurementMeasure(
+    this ComplexPropertyBuilder builder,
+    string propertyName,
+    string columnName
+  )
+  {
+    builder
+      .Property(propertyName)
+      .HasColumnName(columnName)
+      // NOTE: used for calculations
+      .HasColumnType("bigint");
+  }
+
+  public static void MonetaryValue(
+    this ComplexPropertyBuilder builder,
+    string propertyName,
+    string columnName
+  )
+  {
+    builder
+      .Property(propertyName)
+      .HasColumnName(columnName)
+      // NOTE: https://stackoverflow.com/a/27328409
+      .HasColumnType("decimal(19, 4)");
+  }
+
+  // TODO: forget and entity properties are flakey because
+  // they depend on the name of the property
   public static ComplexPropertyBuilder Archived(
     this ComplexPropertyBuilder complexPropertyBuilder,
     string? propertyName = null)

--- a/src/Ozds.Data/Migrations/20250313085413_NumericValues.Designer.cs
+++ b/src/Ozds.Data/Migrations/20250313085413_NumericValues.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Ozds.Data.Context;
@@ -14,9 +15,11 @@ using Ozds.Data.Entities.Enums;
 namespace Ozds.Data.Migrations
 {
     [DbContext(typeof(DataDbContext))]
-    partial class DataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250313085413_NumericValues")]
+    partial class NumericValues
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ozds.Data/Migrations/20250313085413_NumericValues.cs
+++ b/src/Ozds.Data/Migrations/20250313085413_NumericValues.cs
@@ -1,0 +1,3430 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ozds.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class NumericValues : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "usage_reactive_energy_total_ramped_t0fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_reactive_energy_total_ramped_t0_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_power_total_import_t1peak_fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_power_total_import_t1_peak_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_energy_total_import_t2fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_energy_total_import_t2_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_energy_total_import_t1fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_energy_total_import_t1_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_energy_total_import_t0fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_energy_total_import_t0_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "supply_active_energy_total_import_t2fee_eur",
+                table: "network_user_invoices",
+                newName: "supply_active_energy_total_import_t2_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "supply_active_energy_total_import_t1fee_eur",
+                table: "network_user_invoices",
+                newName: "supply_active_energy_total_import_t1_fee_eur");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_import_t0_varh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_export_t0_varh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t2_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t1_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_export_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_import_t0_min_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_import_t0_max_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_export_t0_min_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_export_t0_max_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_import_t0_min_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_import_t0_max_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_total_import_t0_avg_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_export_t0_min_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_export_t0_max_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_total_export_t0_avg_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t2_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t2_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_import_t2_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t1_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t1_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_import_t1_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_export_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_export_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_export_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l3_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l3_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l3_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l2_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l2_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l2_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l1_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l1_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l1_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t2_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t2_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t1_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t1_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_export_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_export_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_meter_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_fee_total_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "total_with_tax_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "total_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "tax_rate_percent",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "tax_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_renewable_energy_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_fee_total_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_business_usage_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_reactive_energy_total_ramped_t0_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_power_total_import_t1_peak_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_energy_total_import_t2_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_energy_total_import_t1_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_energy_total_import_t0_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_active_energy_total_import_t2_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_active_energy_total_import_t1_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "reactive_energy_total_ramped_t0_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "meter_fee_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_power_total_import_t1_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_energy_total_import_t2_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_energy_total_import_t1_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_energy_total_import_t0_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_meter_fee_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_meter_fee_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_fee_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "trp_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "trp_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "svt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "svt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_fee_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rvt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rvt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rnt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rnt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "oie_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "oie_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mvt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mvt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mnt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mnt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mjt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mjt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "jen_total_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "jen_price_eur",
+                table: "network_user_calculations",
+                type: "numeric(19,4)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l3_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l3_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l2_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l2_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l1_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l1_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t2_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t1_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_total_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l3_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l3_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l3_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l3_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l2_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l2_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l2_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l2_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l1_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l1_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l1_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "reactive_energy_l1_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_total_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_total_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_total_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l3_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l3_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_l3_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l3_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l3_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_l3_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l2_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l2_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_l2_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l2_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l2_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_l2_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l1_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l1_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_l1_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l1_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_reactive_power_l1_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_reactive_power_l1_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t2_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t2_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_import_t2_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t1_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t1_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_import_t1_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_total_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_total_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l3_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l3_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l3_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l3_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l3_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l3_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l2_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l2_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l2_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l2_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l2_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l2_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l1_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l1_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l1_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l1_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "derived_active_power_l1_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "derived_active_power_l1_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t2_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t2_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t1_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t1_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_total_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l3_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l2_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "active_energy_l1_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(float),
+                oldType: "real");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "usage_reactive_energy_total_ramped_t0_fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_reactive_energy_total_ramped_t0fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_power_total_import_t1_peak_fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_power_total_import_t1peak_fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_energy_total_import_t2_fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_energy_total_import_t2fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_energy_total_import_t1_fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_energy_total_import_t1fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "usage_active_energy_total_import_t0_fee_eur",
+                table: "network_user_invoices",
+                newName: "usage_active_energy_total_import_t0fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "supply_active_energy_total_import_t2_fee_eur",
+                table: "network_user_invoices",
+                newName: "supply_active_energy_total_import_t2fee_eur");
+
+            migrationBuilder.RenameColumn(
+                name: "supply_active_energy_total_import_t1_fee_eur",
+                table: "network_user_invoices",
+                newName: "supply_active_energy_total_import_t1fee_eur");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_import_t0_varh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_export_t0_varh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t2_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t1_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_export_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_import_t0_wh",
+                table: "schneider_iem3xxx_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_import_t0_min_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_import_t0_max_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_export_t0_min_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_export_t0_max_varh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_import_t0_min_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_import_t0_max_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_import_t0_avg_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_export_t0_min_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_export_t0_max_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_export_t0_avg_var",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t2_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t2_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t2_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t1_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t1_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t1_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_export_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_export_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_export_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_import_t0_min_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_import_t0_max_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_import_t0_avg_w",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t2_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t2_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t1_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t1_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_export_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_export_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_import_t0_min_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_import_t0_max_wh",
+                table: "schneider_iem3xxx_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_meter_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_fee_total_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "total_with_tax_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "total_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "tax_rate_percent",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "tax_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_renewable_energy_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_fee_total_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_business_usage_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_reactive_energy_total_ramped_t0fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_power_total_import_t1peak_fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_energy_total_import_t2fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_energy_total_import_t1fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_active_energy_total_import_t0fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_active_energy_total_import_t2fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_active_energy_total_import_t1fee_eur",
+                table: "network_user_invoices",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "reactive_energy_total_ramped_t0_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "meter_fee_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_power_total_import_t1_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_energy_total_import_t2_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_energy_total_import_t1_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "active_energy_total_import_t0_price_eur",
+                table: "network_user_catalogues",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_meter_fee_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_meter_fee_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "usage_fee_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "trp_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "trp_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "svt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "svt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "supply_fee_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rvt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rvt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rnt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "rnt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "oie_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "oie_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mvt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mvt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mnt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mnt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mjt_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "mjt_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "jen_total_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "jen_price_eur",
+                table: "network_user_calculations",
+                type: "numeric",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(19,4)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l3_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l3_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l2_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l2_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l1_import_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l1_export_t0_varh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t2_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t1_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_import_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_export_t0_wh",
+                table: "abb_b2x_measurements",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_total_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l3_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l3_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l3_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l3_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l2_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l2_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l2_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l2_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l1_import_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l1_import_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l1_export_t0_min_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "reactive_energy_l1_export_t0_max_varh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_total_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l3_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l3_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l3_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l3_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l3_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l3_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l2_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l2_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l2_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l2_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l2_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l2_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l1_import_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l1_import_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l1_import_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l1_export_t0_min_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l1_export_t0_max_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_reactive_power_l1_export_t0_avg_var",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t2_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t2_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t2_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t1_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t1_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t1_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_total_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l3_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l2_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_import_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_import_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_import_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_export_t0_min_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_export_t0_max_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "derived_active_power_l1_export_t0_avg_w",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t2_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t2_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t1_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t1_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_total_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l3_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l2_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_import_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_import_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_export_t0_min_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<float>(
+                name: "active_energy_l1_export_t0_max_wh",
+                table: "abb_b2x_aggregates",
+                type: "real",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+        }
+    }
+}

--- a/src/Ozds.Server/Controllers/AppController.cs
+++ b/src/Ozds.Server/Controllers/AppController.cs
@@ -16,10 +16,10 @@ public class AppController(IAntiforgery antiforgery) : Controller
 
   public IActionResult Cultured(
     string culture,
-    string catchall
+    string? catchall
   )
   {
-    if (catchall.StartsWith("_content"))
+    if (catchall?.StartsWith("_content") ?? false)
     {
       return Redirect($"/{catchall}");
     }

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest.cs
@@ -47,18 +47,18 @@ public class UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest
     var start = Constants.DefaultDateTimeOffset;
     var end = start.AddMonths(1);
 
-    var instantaneousMeasureFakerNoise =
-      new Faker<InstantaneousAggregateMeasureModel>()
+    var derivedMeasureFakerNoise =
+      new Faker<DerivedAggregateMeasureModel>()
         .RuleFor(
-          m => m.Avg, f => f.Random.Decimal(
+          m => m.Max, f => f.Random.Decimal(
             Constants.MinPowerValue, Constants.MaxPowerValue));
 
-    var measureFakerDud = new Faker<InstantaneousAggregateMeasureModel>()
+    var measureFakerDud = new Faker<DerivedAggregateMeasureModel>()
       .RuleFor(
         x => x.Max,
         (f, m) => f.Random.Decimal(0, expected.Peak_kW * 1000M - 0.01M));
 
-    var measureFakerPeak = new Faker<InstantaneousAggregateMeasureModel>()
+    var measureFakerPeak = new Faker<DerivedAggregateMeasureModel>()
       .RuleFor(
         x => x.Max,
         (_, m) => expected.Peak_kW * 1000M);
@@ -75,34 +75,34 @@ public class UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest
             end.Subtract(IntervalModel.QuarterHour.ToTimeSpan(start))))
         .RuleFor(
           x => x.DerivedActivePowerL1ImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL2ImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL3ImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL1ExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL2ExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL3ExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalImportT1_W,
           (_, _) => measureFakerDud.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalImportT2_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .Generate(Constants.DefaultFuzzCount);
     var peakAggregate =
       new Faker<AbbB2xAggregateModel>()
@@ -116,34 +116,34 @@ public class UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest
             end.Subtract(IntervalModel.QuarterHour.ToTimeSpan(start))))
         .RuleFor(
           x => x.DerivedActivePowerL1ImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL2ImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL3ImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalImportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL1ExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL2ExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerL3ExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalExportT0_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalImportT1_W,
           (_, _) => measureFakerPeak.Generate())
         .RuleFor(
           x => x.DerivedActivePowerTotalImportT2_W,
-          f => instantaneousMeasureFakerNoise.Generate())
+          f => derivedMeasureFakerNoise.Generate())
         .Generate();
 
     var aggregates = noiseAggregates

--- a/test/Ozds.Data.Test/Fixtures/Constants.cs
+++ b/test/Ozds.Data.Test/Fixtures/Constants.cs
@@ -2,7 +2,7 @@ namespace Ozds.Data.Test.Fixtures;
 
 public static class Constants
 {
-  public const float MinAggregateValue = 0.0f;
-  public const float MaxAggregateValue = 100.0f;
+  public const int MinAggregateValue = 0;
+  public const int MaxAggregateValue = 100;
   public const int DefaultDbFuzzCount = 3;
 }

--- a/test/Ozds.Data.Test/Fixtures/MeasurementEntityFactory.cs
+++ b/test/Ozds.Data.Test/Fixtures/MeasurementEntityFactory.cs
@@ -53,17 +53,17 @@ public class MeasurementUpsertFactory(DbContext context)
   {
     var faker = new Faker();
 
-    InstantaneousAggregateMeasureEntity DerivedPowerFactory(int i)
+    DerivedAggregateMeasureEntity DerivedPowerFactory(int i)
     {
       var interval = IntervalByIndex(i);
       var timestamp = AggregateTimestampByIndex(i);
       var min = faker.Random
-        .Float(Constants.MinAggregateValue, Constants.MaxAggregateValue);
+        .Long(Constants.MinAggregateValue, Constants.MaxAggregateValue);
       var max = faker.Random
-        .Float(min, Constants.MaxAggregateValue);
+        .Long(min, Constants.MaxAggregateValue);
       var avg = (min + max) / 2;
       return interval == IntervalEntity.QuarterHour
-        ? new InstantaneousAggregateMeasureEntity
+        ? new DerivedAggregateMeasureEntity
         {
           Min = min,
           Max = max,
@@ -71,10 +71,10 @@ public class MeasurementUpsertFactory(DbContext context)
           MinTimestamp = timestamp,
           MaxTimestamp = timestamp
         }
-        : new InstantaneousAggregateMeasureEntity
+        : new DerivedAggregateMeasureEntity
         {
-          Min = float.PositiveInfinity,
-          Max = float.NegativeInfinity,
+          Min = long.MinValue,
+          Max = long.MaxValue,
           Avg = 0.0f,
           MinTimestamp = timestamp,
           MaxTimestamp = timestamp

--- a/test/Ozds.Data.Test/Mutations/MeasurementMutationsTest/CreateMeasurementsTest.cs
+++ b/test/Ozds.Data.Test/Mutations/MeasurementMutationsTest/CreateMeasurementsTest.cs
@@ -820,6 +820,28 @@ public class CreateMeasurementsTest(
       };
     }
 
+    public static DerivedAggregateMeasureEntity Upsert(
+      DerivedAggregateMeasureEntity lhs,
+      long lhsCount,
+      DerivedAggregateMeasureEntity rhs,
+      long rhsCount
+    )
+    {
+      return new DerivedAggregateMeasureEntity
+      {
+        Avg = (lhs.Avg * lhsCount + rhs.Avg * rhsCount)
+          / (lhsCount + rhsCount),
+        Min = Math.Min(lhs.Min, rhs.Min),
+        MinTimestamp = lhs.Min < rhs.Min
+          ? lhs.MinTimestamp
+          : rhs.MinTimestamp,
+        Max = Math.Max(lhs.Max, rhs.Max),
+        MaxTimestamp = lhs.Max > rhs.Max
+          ? lhs.MaxTimestamp
+          : rhs.MaxTimestamp
+      };
+    }
+
     public static CumulativeAggregateMeasureEntity Upsert(
       CumulativeAggregateMeasureEntity lhs,
       CumulativeAggregateMeasureEntity rhs
@@ -832,7 +854,7 @@ public class CreateMeasurementsTest(
       };
     }
 
-    public static InstantaneousAggregateMeasureEntity Upsert(
+    public static DerivedAggregateMeasureEntity Upsert(
       CumulativeAggregateMeasureEntity lhs,
       CumulativeAggregateMeasureEntity rhs,
       DateTimeOffset timestamp
@@ -840,7 +862,7 @@ public class CreateMeasurementsTest(
     {
       var value =
         (Math.Max(lhs.Max, rhs.Max) - Math.Min(lhs.Min, rhs.Min)) * 4;
-      return new InstantaneousAggregateMeasureEntity
+      return new DerivedAggregateMeasureEntity
       {
         Avg = value,
         Min = value,


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #82 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Added

- Migration to use correct column types for numeric values
- `DerivedAggregateMeasureModel` and `DerivedAggregateMeasureEntity` that better
  represent derived power measures on aggregate measurements
- Added new primitive conversion functions for floats and longs

### Changed

- Changed types of numeric properties in `Ozds.Data` to more precise ones
  (`decimal(19, 4)` for monetary values, `bigint` for cumulative measurement
  values, `float` for instantaneous measurement values)

## Testing

Modified calculations tests. Manually tested measurement correctness by running the application with fake measurement pushes. Manually inspected the database and `current.sql` and `current-hypertables.sql` for anomalies.

## Documentation

None added.