### PR TITLE
264 nplus1 problem on new api test implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-### Changed
+### Added
 
 - added new specific test for API returning latest measurements by meter
+
+### Changed
+
+- fix optimized N+1 problem in API test -
+  GetsQuarterHourlyAggregatesByLocationLast
 - updated HtmlSanitizer to version 9.0.892
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -166,20 +166,20 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
     var insertionDateFrom = insertionDateTo.AddDays(-1);
 
     var inserted = await Measurement.Insert(
-      measurementLocations.Select(
+        measurementLocations.Select(
           m => new MeasurementLocationMeterId(
             m.MeasurementLocation.Id,
             m.Meter.Id
           )
-      ),
-      insertionDateFrom,
-      insertionDateTo,
-      cancellationToken
-    ).OfType<IAggregate>()
-    .Where(
-      aggregate =>
-        aggregate.Interval == IntervalModel.QuarterHour
-    ).ToListAsync(cancellationToken);
+        ),
+        insertionDateFrom,
+        insertionDateTo,
+        cancellationToken
+      ).OfType<IAggregate>()
+      .Where(
+        aggregate =>
+          aggregate.Interval == IntervalModel.QuarterHour
+      ).ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
     var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -165,27 +165,21 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       DateTo, CultureInfo.InvariantCulture);
     var insertionDateFrom = insertionDateTo.AddDays(-1);
 
-    var inserted = await measurementLocations.Select(
-        m => Measurement.Insert(
-            [
-              new MeasurementLocationMeterId(
-                m.MeasurementLocation.Id,
-                m.Meter.Id
-              )
-            ],
-            insertionDateFrom,
-            insertionDateTo,
-            cancellationToken
+    var inserted = await Measurement.Insert(
+      measurementLocations.Select(
+          m => new MeasurementLocationMeterId(
+            m.MeasurementLocation.Id,
+            m.Meter.Id
           )
-          .OfType<IAggregate>()
-          .Where(
-            aggregate =>
-              aggregate.Interval == IntervalModel.QuarterHour
-          )
-      )
-      .ToAsyncEnumerable()
-      .SelectMany(x => x)
-      .ToListAsync(cancellationToken);
+      ),
+      insertionDateFrom,
+      insertionDateTo,
+      cancellationToken
+    ).OfType<IAggregate>()
+    .Where(
+      aggregate =>
+        aggregate.Interval == IntervalModel.QuarterHour
+    ).ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
     var apiKeyManager = Services.GetRequiredService<ApiKeyManager>();


### PR DESCRIPTION
# Task
(New PR because I forgot to squash the old one before merge with dev)

Fixes #264 
Closes #264 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Restructured the code so now it does not call queries for every measurement location.
