### PR TITLE
API fix - latest read by location id now returns all meters that have measurements saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## Unreleased - 2025-01-22
+
+### Changed
+
+- fixed unintended reset of the selected measurement points or meters on each
+  property change (for now it's local fix but it could be done so that the state
+  and params of chart control persist after reloading the page)
+
+## Unreleased - 2025-01-19
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased - 2026-01-30
+## Unreleased
 
 ### Changed
 
+- added new specific test for API returning latest measurements by meter
+- updated HtmlSanitizer to version 9.0.892
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements
-
-## Unreleased - 2026-01-19
-
-### Changed
-
 - fixed unintended reset of the selected measurement points or meters on each
   property change (for now it's local fix but it could be done so that the state
   and params of chart control persist after reloading the page)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased - 2025-01-22
+## Unreleased
 
 ### Changed
 
 - fixed unintended reset of the selected measurement points or meters on each
   property change (for now it's local fix but it could be done so that the state
   and params of chart control persist after reloading the page)
-
-## Unreleased - 2025-01-19
-
-### Changed
-
+- fix ReadLastByMeasurementLocationIds now returns latest measurement info for
+  all meters that have measurements
 - fix more decimal places on Column definitions for Regulatory catalogue
 - fix more decimal places on Column definitions for Network User catalogue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## Unreleased - 2026-01-30
+
+### Changed
+
+- fix ReadLastByMeasurementLocationIds now returns latest measurement info for
+  all meters that have measurements
+
+## Unreleased - 2026-01-19
 
 ### Changed
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
 
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.0.876" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
 
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
 

