### PR TITLE
256 make tables searchable by more columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased - 2026-01-28
-
-### Changed
-
-- fix mapped tables did not use toFilter for searching leading to using non
-  mapped records without titles
-- add every type of column can now register it's value mapper
-- added parameter 'searchable' to define columns that can be searched on table
-
-## Unreleased - 2026-01-19
+## Unreleased
 
 ### Removed
 
@@ -28,11 +19,15 @@ and adheres to [Semantic Versioning](https://semver.org/).
   contain methods `Round` which round and return double and decimal respectfully
 - add sentinel injector which is used to overload specific values of invoice
   model or calculator to fail tests on use of wrong rounding method
+- add every type of column can now register it's value mapper
+- added parameter 'searchable' to define columns that can be searched on table
 
 ### Changed
 
 - change all calculators and calculator tests for business now use rounding type
   `MidpointRounding.AwayFromZero` defined in `PrimitiveRoundingExtensions`
+- fix mapped tables did not use toFilter for searching leading to using non
+  mapped records without titles
 
 ## [1.8.0] - 2025-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## Unreleased - 2026-01-28
+
+### Changed
+
+- fix mapped tables did not use toFilter for searching leading to using non
+  mapped records without titles
+- add every type of column can now register it's value mapper
+- added parameter 'searchable' to define columns that can be searched on table
+
+## Unreleased - 2026-01-19
 
 ### Removed
 

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -6819,7 +6819,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 265 column 33
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 10
         From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
@@ -8594,8 +8594,8 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 129 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 47
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 218 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 24
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 26
       </Metadata>
       <Value>
         Delete
@@ -10281,7 +10281,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 138 column 18
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 241 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 26
       </Metadata>
       <Value>
         Forget
@@ -20245,7 +20245,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 120 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 229 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 232 column 26
       </Metadata>
       <Value>
         Restore

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -6819,7 +6819,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 10
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 33
         From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
@@ -8594,8 +8594,8 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 129 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 24
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 26
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 47
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 49
       </Metadata>
       <Value>
         Delete
@@ -10281,7 +10281,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 138 column 18
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 26
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 49
       </Metadata>
       <Value>
         Forget
@@ -20245,7 +20245,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 120 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 232 column 26
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 232 column 49
       </Metadata>
       <Value>
         Restore
@@ -20507,7 +20507,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 62 column 48
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 170 column 52
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 170 column 29
       </Metadata>
       <Value>
         Search

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -8593,6 +8593,8 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 129 column 20
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 24
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 26
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 47
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 218 column 49
       </Metadata>
@@ -10280,6 +10282,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 138 column 18
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 26
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 241 column 49
       </Metadata>
       <Value>

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -6818,7 +6818,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 265 column 33
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 33
         From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
@@ -8593,10 +8593,8 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 129 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 24
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 26
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 47
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 218 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 49
       </Metadata>
       <Value>
         Arhiviraj
@@ -10282,8 +10280,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 138 column 18
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 26
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 241 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 49
       </Metadata>
       <Value>
         Izbriši
@@ -20292,7 +20289,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 120 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 229 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 232 column 49
       </Metadata>
       <Value>
         Obnovi
@@ -20554,7 +20551,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 62 column 48
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 170 column 52
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 170 column 29
       </Metadata>
       <Value>
         Pretraži

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.cs
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.cs
@@ -1,8 +1,23 @@
+using System.Collections.Immutable;
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.EntityFrameworkCore.Query;
+
 namespace Ozds.Client.Components.Models.Base;
 
 public abstract partial class OzdsColumnsComponentBase<TPrefix, TModel>
   : OzdsListModelComponentBase<TPrefix, TModel>
 {
+  private readonly Dictionary<Expression, Func<object, object?>> searchMappers =
+    new Dictionary<Expression, Func<object, object?>>(
+      ExpressionEqualityComparer.Instance
+    );
+
+  [Parameter]
+  public EventCallback<
+    IEnumerable<Func<object, object?>>
+  > SearchMappersChanged { get; set; }
+
   protected virtual int NestingLevel
   {
     get { return 1; }
@@ -11,5 +26,30 @@ public abstract partial class OzdsColumnsComponentBase<TPrefix, TModel>
   public override ModelComponentKind ComponentKind
   {
     get { return ModelComponentKind.Columns; }
+  }
+
+  // NOTE: this adds slight overhead but it returns thread safe snapshot of the mappers
+  //       instead of directly returning intern dict values
+  public IEnumerable<Func<object, object?>> GetSearchMappers()
+  {
+    return searchMappers.Values.ToImmutableList();
+  }
+
+  protected void RegisterSearchMapper<T>(
+    Expression expr,
+    Func<TModel, T> mapperFunc
+  )
+  {
+    searchMappers.TryAdd(expr, model => mapperFunc((TModel)model));
+  }
+
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    await base.OnAfterRenderAsync(firstRender);
+
+    if (firstRender && SearchMappersChanged.HasDelegate)
+    {
+      await SearchMappersChanged.InvokeAsync(GetSearchMappers());
+    }
   }
 }

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -14,8 +14,13 @@
 
 @code {
 
-  protected RenderFragment Column(Expression<Func<TModel, string?>> next)
+  protected RenderFragment Column(Expression<Func<TModel, string?>> next, bool searchable = false)
   {
+    if (searchable)
+    {
+      RegisterSearchMapper(next, next.Compile());
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -26,9 +31,20 @@
          Property="@Wrap(next)"/>);
   }
 
-  protected RenderFragment Column(Expression<Func<TModel, Enum?>> next)
+  protected RenderFragment Column(Expression<Func<TModel, Enum?>> next, bool searchable = false)
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        x =>
+          nextFunc(x) is { } val
+            ? Translate(val.ToString()!)
+            : null
+      );
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -48,9 +64,24 @@
       </PropertyColumn>);
   }
 
