### PR TITLE
1.2.0 :partying_face: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0]
+
 ### Added
 
 - Initial analysis basis fetching in
@@ -202,6 +204,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - init
 
+[1.2.0]: https://github.com/altibiz/ozds/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/altibiz/ozds/compare/1.0.1...1.1.1
 [1.0.1]: https://github.com/altibiz/ozds/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/altibiz/ozds/releases/tag/1.0.0

--- a/src/Ozds.Server/Program.cs
+++ b/src/Ozds.Server/Program.cs
@@ -12,10 +12,8 @@ using Ozds.Server.Extensions;
 using Ozds.Users.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.WebHost.ConfigureKestrel(serverOptions =>
-{
-  serverOptions.Limits.MinRequestBodyDataRate = null;
-});
+builder.WebHost.ConfigureKestrel(
+  serverOptions => { serverOptions.Limits.MinRequestBodyDataRate = null; });
 
 if (builder.Environment.IsDevelopment())
 {


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Added

- Initial analysis basis fetching in
  `Ozds.Data.Queries.MeasurementLocationQueries`
- `aggregate` buffer behavior that skips flushing measurements for faster
  seeding times
- 30 new meters and measurements locations in the dev database
- VS Code launches and tasks for new migration CLI and fake insert command
- Fake insert command that inserts fake data directly into the database
  circumventing the API that the old push and seed commands use
- Cloners in Ozds.Fake that clone generated data for a specific meter model for
  requested meters
- Meter identification class specifically for the Ozds.Fake project
- Optimize loaders in Ozds.Fake for batch generation
- Ozds.Fake workers that can be shared between services
- Ozds.Migration CLI tool that will be used from now on to migrate the database
  manually to latest and to generate database function migrations
- Conversion and aggregation functions that optimize for batch processing using
  enumerables
- MigrationMutations and MigrationQueries to all projects that need migrations
  and added a MigrationService in Ozds.Business that prevents the site from
  running if any migrations are pending
- JsonParameter that allows for passing JSON objects to database functions via
  Dapper
- functions in ExpressionExtensions in Ozds.Data that drive the new database
  function builders
- migration that stores the new function-based measurement mutations in the
  database
- Ozds.Data.Procedures namespace that is responsible for building and compiling
  SQL for creating, deleting and calling function-based queries/mutations
- migration justfile command that uses the new Ozds.Migration CLI tool
- GetStartOfMonthLastYear function and tests and apply where needed
- substituters to Raspberry PI nixos configuration
- initial `rzls` (Razor language server) for better devex
- invoice approval fields on network users and network user invoice states and
  their migrations
- add saga state machine states `Approved` and `Disapproved` for network user
  invoice state machine in `Ozds.Fake` and `Ozds.Messaging`
- `Approved` network user invoice state message `Ozds.Fake` and `Ozds.Messaging`
- `StatefulNetworkUserInvoiceModel` composite model that contains the invoice
  and its state
- boolean fields for edit and details components
- invoice creation number on network user page
- network user invoice state on network user invoice page
- measurement location options for chart
- tooltips for chart options
- `Ozds.Translation` project that handles translating the whole solution via
  regex matches and reflection
- ollama docker container, dev shell app, and `isready.nu` script
- `Ozds.Assets` project that handles all assets currently used for localization
  and fetching embedded document assets like fonts and images
- Translated the whole solution into the new `en.xml` and `hr.xml` files in
  hopes that XML is easier to edit than JSON for translations
- justfile commands for translating the whole solution and for running a single
  instance of the `Ozds.Translation` project

### Changed

- Progressively fetch analysis bases in `AnalysisStateProvider`
- Financial queries so they mirror the interface of measurement queries
- Refactored Ozds.Fake namespaces that implement the Visitor pattern to better
  align with the rest of the project
- Refactored Ozds.Fake Program.cs and IServiceCollection extensions to inject as
  many Ozds services as possible for future-proofing and for current use cases
- Measurement generation methods in Ozds.Fake that optimize for batch generation
  using IAsyncEnumerable
- Refactored Ozds.Fake services to optimize for batch generation
- Refactored MeasurementMutations to use database functions
- Refactored all IServiceCollectionExtensions to only depend on
  IServiceCollection and use the proper configure options pattern for
  configuration
- Move NetworkUserInvoiceIssuer to Ozds.Business.Mutations to keep the
  Ozds.Business.Finance namespace pure and contained only to financial
  calculations
- Adjusted the Ozds.Business.Mutations.MeasurementMutations to the new
  Ozds.Data.Mutations.MeasurementMutations
- Move all DataDbContext stuff to the Ozds.Data.Context namespace as some of
  that stuff uses internal EF Core API
- Adjusted aggregate entity types to use the new Ozds.Data.Procedures.Builders
- Adjusted DapperCommand function to support new function-based measurement
  mutations
- Simplify Ozds.Business.Test and Ozds.Data.Test Startup.cs to use their own
  appsettings.json
- Fix bug in GetStartOfQuarterHour that accounts for Croatian clock rewind on
  27.10.
- Fix vpn connection function
- Flake update
- Fix location selection sending users to location details
- Fix `LocationStateProvider` not fetching locations after exit from location
- Use the new [`deps.json`] instead of the obsolete `deps.nix`
- Fix playwright browser dependency
- Fix scripts requiring timescale docker id/name by fetching the id/name from
  docker
- calculation financial remark to nullable as it should have been
- extract messaging part away from the `NetworkUserInvoiceIssuer` into a reactor
- send invoice email only when it was approved
- Chart control layout
- the way chart fetches data by changing parameters
- starting chart settings
- `Ozds.Fake` service namespaces
- Use the new `Ozds.Assets` in `Ozds.Fake` and `Ozds.Migration`
- Extracted all localization into the new `Ozds.Assets` because it was actually
  needed in three different projects - `Ozds.Business`, `Ozds.Document` and
  `Ozds.Client`
- Adjusted affected projects by localization to use the new localization from
  `Ozds.Assets`
- Adjusted model component fields to use the new localization
- Adjusted calculation item name translation in `Ozds.Document` to use
  hard-coded acronyms where appropriate
- Added the new `Ozds.Assets` into DI container
- Slight `CONTRIBUTING.md` changes
- `format-and-deps` workflow to `generate` and use `just translate` to
  automatically translate the solution on each PR

### Removed

- Leftover analysis queries and tests
- Deleted all IApplicationBuilderExtensions as they were empty because I thought
  we would use them at some point