--- a/scripts/flake/ozds/deps.json
+++ b/scripts/flake/ozds/deps.json
@@ -136,8 +136,8 @@
   },
   {
     "pname": "HtmlSanitizer",
-    "version": "9.0.876",
-    "hash": "sha256-xQtrJafFAC9BfYNHvCRG4ukWDbnKoo1DZgIpIRGz/tw="
+    "version": "9.0.892",
+    "hash": "sha256-8ZVGH6RJ3QjgmwSGdVadS2pd3Tgq9IHXW7VHOX0slH0="
   },
   {
     "pname": "Humanizer.Core",
@@ -1078,11 +1078,6 @@
     "pname": "System.Collections.Immutable",
     "version": "6.0.0",
     "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
-  },
-  {
-    "pname": "System.Collections.Immutable",
-    "version": "9.0.1",
-    "hash": "sha256-23od93P7QHRzlL5NtKNUDujiYGeXRkkw7lXkyN4zOGY="
   },
   {
     "pname": "System.ComponentModel.Annotations",

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -14,6 +14,7 @@ namespace Ozds.Client.Components.Charts;
 
 public partial class MeasurementChartControls : OzdsComponentBase
 {
+  private bool _initParamsSet = false;
   private MeasurementChartParameters _parameters = new();
 
   private MudSelect<string> _select = default!;
@@ -85,20 +86,44 @@ public partial class MeasurementChartControls : OzdsComponentBase
 
   protected override void OnParametersSet()
   {
+    if (_parameters.MeasurementLocations.Count == 0
+      && _parameters.Meters.Count == 0
+      && _initParamsSet)
+    {
+      return;
+    }
+
     if (MeasurementLocations.Count == 1)
     {
       _parameters.MeasurementLocations = MeasurementLocations.ToHashSet();
+      _initParamsSet = true;
       return;
     }
 
     if (Meters.Count == 1)
     {
       _parameters.Meters = Meters.ToHashSet();
+      _initParamsSet = true;
+      return;
+    }
+
+    if (_parameters.MeasurementLocations.Count > 0)
+    {
+      _parameters.MeasurementLocations
+        .IntersectWith(MeasurementLocations);
+      return;
+    }
+
+    if (_parameters.Meters.Count > 0)
+    {
+      _parameters.Meters
+        .IntersectWith(Meters);
       return;
     }
 
     if (MeasurementLocations.Count > 0)
     {
+      _initParamsSet = true;
       _parameters.MeasurementLocations = MeasurementLocations
         .Take(1)
         .ToHashSet();
@@ -107,6 +132,8 @@ public partial class MeasurementChartControls : OzdsComponentBase
 
     if (Meters.Count > 0)
     {
+      _initParamsSet = true;
+
       _parameters.Meters = Meters
         .Take(1)
         .ToHashSet();

--- a/src/Ozds.Data/Queries/MeasurementQueries.cs
+++ b/src/Ozds.Data/Queries/MeasurementQueries.cs
@@ -336,9 +336,10 @@ public class MeasurementQueries(
       filtered = filtered.Where(foreignKeyExpression);
 
       var lastTimestampByMeter = filtered.GroupBy(
-          m => m.MeterId
+        m => m.MeterId
       ).Select(
-        g => new {
+        g => new
+        {
           MeterId = g.Key,
           Timestamp = g.Max(x => x.Timestamp)
         }
@@ -346,8 +347,8 @@ public class MeasurementQueries(
 
       var lastByEveryMeter = filtered.Join(
         lastTimestampByMeter,
-        m => new { m.MeterId, m.Timestamp},
-        x => new { x.MeterId, x.Timestamp},
+        m => new { m.MeterId, m.Timestamp },
+        x => new { x.MeterId, x.Timestamp },
         (m, _) => m
       );
 

--- a/src/Ozds.Data/Queries/MeasurementQueries.cs
+++ b/src/Ozds.Data/Queries/MeasurementQueries.cs
@@ -288,7 +288,7 @@ public class MeasurementQueries(
 
     List<IMeasurementEntity> items = new();
 
-    var futureItems = new List<QueryDeferred<IMeasurementEntity>>();
+    var futureItems = new List<QueryFutureEnumerable<IMeasurementEntity>>();
 
     var types = interval is not null
       ? reflector.AggregateTypes
@@ -335,23 +335,28 @@ public class MeasurementQueries(
           foreignKeyParameter);
       filtered = filtered.Where(foreignKeyExpression);
 
-      var ordered = filtered
-        .OrderByDescending(measurement => measurement.Timestamp);
+      var lastTimestampByMeter = filtered.GroupBy(
+          m => m.MeterId
+      ).Select(
+        g => new {
+          MeterId = g.Key,
+          Timestamp = g.Max(x => x.Timestamp)
+        }
+      );
 
-      futureItems.Add(ordered.DeferredLastOrDefault());
+      var lastByEveryMeter = filtered.Join(
+        lastTimestampByMeter,
+        m => new { m.MeterId, m.Timestamp},
+        x => new { x.MeterId, x.Timestamp},
+        (m, _) => m
+      );
+
+      futureItems.Add(lastByEveryMeter.Future()!);
     }
 
     foreach (var futureItem in futureItems)
     {
-      var value = await futureItem
-        .FutureValue()
-        .ValueAsync(cancellationToken);
-      // NOTE: this is from DeferredLastOrDefault but because the nullability
-      // gets type-erased we have to check regardless
-      if (value is not null)
-      {
-        items.Add(value);
-      }
+      items.AddRange(await futureItem.ToListAsync(cancellationToken));
     }
 
     return items;

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -26,11 +26,11 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
     var testRegisters = TestRegister.SchneideriEM3xxxSet;
 
     var measurementLocation = await MeasurementLocation.Create(
-     cancellationToken,
-     x => x
-       .WithMeter(
-         x => x
-           .WithMeterType(typeof(SchneideriEM3xxxMeterModel))));
+      cancellationToken,
+      x => x
+        .WithMeter(
+          x => x
+            .WithMeterType(typeof(SchneideriEM3xxxMeterModel))));
 
     var scope = await Scope.CreateMeasurementForLocationWithRegisters(
       measurementLocation.Location,
@@ -44,19 +44,19 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       cancellationToken);
 
     var inserted = await Measurement
-    .Insert(
-      [
-        new MeasurementLocationMeterId(
+      .Insert(
+        [
+          new MeasurementLocationMeterId(
             measurementLocation.MeasurementLocation.Id,
             measurementLocation.Meter.Id)
-      ],
-      dateFrom,
-      dateTo,
-      cancellationToken
-    )
-    .OfType<IAggregate>()
-    .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
-    .ToListAsync(cancellationToken);
+        ],
+        dateFrom,
+        dateTo,
+        cancellationToken
+      )
+      .OfType<IAggregate>()
+      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
     var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();
@@ -134,14 +134,15 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
               .WithMeterType(typeof(SchneideriEM3xxxMeterModel)));
 
     var measurementLocation = await MeasurementLocation.Create(
-        cancellationToken,
-        measurementLocationMeterConfigurator
-      );
+      cancellationToken,
+      measurementLocationMeterConfigurator
+    );
 
     var measurementLocations = (await Task.WhenAll(
       Enumerable
         .Range(0, NumberOfMeasurementLocations - 1)
-        .Select(_ => MeasurementLocation.Create(
+        .Select(
+          _ => MeasurementLocation.Create(
             measurementLocation,
             cancellationToken,
             measurementLocationMeterConfigurator
@@ -150,9 +151,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
     measurementLocations.Add(measurementLocation);
 
     var scope = await Scope.CreateMeasurementForLocationWithRegisters(
-     measurementLocation.Location,
-     testRegisters,
-     cancellationToken
+      measurementLocation.Location,
+      testRegisters,
+      cancellationToken
     );
 
     var apiKey = await ApiKey.CreateForUserAndScope(
@@ -160,29 +161,31 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       scope.MeasurementScope,
       cancellationToken);
 
-    var insertionDateTo = DateTimeOffset.Parse(DateTo, CultureInfo.InvariantCulture);
+    var insertionDateTo = DateTimeOffset.Parse(
+      DateTo, CultureInfo.InvariantCulture);
     var insertionDateFrom = insertionDateTo.AddDays(-1);
 
     var inserted = await measurementLocations.Select(
-      m => Measurement.Insert(
-          [
-            new MeasurementLocationMeterId(
+        m => Measurement.Insert(
+            [
+              new MeasurementLocationMeterId(
                 m.MeasurementLocation.Id,
                 m.Meter.Id
               )
-          ],
-          insertionDateFrom,
-          insertionDateTo,
-          cancellationToken
+            ],
+            insertionDateFrom,
+            insertionDateTo,
+            cancellationToken
+          )
+          .OfType<IAggregate>()
+          .Where(
+            aggregate =>
+              aggregate.Interval == IntervalModel.QuarterHour
+          )
       )
-      .OfType<IAggregate>()
-      .Where(aggregate =>
-        aggregate.Interval == IntervalModel.QuarterHour
-      )
-    )
-    .ToAsyncEnumerable()
-    .SelectMany(x => x)
-    .ToListAsync(cancellationToken);
+      .ToAsyncEnumerable()
+      .SelectMany(x => x)
+      .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
     var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();
@@ -201,8 +204,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       .GroupBy(
         m => (m.MeterId, m.MeasurementLocationId)
       )
-      .Select(mg =>
-        mg.MaxBy(m => m.Timestamp)!
+      .Select(
+        mg =>
+          mg.MaxBy(m => m.Timestamp)!
       );
 
     fetched.LocationId.Should().Be(measurementLocation.Location.Id);
@@ -217,7 +221,6 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
 
     foreach (var fetchedMeasurement in fetched.Measurements)
     {
-
       var insertedMeasurement = insertedLatestMeasurements
         .FirstOrDefault(
           insertedMeasurement =>

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -12,6 +12,7 @@ namespace Ozds.Server.Test.Controllers.Api.V1;
 public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
 {
   private const string DateTo = "2025-10-16T11:43:02.931923222+02:00";
+  private const int NumberOfMeasurementLocations = 10;
 
   [Test]
   public async Task
@@ -25,11 +26,11 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
     var testRegisters = TestRegister.SchneideriEM3xxxSet;
 
     var measurementLocation = await MeasurementLocation.Create(
-      cancellationToken,
-      x => x
-        .WithMeter(
-          x => x
-            .WithMeterType(typeof(SchneideriEM3xxxMeterModel))));
+     cancellationToken,
+     x => x
+       .WithMeter(
+         x => x
+           .WithMeterType(typeof(SchneideriEM3xxxMeterModel))));
 
     var scope = await Scope.CreateMeasurementForLocationWithRegisters(
       measurementLocation.Location,
@@ -43,19 +44,19 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       cancellationToken);
 
     var inserted = await Measurement
-      .Insert(
-        [
-          new MeasurementLocationMeterId(
+    .Insert(
+      [
+        new MeasurementLocationMeterId(
             measurementLocation.MeasurementLocation.Id,
             measurementLocation.Meter.Id)
-        ],
-        dateFrom,
-        dateTo,
-        cancellationToken
-      )
-      .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
-      .ToListAsync(cancellationToken);
+      ],
+      dateFrom,
+      dateTo,
+      cancellationToken
+    )
+    .OfType<IAggregate>()
+    .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+    .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
     var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();
@@ -92,6 +93,132 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       fetchedMeasurement.Timestamp.Should().BeBefore(dateTo);
 
       var insertedMeasurement = inserted
+        .FirstOrDefault(
+          insertedMeasurement =>
+            insertedMeasurement.Timestamp == fetchedMeasurement.Timestamp
+            && insertedMeasurement.MeasurementLocationId
+            == fetchedMeasurement.MeasurementLocationId
+            && insertedMeasurement.MeterId == fetchedMeasurement.MeterId)!;
+      insertedMeasurement.Should().NotBeNull();
+
+      foreach (var register in registers)
+      {
+        var insertedValue = insertedMeasurement.RegisterValue(register);
+
+        var fetchedValue = fetchedMeasurement.Registers
+          .FirstOrDefault(
+            fetchedRegister =>
+              fetchedRegister.Key == register.Name)!;
+        fetchedValue.Should().NotBeNull();
+
+        fetchedValue.Value.Should().Be(insertedValue.ToString());
+      }
+    }
+  }
+
+  [Test]
+  public async Task
+    MeasurementsController_GetsQuarterHourlyAggregatesByLocationLast(
+      CancellationToken cancellationToken
+    )
+  {
+    DateTimeOffset? dateFrom = null;
+    DateTimeOffset? dateTo = null;
+    var testRegisters = TestRegister.SchneideriEM3xxxSet;
+
+    Action<TestMeasurementLocationFixture.Configurator>
+      measurementLocationMeterConfigurator =
+        x => x
+          .WithMeter(
+            x => x
+              .WithMeterType(typeof(SchneideriEM3xxxMeterModel)));
+
+    var measurementLocation = await MeasurementLocation.Create(
+        cancellationToken,
+        measurementLocationMeterConfigurator
+      );
+
+    var measurementLocations = (await Task.WhenAll(
+      Enumerable
+        .Range(0, NumberOfMeasurementLocations - 1)
+        .Select(_ => MeasurementLocation.Create(
+            measurementLocation,
+            cancellationToken,
+            measurementLocationMeterConfigurator
+          )))).ToList();
+
+    measurementLocations.Add(measurementLocation);
+
+    var scope = await Scope.CreateMeasurementForLocationWithRegisters(
+     measurementLocation.Location,
+     testRegisters,
+     cancellationToken
+    );
+
+    var apiKey = await ApiKey.CreateForUserAndScope(
+      TestUser.Operator,
+      scope.MeasurementScope,
+      cancellationToken);
+
+    var insertionDateTo = DateTimeOffset.Parse(DateTo, CultureInfo.InvariantCulture);
+    var insertionDateFrom = insertionDateTo.AddDays(-1);
+
+    var inserted = await measurementLocations.Select(
+      m => Measurement.Insert(
+          [
+            new MeasurementLocationMeterId(
+                m.MeasurementLocation.Id,
+                m.Meter.Id
+              )
+          ],
+          insertionDateFrom,
+          insertionDateTo,
+          cancellationToken
+      )
+      .OfType<IAggregate>()
+      .Where(aggregate =>
+        aggregate.Interval == IntervalModel.QuarterHour
+      )
+    )
+    .ToAsyncEnumerable()
+    .SelectMany(x => x)
+    .ToListAsync(cancellationToken);
+
+    var client = Services.GetRequiredService<IOzdsApiV1Client>();
+    var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();
+
+    client.ApiKey = apiKeyManager.Tokenize(apiKey.ApiKey);
+
+    var fetched = await client.QuarterHourlyAggregatesByLocationAsync(
+      measurementLocation.Location.Id,
+      dateFrom,
+      dateTo,
+      0,
+      cancellationToken
+    );
+
+    var insertedLatestMeasurements = inserted
+      .GroupBy(
+        m => (m.MeterId, m.MeasurementLocationId)
+      )
+      .Select(mg =>
+        mg.MaxBy(m => m.Timestamp)!
+      );
+
+    fetched.LocationId.Should().Be(measurementLocation.Location.Id);
+    fetched.Page.Should().Be(0);
+    fetched.PageSize.Should().BeGreaterThan(inserted.Count);
+    fetched.TotalCount.Should().Be(fetched.Measurements.Count);
+    fetched.TotalCount.Should().Be(insertedLatestMeasurements!.Count());
+
+    var registers = testRegisters
+      .Select(testRegister => Scope.TestRegisterToRegisterModel(testRegister))
+      .ToList();
+
+    foreach (var fetchedMeasurement in fetched.Measurements)
+    {
+
+      var insertedMeasurement = insertedLatestMeasurements
         .FirstOrDefault(
           insertedMeasurement =>
             insertedMeasurement.Timestamp == fetchedMeasurement.Timestamp

--- a/test/Ozds.Server.Test/Fixtures/TestMeasurementLocationFixture.cs
+++ b/test/Ozds.Server.Test/Fixtures/TestMeasurementLocationFixture.cs
@@ -24,6 +24,58 @@ public class TestMeasurementLocationFixture(
 {
   public async Task<MeasurementLocationWithNetworkUserAndMeter>
     Create(
+      MeasurementLocationWithNetworkUserAndMeter basis,
+      CancellationToken cancellationToken,
+      Action<Configurator>? configure = null
+    )
+  {
+    var configurator = new Configurator();
+    if (configure is not null)
+    {
+      configure(configurator);
+    }
+
+    var meterFixture = new TestMeterFixture(composition);
+
+    var meter = await meterFixture.Create(
+      cancellationToken,
+      x =>
+      {
+        x.WithMeter(y => y.MessengerId = basis.Messenger.Id);
+        configurator.ConfigureMeter(x);
+      });
+
+    var trackableFixture = new TestTrackableFixture(composition);
+
+    var measurementLocation = await trackableFixture.Create<NetworkUserMeasurementLocationModel>(
+        cancellationToken,
+        m =>
+        {
+          m.NetworkUserId = basis.NetworkUser.Id;
+          m.MeterId = meter.Meter.Id;
+          m.NetworkUserCatalogueId = configurator
+            .GetNetworkUserCatalogueId(basis.Location);
+          configurator.ConfigureMeasurementLocation(m);
+        }
+      );
+
+    return new MeasurementLocationWithNetworkUserAndMeter(
+        basis.RegulatoryCatalogue,
+        basis.RedLowNetworkUserCatalogue,
+        basis.BlueLowNetworkUserCatalogue,
+        basis.WhiteLowNetworkUserCatalogue,
+        basis.WhiteMediumNetworkUserCatalogue,
+        basis.Messenger,
+        basis.Location,
+        basis.NetworkUser,
+        meter.MeasurementValidator,
+        meter.Meter,
+        measurementLocation
+      );
+  }
+
+  public async Task<MeasurementLocationWithNetworkUserAndMeter>
+    Create(
       CancellationToken cancellationToken,
       Action<Configurator>? configure = null
     )

--- a/test/Ozds.Server.Test/Fixtures/TestMeasurementLocationFixture.cs
+++ b/test/Ozds.Server.Test/Fixtures/TestMeasurementLocationFixture.cs
@@ -47,7 +47,8 @@ public class TestMeasurementLocationFixture(
 
     var trackableFixture = new TestTrackableFixture(composition);
 
-    var measurementLocation = await trackableFixture.Create<NetworkUserMeasurementLocationModel>(
+    var measurementLocation =
+      await trackableFixture.Create<NetworkUserMeasurementLocationModel>(
         cancellationToken,
         m =>
         {
@@ -60,18 +61,18 @@ public class TestMeasurementLocationFixture(
       );
 
     return new MeasurementLocationWithNetworkUserAndMeter(
-        basis.RegulatoryCatalogue,
-        basis.RedLowNetworkUserCatalogue,
-        basis.BlueLowNetworkUserCatalogue,
-        basis.WhiteLowNetworkUserCatalogue,
-        basis.WhiteMediumNetworkUserCatalogue,
-        basis.Messenger,
-        basis.Location,
-        basis.NetworkUser,
-        meter.MeasurementValidator,
-        meter.Meter,
-        measurementLocation
-      );
+      basis.RegulatoryCatalogue,
+      basis.RedLowNetworkUserCatalogue,
+      basis.BlueLowNetworkUserCatalogue,
+      basis.WhiteLowNetworkUserCatalogue,
+      basis.WhiteMediumNetworkUserCatalogue,
+      basis.Messenger,
+      basis.Location,
+      basis.NetworkUser,
+      meter.MeasurementValidator,
+      meter.Meter,
+      measurementLocation
+    );
   }
 
   public async Task<MeasurementLocationWithNetworkUserAndMeter>


### PR DESCRIPTION
API fix - latest read by location id now returns 

@HrvojeJuric 
Fixes #259.

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

API was not returning all of meters with measurements. This happened because implementation of method "ReadLastByMeasurementLocationIds" just returned earliest known measurement per aggregate Type.

Variable number of  meters from API are happening because IOT reciever on server has a buffer that accepts messages from messengers and has a hard cap limit for amount of meter readings (messages) it can have. 

## Testing

Swagger API tests.
quarter-hourly-aggregates-by-location GET test 