-  protected RenderFragment Column(Expression<Func<TModel, decimal?>> next, int decimalPlaces = 2)
+  protected RenderFragment Column(
+    Expression<Func<TModel, decimal?>> next,
+    int decimalPlaces = 2,
+    bool searchable = false
+  )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        x =>
+          nextFunc(x) is decimal d
+            ? NumericString(d, decimalPlaces)
+            : null
+      );
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -71,10 +102,37 @@
   }
 
   protected RenderFragment Column<T>(
-    Expression<Func<TModel, IEnumerable<T>?>> next
+    Expression<Func<TModel, IEnumerable<T>?>> next,
+    bool searchable = false
   )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        model =>
+        {
+          var value = nextFunc(model);
+          if (value is null)
+          {
+            return null;
+          }
+
+          return string.Join(
+            ", ",
+            value.Select(
+              v =>
+                v is null
+                  ? ""
+                  : v is Enum e
+                    ? Translate(e.ToString()!)
+                    : v.ToString()
+            )
+          );
+        });
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -106,10 +164,16 @@
   }
 
   protected RenderFragment Column(
-    Expression<Func<TModel, DateTimeOffset?>> next
+    Expression<Func<TModel, DateTimeOffset?>> next,
+    bool searchable = false
   )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(next, x => DateTimeString(nextFunc(x)));
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -130,10 +194,28 @@
   }
 
   protected RenderFragment EnumerableColumn<T>(
-    Expression<Func<TModel, T?>> next
+    Expression<Func<TModel, T?>> next,
+    bool searchable = false
   )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        model =>
+        {
+          if (nextFunc(model) is IEnumerable enumerable)
+          {
+            return enumerable != null
+              ? string.Join(", ", enumerable)
+              : null;
+          }
+
+          return null;
+        });
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -154,10 +236,30 @@
   }
 
   protected RenderFragment EnumerableEnumColumn<T>(
-    Expression<Func<TModel, T?>> next
+    Expression<Func<TModel, T?>> next,
+    bool searchable = false
   )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        model =>
+        {
+          if (nextFunc(model) is IEnumerable<Enum> enumerable)
+          {
+            return string.Join(
+              ", ",
+              enumerable
+                .Select(e => Translate(e.ToString()))
+            );
+          }
+
+          return null;
+        });
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -179,8 +281,16 @@
       </PropertyColumn>);
   }
 
-  protected RenderFragment TextColumn<T>(Expression<Func<TModel, T?>> next)
+  protected RenderFragment TextColumn<T>(
+    Expression<Func<TModel, T?>> next,
+    bool searchable = false
+  )
   {
+    if (searchable)
+    {
+      RegisterSearchMapper(next, next.Compile());
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -191,9 +301,23 @@
          Property="@Wrap(next)"/>);
   }
 
-  protected RenderFragment EnumColumn<T>(Expression<Func<TModel, T?>> next)
+  protected RenderFragment EnumColumn<T>(
+    Expression<Func<TModel, T?>> next,
+    bool searchable = false
+  )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        x =>
+          nextFunc(x) is { } val
+            ? Translate(val.ToString()!)
+            : null
+      );
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -214,9 +338,23 @@
       </PropertyColumn>);
   }
 
