### PR TITLE
fixed unintended reset of the selected measurement points or meters on component parameters change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## Unreleased - 2025-01-22
+
+### Changed
+
+- fixed unintended reset of the selected measurement points or meters on each
+  property change (for now it's local fix but it could be done so that the state
+  and params of chart control persist after reloading the page)
+
+## Unreleased - 2025-01-19
 
 ### Changed
 

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -14,9 +14,8 @@ namespace Ozds.Client.Components.Charts;
 
 public partial class MeasurementChartControls : OzdsComponentBase
 {
-  private MeasurementChartParameters _parameters = new();
-
   private bool _initParamsSet = false;
+  private MeasurementChartParameters _parameters = new();
 
   private MudSelect<string> _select = default!;
 
@@ -88,8 +87,8 @@ public partial class MeasurementChartControls : OzdsComponentBase
   protected override void OnParametersSet()
   {
     if (_parameters.MeasurementLocations.Count == 0
-        && _parameters.Meters.Count == 0
-        && _initParamsSet)
+      && _parameters.Meters.Count == 0
+      && _initParamsSet)
     {
       return;
     }

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -16,6 +16,8 @@ public partial class MeasurementChartControls : OzdsComponentBase
 {
   private MeasurementChartParameters _parameters = new();
 
+  private bool _initParamsSet = false;
+
   private MudSelect<string> _select = default!;
 
   [Parameter]
@@ -85,20 +87,44 @@ public partial class MeasurementChartControls : OzdsComponentBase
 
   protected override void OnParametersSet()
   {
+    if (_parameters.MeasurementLocations.Count == 0
+        && _parameters.Meters.Count == 0
+        && _initParamsSet)
+    {
+      return;
+    }
+
     if (MeasurementLocations.Count == 1)
     {
       _parameters.MeasurementLocations = MeasurementLocations.ToHashSet();
+      _initParamsSet = true;
       return;
     }
 
     if (Meters.Count == 1)
     {
       _parameters.Meters = Meters.ToHashSet();
+      _initParamsSet = true;
+      return;
+    }
+
+    if (_parameters.MeasurementLocations.Count > 0)
+    {
+      _parameters.MeasurementLocations
+        .IntersectWith(MeasurementLocations);
+      return;
+    }
+
+    if (_parameters.Meters.Count > 0)
+    {
+      _parameters.Meters
+        .IntersectWith(Meters);
       return;
     }
 
     if (MeasurementLocations.Count > 0)
     {
+      _initParamsSet = true;
       _parameters.MeasurementLocations = MeasurementLocations
         .Take(1)
         .ToHashSet();
@@ -107,6 +133,8 @@ public partial class MeasurementChartControls : OzdsComponentBase
 
     if (Meters.Count > 0)
     {
+      _initParamsSet = true;
+
       _parameters.Meters = Meters
         .Take(1)
         .ToHashSet();


### PR DESCRIPTION

# Task

@HrvojeJuric

  Fixes #245 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Added new boolean variable which tracks if the initial select has been set. This variable is then used to notify to not reset selected parameters if user decides to not select anything yet. 

If the user selected one or more options _parameter is then intersected with changed selected parameters, and this guarantees that the data in the selected meters or locations is consistent with updated parameters. 

## Testing

You can try changing the browser window size, toggling night and light mode or any kind of parent parameter change which could trigger OnParameterSet() in MeasurementChartControls. 
