### PR TITLE
261 model and entity converters do not yield first element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - added new specific test for API returning latest measurements by meter
-- added dapper queries for getting chunk interval information (WIP)
 
 ### Changed
 
+- fix optimized N+1 problem in API test -
+  GetsQuarterHourlyAggregatesByLocationLast
+- added dapper queries for getting chunk interval information (WIP)
 - fix MeasurementDeletionJobReactorTest now uses chunk interval information to
   determine which measurement chunks will be removed from db
 - updated HtmlSanitizer to version 9.0.892

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - added dapper queries for getting chunk interval information (WIP)
 - fix MeasurementDeletionJobReactorTest now uses chunk interval information to
   determine which measurement chunks will be removed from db
+
+### Changed
+
+- fix converters should now return first elements and not cause discrepancies in
+  data
 - updated HtmlSanitizer to version 9.0.892
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-### Changed
+### Added
 
 - added new specific test for API returning latest measurements by meter
+
+### Changed
+
+- fix converters should now return first elements and not cause discrepancies in
+  data
 - updated HtmlSanitizer to version 9.0.892
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-### Changed
+### Added
 
 - added new specific test for API returning latest measurements by meter
+- added dapper queries for getting chunk interval information (WIP)
+
+### Changed
+
+- fix MeasurementDeletionJobReactorTest now uses chunk interval information to
+  determine which measurement chunks will be removed from db
 - updated HtmlSanitizer to version 9.0.892
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements

