### PR TITLE
243 test in ozdsservertest fails at measurementdeletionjobreactor reacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-### Changed
+### Added
 
 - added new specific test for API returning latest measurements by meter
+- added dapper queries for getting chunk interval information (WIP)
+
+### Changed
+
+- fix MeasurementDeletionJobReactorTest now uses chunk interval information to
+  determine which measurement chunks will be removed from db
 - updated HtmlSanitizer to version 9.0.892
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -23,11 +23,11 @@ public class TimescaleChunkIntervalQueries(
 ) : IQueries
 {
   public async Task<ChunkIntervalInfo?>
-   GetChunkIntervalBeforeCutoff(
-     DateTimeOffset threshold,
-     Type entityType,
-     CancellationToken cancellationToken
-   )
+    GetChunkIntervalBeforeCutoff(
+      DateTimeOffset threshold,
+      Type entityType,
+      CancellationToken cancellationToken
+    )
   {
     await using var context =
       await factory.CreateDbContextAsync(cancellationToken);
@@ -56,11 +56,11 @@ public class TimescaleChunkIntervalQueries(
   }
 
   public async Task<List<ChunkIntervalInfo>>
-   GetChunkIntervalBeforeCutoff(
-     DateTimeOffset threshold,
-     IEnumerable<Type> entityTypes,
-     CancellationToken cancellationToken
-   )
+    GetChunkIntervalBeforeCutoff(
+      DateTimeOffset threshold,
+      IEnumerable<Type> entityTypes,
+      CancellationToken cancellationToken
+    )
   {
     await using var context =
       await factory.CreateDbContextAsync(cancellationToken);

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -1,83 +1,100 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Ozds.Assets.Queries.Abstractions;
+using Ozds.Data.Attributes;
 using Ozds.Data.Context;
 using Ozds.Data.Extensions;
 using Ozds.Data.Reflection;
 
 namespace Ozds.Data.Queries;
 
-public record ChunkInfo
+// NOTE: this code is specific for measurement deletion job test
+// hence it's not implemented further
+[DapperResult]
+public sealed class ChunkIntervalInfo
 {
-  Type? HypertableName;
+  public string HypertableName { get; init; } = "";
 
-  DateTimeOffset? RangeStart;
+  public DateTimeOffset RangeStart { get; init; }
 
-  DateTimeOffset? RangeEnd;
+  public DateTimeOffset RangeEnd { get; init; }
 }
 
 public class TimescaleChunkIntervalQueries(
-  IDbContextFactory<DataDbContext> factory,
-  EntityReflector reflector,
-  ILogger<TimescaleChunkIntervalQueries> logger
+  IDbContextFactory<DataDbContext> factory
 ) : IQueries
 {
 
-  // this could be more specified to be for chunks of measurements
-  public async Task<List<ChunkInfo>>
-    GetChunkInformationForEntityTable(
-      Type entityType,
-      CancellationToken cancellationToken
-    )
-  {
-
-    var context = await factory.CreateDbContextAsync(cancellationToken);
-
-    var tableName = context.GetTableName(entityType);
-
-    const string sqlString = """
-      SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chunks
-      WHERE hypertable_name = @TableName
-      ORDER BY range_start;
-      """;
-
-    var rows = await context.DapperCommand<ChunkInfo>(
-        sqlString,
-        cancellationToken,
-        new { TableName = tableName }
-      );
-
-    return rows;
-  }
-
-  public async Task<ChunkInfo?>
-   GetLatestChunkBeforeCutoff(
+  public async Task<ChunkIntervalInfo?>
+   GetLatestChunkIntervalBeforeCutoff(
      DateTimeOffset threshold,
      Type entityType,
      CancellationToken cancellationToken
    )
   {
 
-    var context = await factory.CreateDbContextAsync(cancellationToken);
+    await using var context = await factory.CreateDbContextAsync(cancellationToken);
 
-    var tableName = context.GetTableName(entityType);
+    var tableName = context.GetTableName(entityType)
+      ?? throw new InvalidOperationException($"Table name not found for for {entityType.Name}.");
 
     const string sqlString = """
-      SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chunks
+      SELECT hypertable_name  AS    "HypertableName",
+             range_start      AS    "RangeStart",
+             range_end        AS    "RangeEnd"
+      FROM timescaledb_information.chunks
       WHERE hypertable_name = @TableName AND range_end < @Threshold
       ORDER BY range_end DESC
       LIMIT 1;
       """;
 
-    var latestChunk = (await context.DapperCommand<ChunkInfo>(
+    return (await context.DapperCommand<ChunkIntervalInfo>(
         sqlString,
         cancellationToken,
-        new {
+        new
+        {
           TableName = tableName,
           Threshold = threshold
         }
       )).FirstOrDefault();
+  }
 
-    return latestChunk;
+  public async Task<List<ChunkIntervalInfo>>
+   GetLatestChunkIntervalBeforeCutoff(
+     DateTimeOffset threshold,
+     IEnumerable<Type> entityTypes,
+     CancellationToken cancellationToken
+   )
+  {
+
+    await using var context = await factory.CreateDbContextAsync(cancellationToken);
+
+    var hypertableNames = entityTypes
+      .Select(x => context.GetTableName(x)
+        ?? throw new InvalidOperationException($"Table name not found for for {x.Name}.")
+      )
+      .ToArray()!;
+
+    const string sqlString = """
+      SELECT hypertable_name  AS    "HypertableName",
+             MIN(range_start) AS    "RangeStart",
+             MAX(range_end)   AS    "RangeEnd"
+      FROM timescaledb_information.chunks
+      WHERE range_end < @Threshold AND hypertable_name = ANY(@HypertableNames)
+      GROUP BY hypertable_name
+      ORDER BY MAX(range_end) DESC
+      LIMIT 1;
+      """;
+
+    return await context.DapperCommand<ChunkIntervalInfo>(
+        sqlString,
+        cancellationToken,
+        new
+        {
+          Threshold = threshold,
+          HypertableNames = hypertableNames
+        }
+      );
   }
 }

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -1,0 +1,83 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.EntityFrameworkCore;
+using Ozds.Assets.Queries.Abstractions;
+using Ozds.Data.Context;
+using Ozds.Data.Extensions;
+using Ozds.Data.Reflection;
+
+namespace Ozds.Data.Queries;
+
+public record ChunkInfo
+{
+  Type? HypertableName;
+
+  DateTimeOffset? RangeStart;
+
+  DateTimeOffset? RangeEnd;
+}
+
+public class TimescaleChunkIntervalQueries(
+  IDbContextFactory<DataDbContext> factory,
+  EntityReflector reflector,
+  ILogger<TimescaleChunkIntervalQueries> logger
+) : IQueries
+{
+
+  // this could be more specified to be for chunks of measurements
+  public async Task<List<ChunkInfo>>
+    GetChunkInformationForEntityTable(
+      Type entityType,
+      CancellationToken cancellationToken
+    )
+  {
+
+    var context = await factory.CreateDbContextAsync(cancellationToken);
+
+    var tableName = context.GetTableName(entityType);
+
+    const string sqlString = """
+      SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chunks
+      WHERE hypertable_name = @TableName
+      ORDER BY range_start;
+      """;
+
+    var rows = await context.DapperCommand<ChunkInfo>(
+        sqlString,
+        cancellationToken,
+        new { TableName = tableName }
+      );
+
+    return rows;
+  }
+
+  public async Task<ChunkInfo?>
+   GetLatestChunkBeforeCutoff(
+     DateTimeOffset threshold,
+     Type entityType,
+     CancellationToken cancellationToken
+   )
+  {
+
+    var context = await factory.CreateDbContextAsync(cancellationToken);
+
+    var tableName = context.GetTableName(entityType);
+
+    const string sqlString = """
+      SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chunks
+      WHERE hypertable_name = @TableName AND range_end < @Threshold
+      ORDER BY range_end DESC
+      LIMIT 1;
+      """;
+
+    var latestChunk = (await context.DapperCommand<ChunkInfo>(
+        sqlString,
+        cancellationToken,
+        new {
+          TableName = tableName,
+          Threshold = threshold
+        }
+      )).FirstOrDefault();
+
+    return latestChunk;
+  }
+}

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -40,13 +40,11 @@ public class TimescaleChunkIntervalQueries(
       ?? throw new InvalidOperationException($"Table name not found for for {entityType.Name}.");
 
     const string sqlString = """
-      SELECT hypertable_name  AS    "HypertableName",
-             range_start      AS    "RangeStart",
-             range_end        AS    "RangeEnd"
+      SELECT @TableName            AS    "HypertableName",
+             MIN(range_start)      AS    "RangeStart",
+             MAX(range_end)        AS    "RangeEnd"
       FROM timescaledb_information.chunks
-      WHERE hypertable_name = @TableName AND range_end < @Threshold
-      ORDER BY range_end DESC
-      LIMIT 1;
+      WHERE hypertable_name = @TableName AND range_end < @Threshold;
       """;
 
     return (await context.DapperCommand<ChunkIntervalInfo>(
@@ -77,14 +75,12 @@ public class TimescaleChunkIntervalQueries(
       .ToArray()!;
 
     const string sqlString = """
-      SELECT hypertable_name  AS    "HypertableName",
-             MIN(range_start) AS    "RangeStart",
-             MAX(range_end)   AS    "RangeEnd"
+      SELECT hypertable_name      AS    "HypertableName",
+             MIN(range_start)     AS    "RangeStart",
+             MAX(range_end)       AS    "RangeEnd"
       FROM timescaledb_information.chunks
       WHERE range_end < @Threshold AND hypertable_name = ANY(@HypertableNames)
-      GROUP BY hypertable_name
-      ORDER BY MAX(range_end) DESC
-      LIMIT 1;
+      GROUP BY hypertable_name;
       """;
 
     return await context.DapperCommand<ChunkIntervalInfo>(

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -27,7 +27,7 @@ public class TimescaleChunkIntervalQueries(
 {
 
   public async Task<ChunkIntervalInfo?>
-   GetLatestChunkIntervalBeforeCutoff(
+   GetChunkIntervalBeforeCutoff(
      DateTimeOffset threshold,
      Type entityType,
      CancellationToken cancellationToken
@@ -59,7 +59,7 @@ public class TimescaleChunkIntervalQueries(
   }
 
   public async Task<List<ChunkIntervalInfo>>
-   GetLatestChunkIntervalBeforeCutoff(
+   GetChunkIntervalBeforeCutoff(
      DateTimeOffset threshold,
      IEnumerable<Type> entityTypes,
      CancellationToken cancellationToken

--- a/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
+++ b/src/Ozds.Data/Queries/TimescaleChunkIntervalQueries.cs
@@ -1,11 +1,8 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Ozds.Assets.Queries.Abstractions;
 using Ozds.Data.Attributes;
 using Ozds.Data.Context;
 using Ozds.Data.Extensions;
-using Ozds.Data.Reflection;
 
 namespace Ozds.Data.Queries;
 
@@ -25,19 +22,19 @@ public class TimescaleChunkIntervalQueries(
   IDbContextFactory<DataDbContext> factory
 ) : IQueries
 {
-
   public async Task<ChunkIntervalInfo?>
-   GetLatestChunkIntervalBeforeCutoff(
-     DateTimeOffset threshold,
-     Type entityType,
-     CancellationToken cancellationToken
-   )
+    GetLatestChunkIntervalBeforeCutoff(
+      DateTimeOffset threshold,
+      Type entityType,
+      CancellationToken cancellationToken
+    )
   {
-
-    await using var context = await factory.CreateDbContextAsync(cancellationToken);
+    await using var context =
+      await factory.CreateDbContextAsync(cancellationToken);
 
     var tableName = context.GetTableName(entityType)
-      ?? throw new InvalidOperationException($"Table name not found for for {entityType.Name}.");
+      ?? throw new InvalidOperationException(
+        $"Table name not found for for {entityType.Name}.");
 
     const string sqlString = """
       SELECT hypertable_name  AS    "HypertableName",
@@ -50,29 +47,31 @@ public class TimescaleChunkIntervalQueries(
       """;
 
     return (await context.DapperCommand<ChunkIntervalInfo>(
-        sqlString,
-        cancellationToken,
-        new
-        {
-          TableName = tableName,
-          Threshold = threshold
-        }
-      )).FirstOrDefault();
+      sqlString,
+      cancellationToken,
+      new
+      {
+        TableName = tableName,
+        Threshold = threshold
+      }
+    )).FirstOrDefault();
   }
 
   public async Task<List<ChunkIntervalInfo>>
-   GetLatestChunkIntervalBeforeCutoff(
-     DateTimeOffset threshold,
-     IEnumerable<Type> entityTypes,
-     CancellationToken cancellationToken
-   )
+    GetLatestChunkIntervalBeforeCutoff(
+      DateTimeOffset threshold,
+      IEnumerable<Type> entityTypes,
+      CancellationToken cancellationToken
+    )
   {
-
-    await using var context = await factory.CreateDbContextAsync(cancellationToken);
+    await using var context =
+      await factory.CreateDbContextAsync(cancellationToken);
 
     var hypertableNames = entityTypes
-      .Select(x => context.GetTableName(x)
-        ?? throw new InvalidOperationException($"Table name not found for for {x.Name}.")
+      .Select(
+        x => context.GetTableName(x)
+          ?? throw new InvalidOperationException(
+            $"Table name not found for for {x.Name}.")
       )
       .ToArray()!;
 
@@ -88,13 +87,13 @@ public class TimescaleChunkIntervalQueries(
       """;
 
     return await context.DapperCommand<ChunkIntervalInfo>(
-        sqlString,
-        cancellationToken,
-        new
-        {
-          Threshold = threshold,
-          HypertableNames = hypertableNames
-        }
-      );
+      sqlString,
+      cancellationToken,
+      new
+      {
+        Threshold = threshold,
+        HypertableNames = hypertableNames
+      }
+    );
   }
 }

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -35,7 +35,6 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
   private TimeSpan Interval { get; }
 
-  // TODO: make it work with delete_chunks
   [Test]
   public async Task MeasurementDeletionJobReactor_Reacts(
     CancellationToken cancellationToken
@@ -65,7 +64,7 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       .ToListAsync(cancellationToken);
 
     var lastChunkByModelType = (await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
-    .GetLatestChunkIntervalBeforeCutoff(
+    .GetChunkIntervalBeforeCutoff(
       deletionCutoff,
       dataReflector.MeasurementTypes,
       cancellationToken)

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -66,16 +66,16 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
     var deletedChunkIntervalByModelType =
     (
       await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
-      .GetChunkIntervalBeforeCutoff(
-        deletionCutoff,
-        dataReflector.MeasurementTypes,
-        cancellationToken)
+        .GetChunkIntervalBeforeCutoff(
+          deletionCutoff,
+          dataReflector.MeasurementTypes,
+          cancellationToken)
     ).ToDictionary(
       x =>
         Services.GetRequiredService<ModelEntityConverter>()
-        .ModelType(
+          .ModelType(
             dataReflector.ResolveEntityTypeFromTable(x.HypertableName)
-        )
+          )
     );
 
     itemsBefore.Should().AllSatisfy(
@@ -99,8 +99,9 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
     var determinedItemsAfter = itemsBefore.Where(
       x =>
-      !deletedChunkIntervalByModelType.TryGetValue(x.GetType(), out var chunkInfo)
-      || x.Timestamp > chunkInfo.RangeEnd
+        !deletedChunkIntervalByModelType.TryGetValue(
+          x.GetType(), out var chunkInfo)
+        || x.Timestamp > chunkInfo.RangeEnd
     ).ToList();
 
     var determinedTimestampMinimum = itemsBefore.Min(x => x.Timestamp);

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -1,7 +1,11 @@
+using Ozds.Business.Conversion;
 using Ozds.Business.Models.Abstractions;
 using Ozds.Business.Queries;
 using Ozds.Fake.Identification;
 using Ozds.Server.Test.Base;
+
+using DataEntityReflector = Ozds.Data.Reflection.EntityReflector;
+using DataTimescaleChunkIntervalQueries = Ozds.Data.Queries.TimescaleChunkIntervalQueries;
 
 namespace Ozds.Server.Test.Reactors;
 
@@ -43,6 +47,8 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
     var dateFrom = dateTo - Interval * 2;
     var deletionCutoff = dateFrom + Interval;
 
+    var reflector = Services.GetRequiredService<DataEntityReflector>();
+
     var itemsBefore = await Measurement
       .Insert(
         [
@@ -58,6 +64,19 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       .Where(x => x is not IAggregate)
       .ToListAsync(cancellationToken);
 
+    var lastChunkByModelType = (await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
+    .GetLatestChunkIntervalBeforeCutoff(
+      deletionCutoff,
+      reflector.MeasurementTypes,
+      cancellationToken)
+    ).ToDictionary(
+      x =>
+        Services.GetRequiredService<ModelEntityConverter>()
+        .ModelType(
+            reflector.ResolveEntityTypeFromTable(x.HypertableName)
+        )
+    );
+
     itemsBefore.Should().AllSatisfy(
       x =>
         x.Timestamp.Should().BeAfter(dateFrom));
@@ -65,7 +84,7 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       x =>
         x.Timestamp.Should().BeBefore(dateTo));
 
-    await Task.Delay(TimeSpan.FromMinutes(2), cancellationToken);
+    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
 
     var itemsAfter = await Services.GetRequiredService<MeasurementQueries>()
       .ReadByMeasurementLocationIds(
@@ -77,10 +96,18 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
         cancellationToken
       );
 
-    itemsAfter.TotalCount.Should().BeLessThan(itemsBefore.Count);
+    var determinedItemsAfter = itemsBefore.Where(
+      x =>
+      !lastChunkByModelType.TryGetValue(x.GetType(), out var chunkInfo)
+      || x.Timestamp > chunkInfo.RangeEnd
+    ).ToList();
+
+    var determinedTimestampMinimum = itemsBefore.Min(x => x.Timestamp);
+
+    itemsAfter.TotalCount.Should().BeLessThanOrEqualTo(determinedItemsAfter.Count);
 
     itemsAfter.Items.Should().AllSatisfy(
       x =>
-        x.Timestamp.Should().BeAfter(deletionCutoff));
+        x.Timestamp.Should().BeOnOrAfter(determinedTimestampMinimum));
   }
 }

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -63,11 +63,13 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       .Where(x => x is not IAggregate)
       .ToListAsync(cancellationToken);
 
-    var lastChunkByModelType = (await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
-    .GetChunkIntervalBeforeCutoff(
-      deletionCutoff,
-      dataReflector.MeasurementTypes,
-      cancellationToken)
+    var deletedChunkIntervalByModelType =
+    (
+      await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
+      .GetChunkIntervalBeforeCutoff(
+        deletionCutoff,
+        dataReflector.MeasurementTypes,
+        cancellationToken)
     ).ToDictionary(
       x =>
         Services.GetRequiredService<ModelEntityConverter>()
@@ -97,7 +99,7 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
     var determinedItemsAfter = itemsBefore.Where(
       x =>
-      !lastChunkByModelType.TryGetValue(x.GetType(), out var chunkInfo)
+      !deletedChunkIntervalByModelType.TryGetValue(x.GetType(), out var chunkInfo)
       || x.Timestamp > chunkInfo.RangeEnd
     ).ToList();
 

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -31,6 +31,7 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
   private TimeSpan Interval { get; }
 
+  // TODO: make it work with delete_chunks
   [Test]
   public async Task MeasurementDeletionJobReactor_Reacts(
     CancellationToken cancellationToken

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -3,9 +3,9 @@ using Ozds.Business.Models.Abstractions;
 using Ozds.Business.Queries;
 using Ozds.Fake.Identification;
 using Ozds.Server.Test.Base;
-
 using DataEntityReflector = Ozds.Data.Reflection.EntityReflector;
-using DataTimescaleChunkIntervalQueries = Ozds.Data.Queries.TimescaleChunkIntervalQueries;
+using DataTimescaleChunkIntervalQueries =
+  Ozds.Data.Queries.TimescaleChunkIntervalQueries;
 
 namespace Ozds.Server.Test.Reactors;
 
@@ -64,18 +64,19 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
       .Where(x => x is not IAggregate)
       .ToListAsync(cancellationToken);
 
-    var lastChunkByModelType = (await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
-    .GetLatestChunkIntervalBeforeCutoff(
-      deletionCutoff,
-      reflector.MeasurementTypes,
-      cancellationToken)
-    ).ToDictionary(
-      x =>
-        Services.GetRequiredService<ModelEntityConverter>()
-        .ModelType(
-            reflector.ResolveEntityTypeFromTable(x.HypertableName)
-        )
-    );
+    var lastChunkByModelType = (await Services
+        .GetRequiredService<DataTimescaleChunkIntervalQueries>()
+        .GetLatestChunkIntervalBeforeCutoff(
+          deletionCutoff,
+          reflector.MeasurementTypes,
+          cancellationToken)
+      ).ToDictionary(
+        x =>
+          Services.GetRequiredService<ModelEntityConverter>()
+            .ModelType(
+              reflector.ResolveEntityTypeFromTable(x.HypertableName)
+            )
+      );
 
     itemsBefore.Should().AllSatisfy(
       x =>
@@ -98,13 +99,14 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
     var determinedItemsAfter = itemsBefore.Where(
       x =>
-      !lastChunkByModelType.TryGetValue(x.GetType(), out var chunkInfo)
-      || x.Timestamp > chunkInfo.RangeEnd
+        !lastChunkByModelType.TryGetValue(x.GetType(), out var chunkInfo)
+        || x.Timestamp > chunkInfo.RangeEnd
     ).ToList();
 
     var determinedTimestampMinimum = itemsBefore.Min(x => x.Timestamp);
 
-    itemsAfter.TotalCount.Should().BeLessThanOrEqualTo(determinedItemsAfter.Count);
+    itemsAfter.TotalCount.Should()
+      .BeLessThanOrEqualTo(determinedItemsAfter.Count);
 
     itemsAfter.Items.Should().AllSatisfy(
       x =>

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -47,7 +47,7 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
     var dateFrom = dateTo - Interval * 2;
     var deletionCutoff = dateFrom + Interval;
 
-    var reflector = Services.GetRequiredService<DataEntityReflector>();
+    var dataReflector = Services.GetRequiredService<DataEntityReflector>();
 
     var itemsBefore = await Measurement
       .Insert(
@@ -67,13 +67,13 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
     var lastChunkByModelType = (await Services.GetRequiredService<DataTimescaleChunkIntervalQueries>()
     .GetLatestChunkIntervalBeforeCutoff(
       deletionCutoff,
-      reflector.MeasurementTypes,
+      dataReflector.MeasurementTypes,
       cancellationToken)
     ).ToDictionary(
       x =>
         Services.GetRequiredService<ModelEntityConverter>()
         .ModelType(
-            reflector.ResolveEntityTypeFromTable(x.HypertableName)
+            dataReflector.ResolveEntityTypeFromTable(x.HypertableName)
         )
     );
 


### PR DESCRIPTION
# Task
(New PR because I forgot to squash the old one before merge with dev)

Fixes #243.
Closes #243.

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Added chunk queries by which we will then determine what elements should be deleted from the fixture returned elements in deletion test. So test is much more determined by parameters of chunk scales present in database.

Since to make the test pass you have to achieve high level of granularity in the buckets in timescale which then kinda defeats their purpose.

## Testing

Run the test "measurementdeletionjobreactortest", don't forget to include fix - #262 since item count is also affected by the problem with converters not returning first item.
