### PR TITLE
Disposable component base and minor issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - scope state provider in `Ozds.Client` to manage lifetime of scoped services
   per client session
+- disposable base component in `Ozds.Client` for root components
 
 ### Changed
 
 - get scoped services from cascading parameter rather than managing service
   scope inside `OzdsComponentBase`
 - use `-dev` suffix for service bus endpoints in dev
+- use `DisposableBaseComponent` as base for root components
+- recursively unwrap conversions for member expression translations
 
 ## [1.2.1]
 

--- a/src/Ozds.Business/Math/PhasicMeasure.cs
+++ b/src/Ozds.Business/Math/PhasicMeasure.cs
@@ -67,19 +67,19 @@ public record class InstantaneousPhaseMeasure<T>(
   {
     return other is InstantaneousPhaseMeasure<T> otherInstantaneous
       ? new InstantaneousPhaseMeasure<T>(
-          selector(Avg, otherInstantaneous.Avg),
-          selector(Min, otherInstantaneous.Min),
-          MinTimestamp,
-          selector(Max, otherInstantaneous.Max),
-          MaxTimestamp
-        )
+        selector(Avg, otherInstantaneous.Avg),
+        selector(Min, otherInstantaneous.Min),
+        MinTimestamp,
+        selector(Max, otherInstantaneous.Max),
+        MaxTimestamp
+      )
       : new InstantaneousPhaseMeasure<T>(
-          selector(Avg, other),
-          selector(Min, other),
-          MinTimestamp,
-          selector(Max, other),
-          MaxTimestamp
-        );
+        selector(Avg, other),
+        selector(Min, other),
+        MinTimestamp,
+        selector(Max, other),
+        MaxTimestamp
+      );
   }
 }
 
@@ -105,13 +105,13 @@ public record class CumulativePhasicMeasure<T>(
   {
     return other is CumulativePhasicMeasure<T> otherCumulative
       ? new CumulativePhasicMeasure<T>(
-          selector(Min, otherCumulative.Min),
-          selector(Max, otherCumulative.Max)
-        )
+        selector(Min, otherCumulative.Min),
+        selector(Max, otherCumulative.Max)
+      )
       : new CumulativePhasicMeasure<T>(
-          selector(Min, other),
-          selector(Max, other)
-        );
+        selector(Min, other),
+        selector(Max, other)
+      );
   }
 }
 