--- a/scripts/Ozds.Fake/Conversion/MeasurementRecordConverter.cs
+++ b/scripts/Ozds.Fake/Conversion/MeasurementRecordConverter.cs
@@ -27,6 +27,8 @@ public class MeasurementRecordConverter(
     var current = enumerator.Current;
     var converter = GetModelConverter(current);
 
+    yield return converter.ConvertToModel(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -53,6 +55,8 @@ public class MeasurementRecordConverter(
 
     var current = enumerator.Current;
     var converter = GetModelConverter(current);
+
+    yield return converter.ConvertToModel(current);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {

--- a/src/Ozds.Business/Conversion/ModelCachingEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/ModelCachingEntityConverter.cs
@@ -40,6 +40,8 @@ public class ModelCachingEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
 
+    yield return converter.ToEntity(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -74,6 +76,8 @@ public class ModelCachingEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
+
+    yield return converter.ToEntity(current);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {
@@ -115,6 +119,8 @@ public class ModelCachingEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
 
+    yield return converter.ToModel(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -149,6 +155,8 @@ public class ModelCachingEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
+
+    yield return converter.ToModel(current);
 
     while (await enumerator.MoveNextAsync())
     {

--- a/src/Ozds.Business/Conversion/ModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/ModelEntityConverter.cs
@@ -1,7 +1,6 @@
-using Ozds.Business.Conversion.Abstractions;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using static System.Net.Mime.MediaTypeNames;
+using Ozds.Business.Conversion.Abstractions;
 
 namespace Ozds.Business.Conversion;
 

--- a/src/Ozds.Business/Conversion/ModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/ModelEntityConverter.cs
@@ -1,6 +1,7 @@
+using Ozds.Business.Conversion.Abstractions;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Ozds.Business.Conversion.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Ozds.Business.Conversion;
 
@@ -39,6 +40,8 @@ public class ModelEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
 
+    yield return converter.ToEntity(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -73,6 +76,8 @@ public class ModelEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
+
+    yield return converter.ToEntity(current);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {
@@ -114,6 +119,8 @@ public class ModelEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
 
+    yield return converter.ToModel(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -148,6 +155,8 @@ public class ModelEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
+
+    yield return converter.ToModel(current);
 
     while (await enumerator.MoveNextAsync())
     {

--- a/src/Ozds.Business/Conversion/ModelReportEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/ModelReportEntityConverter.cs
@@ -39,6 +39,8 @@ public class ModelReportEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
 
+    yield return converter.ToEntity(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -73,6 +75,8 @@ public class ModelReportEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
+
+    yield return converter.ToEntity(current);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {
@@ -114,6 +118,8 @@ public class ModelReportEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
 
+    yield return converter.ToModel(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -148,6 +154,8 @@ public class ModelReportEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
+
+    yield return converter.ToModel(current);
 
     while (await enumerator.MoveNextAsync())
     {

--- a/src/Ozds.Business/Conversion/ModelUserEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/ModelUserEntityConverter.cs
@@ -39,6 +39,8 @@ public class ModelUserEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
 
+    yield return converter.ToEntity(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -73,6 +75,8 @@ public class ModelUserEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetEntityConverterForConversion(current.GetType());
+
+    yield return converter.ToEntity(current);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {
@@ -114,6 +118,8 @@ public class ModelUserEntityConverter(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
 
+    yield return converter.ToModel(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -148,6 +154,8 @@ public class ModelUserEntityConverter(IServiceProvider serviceProvider)
 
     var current = enumerator.Current;
     var converter = GetModelConverterForConversion(current.GetType());
+
+    yield return converter.ToModel(current);
 
     while (await enumerator.MoveNextAsync())
     {

--- a/src/Ozds.Business/Conversion/PushRequestMeasurementConverter.cs
+++ b/src/Ozds.Business/Conversion/PushRequestMeasurementConverter.cs
@@ -63,6 +63,8 @@ public class PushRequestMeasurementConverter(
     var current = enumerator.Current;
     var converter = GetMeasurementConverter(current.GetType());
 
+    yield return converter.ToPushRequest(current);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -89,6 +91,8 @@ public class PushRequestMeasurementConverter(
 
     var current = enumerator.Current;
     var converter = GetMeasurementConverter(current.GetType());
+
+    yield return converter.ToPushRequest(current);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {
@@ -150,6 +154,10 @@ public class PushRequestMeasurementConverter(
     var current = enumerator.Current;
     var converter = GetPushRequestConverter(current.GetType());
 
+    yield return converter.ToMeasurement(
+      current.MeterPushRequest,
+      current.MeasurementLocationId);
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -178,6 +186,10 @@ public class PushRequestMeasurementConverter(
 
     var current = enumerator.Current;
     var converter = GetPushRequestConverter(current.GetType());
+
+    yield return converter.ToMeasurement(
+      current.MeterPushRequest,
+      current.MeasurementLocationId);
 
     while (await enumerator.MoveNextAsync(cancellationToken))
     {

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+using Ozds.Assets.Queries.Abstractions;
+using Ozds.Data.Attributes;
+using Ozds.Data.Context;
+using Ozds.Data.Extensions;
+
+namespace Ozds.Data.Queries;
+
+// NOTE: this code is specific for measurement deletion job test
+// hence it's not implemented further
+[DapperResult]
+public sealed class ChunkIntervalInfo
+{
+  public string HypertableName { get; init; } = "";
+
+  public DateTimeOffset RangeStart { get; init; }
+
+  public DateTimeOffset RangeEnd { get; init; }
+}
+
+public class TimescaleChunkIntervalQueries(
+  IDbContextFactory<DataDbContext> factory
+) : IQueries
+{
+  public async Task<ChunkIntervalInfo?>
+    GetChunkIntervalBeforeCutoff(
+      DateTimeOffset threshold,
+      Type entityType,
+      CancellationToken cancellationToken
+    )
+  {
+    await using var context =
+      await factory.CreateDbContextAsync(cancellationToken);
+
+    var tableName = context.GetTableName(entityType)
+      ?? throw new InvalidOperationException(
+        $"Table name not found for for {entityType.Name}.");
+
+    const string sqlString = """
+      SELECT @TableName            AS    "HypertableName",
+             MIN(range_start)      AS    "RangeStart",
+             MAX(range_end)        AS    "RangeEnd"
+      FROM timescaledb_information.chunks
+      WHERE hypertable_name = @TableName AND range_end < @Threshold;
+      """;
+
+    return (await context.DapperCommand<ChunkIntervalInfo>(
+      sqlString,
+      cancellationToken,
+      new
+      {
+        TableName = tableName,
+        Threshold = threshold
+      }
+    )).FirstOrDefault();
+  }
+
+  public async Task<List<ChunkIntervalInfo>>
+    GetChunkIntervalBeforeCutoff(
+      DateTimeOffset threshold,
+      IEnumerable<Type> entityTypes,
+      CancellationToken cancellationToken
+    )
+  {
+    await using var context =
+      await factory.CreateDbContextAsync(cancellationToken);
+
+    var hypertableNames = entityTypes
+      .Select(
+        x => context.GetTableName(x)
+          ?? throw new InvalidOperationException(
+            $"Table name not found for for {x.Name}.")
+      )
+      .ToArray()!;
+
+    const string sqlString = """
+      SELECT hypertable_name      AS    "HypertableName",
+             MIN(range_start)     AS    "RangeStart",
+             MAX(range_end)       AS    "RangeEnd"
+      FROM timescaledb_information.chunks
+      WHERE range_end < @Threshold AND hypertable_name = ANY(@HypertableNames)
+      GROUP BY hypertable_name;
+      """;
+
+    return await context.DapperCommand<ChunkIntervalInfo>(
+      sqlString,
+      cancellationToken,
+      new
+      {
+        Threshold = threshold,
+        HypertableNames = hypertableNames
+      }
+    );
+  }
+}

--- a/test/Ozds.Data.Test/Mutations/MeasurementMutationsTest/CreateMeasurementsTest.cs
+++ b/test/Ozds.Data.Test/Mutations/MeasurementMutationsTest/CreateMeasurementsTest.cs
@@ -216,7 +216,7 @@ public class CreateMeasurementsTest : OzdsDataTestBase
         ))
       .Select(
         x =>
-          x.Key.Item4 is { }
+          x.Key.Item5 is { }
             ? x.Aggregate(
               (lhs, rhs) => (lhs, rhs) switch
               {
@@ -888,13 +888,13 @@ public class CreateMeasurementsTest : OzdsDataTestBase
         Avg = (lhs.Avg * lhsCount + rhs.Avg * rhsCount)
           / (lhsCount + rhsCount),
         Min = Math.Min(lhs.Min, rhs.Min),
-        MinTimestamp = lhs.Min < rhs.Min
-          ? lhs.MinTimestamp
-          : rhs.MinTimestamp,
+        MinTimestamp = rhs.Min < lhs.Min
+          ? rhs.MinTimestamp
+          : lhs.MinTimestamp,
         Max = Math.Max(lhs.Max, rhs.Max),
-        MaxTimestamp = lhs.Max > rhs.Max
-          ? lhs.MaxTimestamp
-          : rhs.MaxTimestamp
+        MaxTimestamp = rhs.Max > lhs.Max
+          ? rhs.MaxTimestamp
+          : lhs.MaxTimestamp
       };
     }
 
@@ -910,13 +910,13 @@ public class CreateMeasurementsTest : OzdsDataTestBase
         Avg = (lhs.Avg * lhsCount + rhs.Avg * rhsCount)
           / (lhsCount + rhsCount),
         Min = Math.Min(lhs.Min, rhs.Min),
-        MinTimestamp = lhs.Min < rhs.Min
-          ? lhs.MinTimestamp
-          : rhs.MinTimestamp,
+        MinTimestamp = rhs.Min < lhs.Min
+          ? rhs.MinTimestamp
+          : lhs.MinTimestamp,
         Max = Math.Max(lhs.Max, rhs.Max),
-        MaxTimestamp = lhs.Max > rhs.Max
-          ? lhs.MaxTimestamp
-          : rhs.MaxTimestamp
+        MaxTimestamp = rhs.Max > lhs.Max
+          ? rhs.MaxTimestamp
+          : lhs.MaxTimestamp
       };
     }
 

--- a/test/Ozds.Data.Test/Mutations/MeasurementMutationsTest/CreateMeasurementsTest.cs
+++ b/test/Ozds.Data.Test/Mutations/MeasurementMutationsTest/CreateMeasurementsTest.cs
@@ -216,7 +216,7 @@ public class CreateMeasurementsTest : OzdsDataTestBase
         ))
       .Select(
         x =>
-          x.Key.Item5 is { }
+          x.Key.Item5 is not null
             ? x.Aggregate(
               (lhs, rhs) => (lhs, rhs) switch
               {

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -165,27 +165,21 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       DateTo, CultureInfo.InvariantCulture);
     var insertionDateFrom = insertionDateTo.AddDays(-1);
 
-    var inserted = await measurementLocations.Select(
-        m => Measurement.Insert(
-            [
-              new MeasurementLocationMeterId(
-                m.MeasurementLocation.Id,
-                m.Meter.Id
-              )
-            ],
-            insertionDateFrom,
-            insertionDateTo,
-            cancellationToken
+    var inserted = await Measurement.Insert(
+        measurementLocations.Select(
+          m => new MeasurementLocationMeterId(
+            m.MeasurementLocation.Id,
+            m.Meter.Id
           )
-          .OfType<IAggregate>()
-          .Where(
-            aggregate =>
-              aggregate.Interval == IntervalModel.QuarterHour
-          )
-      )
-      .ToAsyncEnumerable()
-      .SelectMany(x => x)
-      .ToListAsync(cancellationToken);
+        ),
+        insertionDateFrom,
+        insertionDateTo,
+        cancellationToken
+      ).OfType<IAggregate>()
+      .Where(
+        aggregate =>
+          aggregate.Interval == IntervalModel.QuarterHour
+      ).ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
     var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -1,7 +1,11 @@
+using Ozds.Business.Conversion;
 using Ozds.Business.Models.Abstractions;
 using Ozds.Business.Queries;
 using Ozds.Fake.Identification;
 using Ozds.Server.Test.Base;
+using DataEntityReflector = Ozds.Data.Reflection.EntityReflector;
+using DataTimescaleChunkIntervalQueries =
+  Ozds.Data.Queries.TimescaleChunkIntervalQueries;
 
 namespace Ozds.Server.Test.Reactors;
 
@@ -42,6 +46,8 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
     var dateFrom = dateTo - Interval * 2;
     var deletionCutoff = dateFrom + Interval;
 
+    var dataReflector = Services.GetRequiredService<DataEntityReflector>();
+
     var itemsBefore = await Measurement
       .Insert(
         [
@@ -57,6 +63,21 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       .Where(x => x is not IAggregate)
       .ToListAsync(cancellationToken);
 
+    var deletedChunkIntervalByModelType =
+    (
+      await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
+        .GetChunkIntervalBeforeCutoff(
+          deletionCutoff,
+          dataReflector.MeasurementTypes,
+          cancellationToken)
+    ).ToDictionary(
+      x =>
+        Services.GetRequiredService<ModelEntityConverter>()
+          .ModelType(
+            dataReflector.ResolveEntityTypeFromTable(x.HypertableName)
+          )
+    );
+
     itemsBefore.Should().AllSatisfy(
       x =>
         x.Timestamp.Should().BeAfter(dateFrom));
@@ -64,7 +85,7 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       x =>
         x.Timestamp.Should().BeBefore(dateTo));
 
-    await Task.Delay(TimeSpan.FromMinutes(2), cancellationToken);
+    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
 
     var itemsAfter = await Services.GetRequiredService<MeasurementQueries>()
       .ReadByMeasurementLocationIds(
@@ -76,10 +97,20 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
         cancellationToken
       );
 
-    itemsAfter.TotalCount.Should().BeLessThan(itemsBefore.Count);
+    var determinedItemsAfter = itemsBefore.Where(
+      x =>
+        !deletedChunkIntervalByModelType.TryGetValue(
+          x.GetType(), out var chunkInfo)
+        || x.Timestamp > chunkInfo.RangeEnd
+    ).ToList();
+
+    var determinedTimestampMinimum = itemsBefore.Min(x => x.Timestamp);
+
+    itemsAfter.TotalCount.Should()
+      .BeLessThanOrEqualTo(determinedItemsAfter.Count);
 
     itemsAfter.Items.Should().AllSatisfy(
       x =>
-        x.Timestamp.Should().BeAfter(deletionCutoff));
+        x.Timestamp.Should().BeOnOrAfter(determinedTimestampMinimum));
   }
 }


### PR DESCRIPTION
@HrvojeJuric
Fixes #261 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Simple solution - added yield return convert(current), since the the function already acts like generator.

<img width="489" height="113" alt="image" src="https://github.com/user-attachments/assets/900efeac-e570-418a-aedb-341b56a78924" />

### Appendix
CreateMeasurementTest Upsert failures

All of the upsert tests contain this aggregating (or reducing) logic, the problem is that this differs from the logic which happens in database.

Example on test:
*File used: CreateMeasurementsTest.cs*

<img width="299" height="126" alt="image" src="https://github.com/user-attachments/assets/1dc949b1-7dfe-4c46-8aca-ca3eba836062" />

Example on database (any timestamp aggregation procedure is like this):
*File used: MeasurementProcedureCompiler.cs*

<img width="664" height="182" alt="image" src="https://github.com/user-attachments/assets/59c68e61-d5b1-4a6d-a151-1eb3f4d038ab" />

Delta table here is rhs in tests or value to be accumulated on accumulation functions like aggregate or reduce, this then becomes problem since if the values are equal on both sides, DB will always apply timestamp from the lhs (oldTable) and script will use the rhs (deltaTable/newTable).

Simple patch fix - just imitate the way of comparison from the database on test.

<img width="428" height="251" alt="image" src="https://github.com/user-attachments/assets/fb7443d1-172a-43c0-befd-4778820c0aef" />

## Testing

How I even got to this problem is while testing discrepancy of data on test JobMeasurementDeletionsReactorTest, what I recommend is you add breakpoint on data that is returned by fixture (data that is supposed to be written in db) and check the size diff between that and what actually gets returned by client read on database (this way you can also observe discrepancy if you didn't apply this fix).