-  protected RenderFragment DateColumn<T>(Expression<Func<TModel, T?>> next)
+  protected RenderFragment DateColumn<T>(
+    Expression<Func<TModel, T?>> next,
+    bool searchable = false
+  )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        x =>
+          nextFunc(x) is DateTimeOffset d
+            ? DateString(d)
+            : null
+      );
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -236,9 +374,23 @@
       </PropertyColumn>);
   }
 
-  protected RenderFragment DateTimeColumn<T>(Expression<Func<TModel, T?>> next)
+  protected RenderFragment DateTimeColumn<T>(
+    Expression<Func<TModel, T?>> next,
+    bool searchable = false
+  )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        x =>
+          nextFunc(x) is DateTimeOffset d
+            ? DateTimeString(d)
+            : null
+      );
+    }
+
     return Nest(
       @<PropertyColumn
          Filterable="false"
@@ -259,10 +411,22 @@
   }
 
   protected RenderFragment LinkColumn(
-    Expression<Func<TModel, IIdentifiable?>> next
+    Expression<Func<TModel, IIdentifiable?>> next,
+    bool searchable = false
   )
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        x =>
+          nextFunc(x) is { } model
+            ? model.Title
+            : null
+      );
+    }
+
     return Nest(
       @<TemplateColumn
          T="TPrefix"
@@ -279,11 +443,17 @@
   }
 
   protected RenderFragment LinkColumn<T>(
-    Expression<Func<TModel, string?>> next
+    Expression<Func<TModel, string?>> next,
+    bool searchable = false
   )
     where T : IIdentifiable
   {
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(next, nextFunc);
+    }
+
     return Nest(
       @<TemplateColumn
          T="TPrefix"
@@ -304,11 +474,29 @@
 
   protected RenderFragment PolymorphicLinkColumn(
     Expression<Func<TModel, Type?>> type,
-    Expression<Func<TModel, string?>> next
+    Expression<Func<TModel, string?>> next,
+    bool searchable = false
   )
   {
     var typeFunc = type.Compile();
     var nextFunc = next.Compile();
+    if (searchable)
+    {
+      RegisterSearchMapper(
+        next,
+        model =>
+        {
+          var modelType = typeFunc(model);
+          var id = nextFunc(model);
+          if (modelType is null || id is null)
+          {
+            return null;
+          }
+
+          return $"{Translate(modelType.Name)} {id}";
+        });
+    }
+
     return Nest(
       @<TemplateColumn
          T="TPrefix"

--- a/src/Ozds.Client/Components/Models/Columns.cs
+++ b/src/Ozds.Client/Components/Models/Columns.cs
@@ -1,11 +1,24 @@
+using Microsoft.AspNetCore.Components;
 using Ozds.Client.Components.Models.Base;
 
 namespace Ozds.Client.Components.Models;
 
 public class Columns<TPrefix> : ListModelComponent<TPrefix, TPrefix>
 {
+  [Parameter]
+  public EventCallback<
+    IEnumerable<Func<object, object?>>
+  > SearchMappersChanged { get; set; }
+
   protected override ModelComponentKind ComponentKind
   {
     get { return ModelComponentKind.Columns; }
+  }
+
+  protected override Dictionary<string, object> CreateParameters()
+  {
+    var parameters = base.CreateParameters();
+    parameters[nameof(SearchMappersChanged)] = SearchMappersChanged;
+    return parameters;
   }
 }

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
@@ -4,11 +4,11 @@
 @typeparam TModel where TModel : Ozds.Business.Analysis.MeasurementLocationAnalysis
 @inherits Ozds.Client.Components.Models.Base.OzdsColumnsComponentBase<TPrefix, TModel>
 
-@LinkColumn(x => x.NetworkUser)
+@LinkColumn(x => x.NetworkUser, true)
 
-@LinkColumn(x => x.Meter)
+@LinkColumn(x => x.Meter, true)
 
-@LinkColumn(x => x.MeasurementLocation)
+@LinkColumn(x => x.MeasurementLocation, true)
 
 @Column(x => x.Analysis.LastMonthConsumption.ActiveEnergy_kWh)
 

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
@@ -4,9 +4,9 @@
 @typeparam TModel where TModel : Ozds.Business.Analysis.MeterAnalysis
 @inherits Ozds.Client.Components.Models.Base.OzdsColumnsComponentBase<TPrefix, TModel>
 
-@LinkColumn(x => x.NetworkUser)
+@LinkColumn(x => x.NetworkUser, true)
 
-@LinkColumn(x => x.Meter)
+@LinkColumn(x => x.Meter, true)
 
 @Column(x => x.Analysis.LastMonthConsumption.ActiveEnergy_kWh)
 

--- a/src/Ozds.Client/Components/Streaming/MappedTable.razor
+++ b/src/Ozds.Client/Components/Streaming/MappedTable.razor
@@ -160,30 +160,33 @@
 
                                  <MudSpacer/>
 
-                                 @if (typeof(T).IsAssignableTo(typeof(IIdentifiable)) || typeof(T).IsAssignableTo(typeof(IAnalysis)))
-                                 {
-                                   <MudTextField
-                                     T="string"
-                                     Value="@searchString"
-                                     DebounceInterval="500"
-                                     OnDebounceIntervalElapsed="@OnDataGridSearch"
-                                     Placeholder="@Translate("Search")"
-                                     Adornment="Adornment.Start"
-                                     Immediate="true"
-                                     AdornmentIcon="@Icons.Material.Filled.Search"
-                                     IconSize="Size.Medium">
-                                   </MudTextField>
-                                 }
-                               </ToolBarContent>
-                               <Columns>
-                                 @if (Columns is null)
-                                 {
-                                   <Columns TPrefix="T" Models="@fetchedModel.Items"/>
-                                 }
-                                 else
-                                 {
-                                   @Columns(fetchedModel.Items)
-                                 }
+          @if (typeof(T).IsAssignableTo(typeof(IIdentifiable)) || typeof(T).IsAssignableTo(typeof(IAnalysis)))
+          {
+            <MudTextField
+              T="string"
+              Value="@searchString"
+              DebounceInterval="500"
+              OnDebounceIntervalElapsed="@OnDataGridSearch"
+              Placeholder="@Translate("Search")"
+              Adornment="Adornment.Start"
+              Immediate="true"
+              AdornmentIcon="@Icons.Material.Filled.Search"
+              IconSize="Size.Medium">
+            </MudTextField>
+          }
+        </ToolBarContent>
+        <Columns>
+          @if (Columns is null)
+          {
+            <Columns
+              TPrefix="T"
+              Models="@fetchedModel.Items"
+              SearchMappersChanged="OnColumnSearchMappersChanged"/>
+          }
+          else
+          {
+            @Columns(fetchedModel.Items)
+          }
 
                                  @if (Actions is { } actions
                                    || (WithMutations

--- a/src/Ozds.Client/Components/Streaming/Table.cs
+++ b/src/Ozds.Client/Components/Streaming/Table.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using Ozds.Business.Models.Abstractions;
@@ -18,6 +19,9 @@ public class Table<T> : MappedTable<T, T>
 public partial class MappedTable<T, TMapped> : OzdsComponentBase
   where T : notnull
 {
+  private IEnumerable<Func<object, object?>> _columnSearchMappers =
+    new List<Func<object, object?>>();
+
   private bool checkedDeleted;
 
   private MudDataGrid<T>? dataGrid;
@@ -136,6 +140,13 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
   {
     await FetchPaging();
     await FetchDataGrid();
+  }
+
+  private void OnColumnSearchMappersChanged(
+    IEnumerable<Func<object, object?>> selectors
+  )
+  {
+    _columnSearchMappers = selectors ?? Array.Empty<Func<object, object?>>();
   }
 
   protected override void OnParametersSet()
@@ -641,8 +652,24 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
       return false;
     }
 
+    if (_columnSearchMappers is { } searchFields)
+    {
+      foreach (var mapper in searchFields)
+      {
+        if (
+          mapper(model) is { } mappedModel
+          && mappedModel.ToString() is { } stringTransform
+          && stringTransform.Contains(searchString)
+        )
+        {
+          return true;
+        }
+      }
+    }
+
+    // fallback just for older way of identifying
     if (
-      model is IIdentifiable { Title: { } title }
+      toFilter is IIdentifiable { Title: { } title }
       && title.Contains(searchString)
     )
     {


### PR DESCRIPTION
# Task

@brunoAltinet 

Feature #256.

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Marko has requested that specific tables can be searched by multiple columns in one provided search filed. 

I've implemented so that you can now specify each column to be searchable, and if so, search mapper is assigned to that table that then takes the provided model and maps it to value present in column so user searches what the columns actually displays. 

Currently there is still present fallback feature that just takes and searches the .Title of mapped model so the original intended search behavior persists until I've mapped all of the searchable columns.

## Testing
Search tables titled:
"Measurement location analysis"
"Meter analysis"

on

/measurements

Now the tables should be searchable by all link columns.