--- a/src/Ozds.Client/Components/Base/DisposableComponentBase.cs
+++ b/src/Ozds.Client/Components/Base/DisposableComponentBase.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Ozds.Client.Components.Base;
+
+public class DisposableComponentBase : ComponentBase, IDisposable
+{
+  private static readonly CancellationTokenSource _cancelledTokenSource =
+    CreateCancelledTokenSource();
+
+  private CancellationTokenSource? cancellationTokenSource = new();
+
+  protected CancellationToken CancellationToken =>
+    cancellationTokenSource?.Token ?? _cancelledTokenSource.Token;
+
+  protected bool IsDisposed { get; private set; }
+
+  private static CancellationTokenSource CreateCancelledTokenSource()
+  {
+    var cancellationTokenSource = new CancellationTokenSource();
+    cancellationTokenSource.Cancel();
+    return cancellationTokenSource;
+  }
+
+  public void Dispose()
+  {
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+
+  protected virtual void Dispose(bool disposing)
+  {
+    if (IsDisposed)
+    {
+      return;
+    }
+
+    if (disposing)
+    {
+#pragma warning disable S1066 // Mergeable "if" statements should be combined
+      if (cancellationTokenSource is not null)
+#pragma warning restore S1066 // Mergeable "if" statements should be combined
+      {
+        cancellationTokenSource.Cancel();
+        cancellationTokenSource.Dispose();
+        cancellationTokenSource = null;
+      }
+    }
+
+    IsDisposed = true;
+  }
+}

--- a/src/Ozds.Client/Components/Base/DisposableComponentBase.cs
+++ b/src/Ozds.Client/Components/Base/DisposableComponentBase.cs
@@ -9,22 +9,27 @@ public class DisposableComponentBase : ComponentBase, IDisposable
 
   private CancellationTokenSource? cancellationTokenSource = new();
 
-  protected CancellationToken CancellationToken =>
-    cancellationTokenSource?.Token ?? _cancelledTokenSource.Token;
+  protected CancellationToken CancellationToken
+  {
+    get
+    {
+      return cancellationTokenSource?.Token ?? _cancelledTokenSource.Token;
+    }
+  }
 
   protected bool IsDisposed { get; private set; }
+
+  public void Dispose()
+  {
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
 
   private static CancellationTokenSource CreateCancelledTokenSource()
   {
     var cancellationTokenSource = new CancellationTokenSource();
     cancellationTokenSource.Cancel();
     return cancellationTokenSource;
-  }
-
-  public void Dispose()
-  {
-    Dispose(true);
-    GC.SuppressFinalize(this);
   }
 
   protected virtual void Dispose(bool disposing)

--- a/src/Ozds.Client/Components/Base/OzdsComponentBase.cs
+++ b/src/Ozds.Client/Components/Base/OzdsComponentBase.cs
@@ -35,18 +35,38 @@ public abstract class OzdsComponentBase : DisposableComponentBase
   [Inject]
   private TemplateBinderFactory TemplateBinderFactory { get; set; } = default!;
 
-  protected string Href => new Uri(NavigationManager.Uri).AbsolutePath;
+  protected string Href
+  {
+    get { return new Uri(NavigationManager.Uri).AbsolutePath; }
+  }
 
-  protected string LoginHref =>
-    $"/login?returnUrl={Uri.EscapeDataString(Href)}";
+  protected string LoginHref
+  {
+    get { return $"/login?returnUrl={Uri.EscapeDataString(Href)}"; }
+  }
 
-  protected string LogoutHref =>
-    $"/users/logoff?returnUrl=/login?returnUrl={Uri.EscapeDataString(Href)}";
+  protected string LogoutHref
+  {
+    get
+    {
+      return
+        $"/users/logoff?returnUrl=/login?returnUrl={Uri.EscapeDataString(Href)}";
+    }
+  }
 
-  protected string IndexHref => BasedHref("/");
+  protected string IndexHref
+  {
+    get { return BasedHref("/"); }
+  }
 
-  protected IServiceProvider ScopedServices => ScopeState?.ScopedServices ??
-    throw new InvalidOperationException($"{this} got disposed");
+  protected IServiceProvider ScopedServices
+  {
+    get
+    {
+      return ScopeState?.ScopedServices ??
+        throw new InvalidOperationException($"{this} got disposed");
+    }
+  }
 
   protected CultureInfo CroatianCulture
   {

--- a/src/Ozds.Client/Components/Base/OzdsComponentBase.cs
+++ b/src/Ozds.Client/Components/Base/OzdsComponentBase.cs
@@ -11,20 +11,17 @@ using Ozds.Client.State;
 
 namespace Ozds.Client.Components.Base;
 
-public abstract class OzdsComponentBase : ComponentBase, IDisposable
+// NOTE: to be used inside ErrorBoundary, ScopeStateProvider
+// and CultureStateProvider
+public abstract class OzdsComponentBase : DisposableComponentBase
 {
   private static readonly JsonSerializerOptions JsonSerializerOptions = new()
   {
     WriteIndented = true
   };
 
-  private static readonly CancellationTokenSource _cancelledTokenSource =
-    CreateCancelledTokenSource();
-
-  private CancellationTokenSource? cancellationTokenSource = new();
-
   [CascadingParameter]
-  private CultureState? CultureState { get; set; } = default!;
+  private CultureState CultureState { get; set; } = default!;
 
   [CascadingParameter]
   private ScopeState ScopeState { get; set; } = default!;
@@ -48,12 +45,8 @@ public abstract class OzdsComponentBase : ComponentBase, IDisposable
 
   protected string IndexHref => BasedHref("/");
 
-  protected IServiceProvider ScopedServices => ScopeState.ScopedServices;
-
-  protected CancellationToken CancellationToken =>
-    cancellationTokenSource?.Token ?? _cancelledTokenSource.Token;
-
-  protected bool IsDisposed { get; private set; }
+  protected IServiceProvider ScopedServices => ScopeState?.ScopedServices ??
+    throw new InvalidOperationException($"{this} got disposed");
 
   protected CultureInfo CroatianCulture
   {
@@ -253,7 +246,7 @@ public abstract class OzdsComponentBase : ComponentBase, IDisposable
 
   protected CultureInfo GetCulture()
   {
-    return CultureState?.Culture ?? CroatianCulture;
+    return CultureState.Culture;
   }
 
   protected Task SetCulture(CultureInfo culture)
@@ -264,40 +257,5 @@ public abstract class OzdsComponentBase : ComponentBase, IDisposable
     }
 
     return Task.CompletedTask;
-  }
-
-  private static CancellationTokenSource CreateCancelledTokenSource()
-  {
-    var cancellationTokenSource = new CancellationTokenSource();
-    cancellationTokenSource.Cancel();
-    return cancellationTokenSource;
-  }
-
-  public void Dispose()
-  {
-    Dispose(true);
-    GC.SuppressFinalize(this);
-  }
-
-  protected virtual void Dispose(bool disposing)
-  {
-    if (IsDisposed)
-    {
-      return;
-    }
-
-    if (disposing)
-    {
-#pragma warning disable S1066 // Mergeable "if" statements should be combined
-      if (cancellationTokenSource is not null)
-#pragma warning restore S1066 // Mergeable "if" statements should be combined
-      {
-        cancellationTokenSource.Cancel();
-        cancellationTokenSource.Dispose();
-        cancellationTokenSource = null;
-      }
-    }
-
-    IsDisposed = true;
   }
 }

--- a/src/Ozds.Client/Components/Providers/CultureStateProvider.cs
+++ b/src/Ozds.Client/Components/Providers/CultureStateProvider.cs
@@ -6,7 +6,8 @@ using Ozds.Client.State;
 
 namespace Ozds.Client.Components.Providers;
 
-public partial class CultureStateProvider : OzdsComponentBase
+// NOTE: rendered at root so keep dependencies minimal
+public partial class CultureStateProvider : DisposableComponentBase
 {
   private const string CultureKey = "culture";
 

--- a/src/Ozds.Client/Components/Providers/CultureStateProvider.razor
+++ b/src/Ozds.Client/Components/Providers/CultureStateProvider.razor
@@ -1,6 +1,7 @@
 @namespace Ozds.Client.Components.Providers
+@using Ozds.Client.Components.Base
 
-@inherits Ozds.Client.Components.Base.OzdsComponentBase
+@inherits DisposableComponentBase
 
 @if (_state is null)
 {

--- a/src/Ozds.Client/Components/Providers/CultureStateProvider.razor
+++ b/src/Ozds.Client/Components/Providers/CultureStateProvider.razor
@@ -1,7 +1,6 @@
 @namespace Ozds.Client.Components.Providers
-@using Ozds.Client.Components.Base
 
-@inherits DisposableComponentBase
+@inherits Ozds.Client.Components.Base.DisposableComponentBase
 
 @if (_state is null)
 {

--- a/src/Ozds.Client/Components/Providers/ScopeStateProvider.cs
+++ b/src/Ozds.Client/Components/Providers/ScopeStateProvider.cs
@@ -7,22 +7,22 @@ namespace Ozds.Client.Components.Providers;
 // NOTE: rendered at root so keep dependencies minimal
 public partial class ScopeStateProvider : DisposableComponentBase
 {
+  private IServiceScope? _scope;
+
+  private ScopeState? _state;
+
   [Parameter]
   public RenderFragment ChildContent { get; set; } = default!;
 
   [Inject]
   private IServiceScopeFactory ScopeFactory { get; set; } = default!;
 
-  private IServiceScope? _scope;
-
-  private ScopeState? _state;
-
   protected override void OnParametersSet()
   {
     if (_scope is null)
     {
       _scope = ScopeFactory.CreateScope();
-      _state = new(_scope.ServiceProvider);
+      _state = new ScopeState(_scope.ServiceProvider);
     }
   }
 
@@ -36,7 +36,7 @@ public partial class ScopeStateProvider : DisposableComponentBase
     if (disposing)
     {
 #pragma warning disable S1066 // Mergeable "if" statements should be combined
-      if (_scope is { })
+      if (_scope is not null)
 #pragma warning restore S1066 // Mergeable "if" statements should be combined
       {
         _state = null;

--- a/src/Ozds.Client/Components/Providers/ScopeStateProvider.cs
+++ b/src/Ozds.Client/Components/Providers/ScopeStateProvider.cs
@@ -4,7 +4,8 @@ using Ozds.Client.State;
 
 namespace Ozds.Client.Components.Providers;
 
-public partial class ScopeStateProvider : OzdsComponentBase
+// NOTE: rendered at root so keep dependencies minimal
+public partial class ScopeStateProvider : DisposableComponentBase
 {
   [Parameter]
   public RenderFragment ChildContent { get; set; } = default!;

--- a/src/Ozds.Client/Components/Providers/ScopeStateProvider.razor
+++ b/src/Ozds.Client/Components/Providers/ScopeStateProvider.razor
@@ -1,6 +1,7 @@
 @namespace Ozds.Client.Components.Providers
+@using Ozds.Client.Components.Base
 
-@inherits Ozds.Client.Components.Base.OzdsComponentBase
+@inherits DisposableComponentBase
 
 @if (_state is null)
 {

--- a/src/Ozds.Client/Components/Providers/ScopeStateProvider.razor
+++ b/src/Ozds.Client/Components/Providers/ScopeStateProvider.razor
@@ -1,7 +1,6 @@
 @namespace Ozds.Client.Components.Providers
-@using Ozds.Client.Components.Base
 
-@inherits DisposableComponentBase
+@inherits Ozds.Client.Components.Base.DisposableComponentBase
 
 @if (_state is null)
 {

--- a/src/Ozds.Client/Components/Streaming/ErrorBoundary.cs
+++ b/src/Ozds.Client/Components/Streaming/ErrorBoundary.cs
@@ -5,7 +5,8 @@ using ErrorEventArgs = Ozds.Business.Observers.EventArgs.ErrorEventArgs;
 
 namespace Ozds.Client.Components.Streaming;
 
-public partial class ErrorBoundary : OzdsComponentBase
+// NOTE: rendered at root so keep dependencies minimal
+public partial class ErrorBoundary : DisposableComponentBase
 {
   private InnerErrorBoundary? inner;
 

--- a/src/Ozds.Client/Components/Streaming/ErrorBoundary.razor
+++ b/src/Ozds.Client/Components/Streaming/ErrorBoundary.razor
@@ -1,5 +1,6 @@
 @namespace Ozds.Client.Components.Streaming
-@inherits Ozds.Client.Components.Base.OzdsComponentBase
+@using Ozds.Client.Components.Base
+@inherits DisposableComponentBase
 
 <InnerErrorBoundary This="this" @ref="@inner">
   <ChildContent>
@@ -12,7 +13,7 @@
       </div>
       <div>
         <button @onclick="@OnRecover">
-          @Translate("Recover")
+          Recover
         </button>
       </div>
     </div>

--- a/src/Ozds.Client/Components/Streaming/ErrorBoundary.razor
+++ b/src/Ozds.Client/Components/Streaming/ErrorBoundary.razor
@@ -1,6 +1,5 @@
 @namespace Ozds.Client.Components.Streaming
-@using Ozds.Client.Components.Base
-@inherits DisposableComponentBase
+@inherits Ozds.Client.Components.Base.DisposableComponentBase
 
 <InnerErrorBoundary This="this" @ref="@inner">
   <ChildContent>

--- a/src/Ozds.Client/Extensions/ExpressionExtensions.cs
+++ b/src/Ozds.Client/Extensions/ExpressionExtensions.cs
@@ -23,24 +23,27 @@ public static class ExpressionExtensions
     return "";
   }
 
-  public static MemberExpression LabelExpression<TIn, TOut>(
-    this Expression<Func<TIn, TOut>> expression
+  public static MemberExpression LabelExpression(
+    this Expression expression
   )
   {
-    if (expression.Body is MemberExpression memberExpression)
+    var body = expression is LambdaExpression { Body: { } lambdaBody }
+      ? lambdaBody
+      : expression;
+
+    if (body is MemberExpression memberExpression)
     {
       return memberExpression;
     }
 
-    if (expression.Body is UnaryExpression unaryExpression
-      && unaryExpression.NodeType == ExpressionType.Convert
-      && unaryExpression.Operand is MemberExpression innerMemberExpression)
+    if (body is UnaryExpression unaryExpression
+      && unaryExpression.NodeType == ExpressionType.Convert)
     {
-      return innerMemberExpression;
+      return LabelExpression(unaryExpression.Operand);
     }
 
     throw new InvalidOperationException(
-      "Expression is not a member expression.");
+      $"Expression {expression} is not a member expression.");
   }
 
   public static Expression<Func<TIn, TOut>> Prefix<TIn, TMid, TOut>(

--- a/src/Ozds.Data/Queries/MeasurementQueries.cs
+++ b/src/Ozds.Data/Queries/MeasurementQueries.cs
@@ -360,7 +360,7 @@ public class MeasurementQueries(
         .ValueAsync(cancellationToken);
       // NOTE: this is from DeferredLastOrDefault but because the nullability
       // gets type-erased we have to check regardless
-      if (value is { })
+      if (value is not null)
       {
         items.Add(value);
       }


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #182 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

It was first and error within the `ErrorBoundary` that got fixed with using the new disposable component base as its base and then i solved the actual error on this page and it was because the label expression translation thing wasn't unwrapping conversions enough.

## Description

### Added

- disposable base component in `Ozds.Client` for root components

### Changed

- use `DisposableBaseComponent` as base for root components
- recursively unwrap conversions for member expression translations

## Testing

Manual.

## Documentation

None.
