### PR TITLE
268 network user invoice decimal precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Removed
+
+- duplicated change log left from .NET 10 rebase
+
+### Added
+
+- add extensions in business now have `PrimitiveRoundingExtensions` which
+  contain methods `Round` which round and return double and decimal respectfully
+- add sentinel injector which is used to overload specific values of invoice
+  model or calculator to fail tests on use of wrong rounding method
+
+### Changed
+
+- change all calculators and calculator tests for business now use rounding type
+  `MidpointRounding.AwayFromZero` defined in `PrimitiveRoundingExtensions`
+
 ## [1.8.0] - 2025-02-19
 
 ### Added
@@ -26,12 +42,6 @@ and adheres to [Semantic Versioning](https://semver.org/).
   and params of chart control persist after reloading the page)
 - fix ReadLastByMeasurementLocationIds now returns latest measurement info for
   all meters that have measurements
-- updated .NET version from 8 to 10
-- updated Azure.Identity package
-- replaced deprecated implementation on ServiceCryptography
-- update System.Linq.Async package to version 7.0.0
-- fixed problem with removed async functions from package System.Linq.Async on
-  RegexService.cs and MeasurementMutations.cs
 - updated .NET version from 8 to 10
 - updated Azure.Identity package
 - replaced deprecated implementation on ServiceCryptography

--- a/src/Ozds.Business/Extensions/PrimitiveRoundingExtensions.cs
+++ b/src/Ozds.Business/Extensions/PrimitiveRoundingExtensions.cs
@@ -1,0 +1,16 @@
+using AngleSharp.Io;
+
+namespace Ozds.Business.Extensions;
+
+public static class PrimitiveRoundingExtensions
+{
+  public static decimal Round(decimal value, int digits)
+  {
+    return System.Math.Round(value, digits, MidpointRounding.AwayFromZero);
+  }
+
+  public static double Round(double value, int digits)
+  {
+    return System.Math.Round(value, digits, MidpointRounding.AwayFromZero);
+  }
+}

--- a/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class SupplyActiveEnergyTotalImportT1CalculationItemCalculator
@@ -34,7 +36,7 @@ public class SupplyActiveEnergyTotalImportT1CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class SupplyActiveEnergyTotalImportT1CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new SupplyActiveEnergyTotalImportT1CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class SupplyActiveEnergyTotalImportT2CalculationItemCalculator
@@ -34,7 +36,7 @@ public class SupplyActiveEnergyTotalImportT2CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class SupplyActiveEnergyTotalImportT2CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new SupplyActiveEnergyTotalImportT2CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/SupplyBusinessUsageCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyBusinessUsageCalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class SupplyBusinessUsageCalculationItemCalculator
@@ -34,7 +36,7 @@ public class SupplyBusinessUsageCalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class SupplyBusinessUsageCalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new SupplyBusinessUsageCalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/SupplyBusinessUsageCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyBusinessUsageCalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class SupplyRenewableEnergyCalculationItemCalculator
@@ -34,7 +36,7 @@ public class SupplyRenewableEnergyCalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class SupplyRenewableEnergyCalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new SupplyRenewableEnergyCalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class UsageActiveEnergyTotalImportT0CalculationItemCalculator
@@ -34,7 +36,7 @@ public class UsageActiveEnergyTotalImportT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class UsageActiveEnergyTotalImportT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new UsageActiveEnergyTotalImportT0CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class UsageActiveEnergyTotalImportT1CalculationItemCalculator
@@ -34,7 +36,7 @@ public class UsageActiveEnergyTotalImportT1CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class UsageActiveEnergyTotalImportT1CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new UsageActiveEnergyTotalImportT1CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class UsageActiveEnergyTotalImportT2CalculationItemCalculator
@@ -34,7 +36,7 @@ public class UsageActiveEnergyTotalImportT2CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var minKilo = System.Math.Round(min / 1000M, 2);
+    var minKilo = Round(min / 1000M, 2);
 
     var max = aggregates
       .Last()
@@ -43,13 +45,13 @@ public class UsageActiveEnergyTotalImportT2CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var maxKilo = System.Math.Round(max / 1000M, 2);
+    var maxKilo = Round(max / 1000M, 2);
 
-    var amountKilo = System.Math.Round(maxKilo - minKilo, 0);
+    var amountKilo = Round(maxKilo - minKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new UsageActiveEnergyTotalImportT2CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class UsageActivePowerTotalImportT1PeakCalculationItemCalculator
@@ -36,13 +38,13 @@ public class UsageActivePowerTotalImportT1PeakCalculationItemCalculator
       .DefaultIfEmpty()
       .Max();
 
-    var peakKilo = System.Math.Round(peak / 1000M, 2);
+    var peakKilo = Round(peak / 1000M, 2);
 
-    var amountKilo = System.Math.Round(peakKilo, 0);
+    var amountKilo = Round(peakKilo, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 3);
+    var price = Round(calculationBasis.Price_EUR, 3);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(amountKilo * price, 2);
 
     return new UsageActivePowerTotalImportT1PeakCalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/UsageMeterFeeCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageMeterFeeCalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;

--- a/src/Ozds.Business/Finance/Complex/UsageMeterFeeCalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageMeterFeeCalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class UsageMeterFeeCalculationItemCalculator
@@ -11,11 +13,11 @@ public class UsageMeterFeeCalculationItemCalculator
     CalculationItemBasisModel calculationBasis
   )
   {
-    var amount = System.Math.Round(1M, 0);
+    var amount = Round(1M, 0);
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 3);
+    var price = Round(calculationBasis.Price_EUR, 3);
 
-    var total = System.Math.Round(amount * price, 2);
+    var total = Round(amount * price, 2);
 
     return new UsageMeterFeeCalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculator.cs
@@ -2,6 +2,8 @@ using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Complex;
 
 public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
@@ -41,7 +43,9 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveImportMinKilo = System.Math.Round(reactiveImportMin / 1000M, 2);
+    var reactiveImportMinKilo = Round(
+      reactiveImportMin / 1000M,
+      2);
 
     var reactiveImportMax = aggregates
       .Last()
@@ -50,9 +54,11 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveImportMaxKilo = System.Math.Round(reactiveImportMax / 1000M, 2);
+    var reactiveImportMaxKilo = Round(
+      reactiveImportMax / 1000M,
+      2);
 
-    var reactiveImportAmountKilo = System.Math.Round(
+    var reactiveImportAmountKilo = Round(
       reactiveImportMaxKilo - reactiveImportMinKilo,
       0
     );
@@ -64,7 +70,9 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveExportMinKilo = System.Math.Round(reactiveExportMin / 1000M, 2);
+    var reactiveExportMinKilo = Round(
+      reactiveExportMin / 1000M,
+      2);
 
     var reactiveExportMax = aggregates
       .Last()
@@ -73,9 +81,11 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveExportMaxKilo = System.Math.Round(reactiveExportMax / 1000M, 2);
+    var reactiveExportMaxKilo = Round(
+      reactiveExportMax / 1000M,
+      2);
 
-    var reactiveExportAmountKilo = System.Math.Round(
+    var reactiveExportAmountKilo = Round(
       reactiveExportMaxKilo - reactiveExportMinKilo,
       0
     );
@@ -87,7 +97,9 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var activeImportMinKilo = System.Math.Round(activeImportMin / 1000M, 2);
+    var activeImportMinKilo = Round(
+      activeImportMin / 1000M,
+      2);
 
     var activeImportMax = aggregates
       .Last()
@@ -96,14 +108,16 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var activeImportMaxKilo = System.Math.Round(activeImportMax / 1000M, 2);
+    var activeImportMaxKilo = Round(
+      activeImportMax / 1000M,
+      2);
 
-    var activeImportAmountKilo = System.Math.Round(
+    var activeImportAmountKilo = Round(
       activeImportMaxKilo - activeImportMinKilo,
       0
     );
 
-    var amountKilo = System.Math.Round(
+    var amountKilo = Round(
       System.Math.Max(
         System.Math.Abs(reactiveImportAmountKilo)
           + System.Math.Abs(reactiveExportAmountKilo)
@@ -113,9 +127,13 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       0
     );
 
-    var price = System.Math.Round(calculationBasis.Price_EUR, 6);
+    var price = Round(
+      calculationBasis.Price_EUR,
+      6);
 
-    var total = System.Math.Round(amountKilo * price, 2);
+    var total = Round(
+      amountKilo * price,
+      2);
 
     return new UsageReactiveEnergyTotalRampedT0CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculator.cs
+++ b/src/Ozds.Business/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculator.cs
@@ -1,7 +1,6 @@
 using Ozds.Business.Finance.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Complex;
@@ -43,9 +42,7 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveImportMinKilo = Round(
-      reactiveImportMin / 1000M,
-      2);
+    var reactiveImportMinKilo = Round(reactiveImportMin / 1000M, 2);
 
     var reactiveImportMax = aggregates
       .Last()
@@ -54,9 +51,7 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveImportMaxKilo = Round(
-      reactiveImportMax / 1000M,
-      2);
+    var reactiveImportMaxKilo = Round(reactiveImportMax / 1000M, 2);
 
     var reactiveImportAmountKilo = Round(
       reactiveImportMaxKilo - reactiveImportMinKilo,
@@ -70,9 +65,7 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveExportMinKilo = Round(
-      reactiveExportMin / 1000M,
-      2);
+    var reactiveExportMinKilo = Round(reactiveExportMin / 1000M, 2);
 
     var reactiveExportMax = aggregates
       .Last()
@@ -81,9 +74,7 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var reactiveExportMaxKilo = Round(
-      reactiveExportMax / 1000M,
-      2);
+    var reactiveExportMaxKilo = Round(reactiveExportMax / 1000M, 2);
 
     var reactiveExportAmountKilo = Round(
       reactiveExportMaxKilo - reactiveExportMinKilo,
@@ -97,9 +88,7 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var activeImportMinKilo = Round(
-      activeImportMin / 1000M,
-      2);
+    var activeImportMinKilo = Round(activeImportMin / 1000M, 2);
 
     var activeImportMax = aggregates
       .Last()
@@ -108,9 +97,7 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       .AggregateMin()
       .PhaseSum();
 
-    var activeImportMaxKilo = Round(
-      activeImportMax / 1000M,
-      2);
+    var activeImportMaxKilo = Round(activeImportMax / 1000M, 2);
 
     var activeImportAmountKilo = Round(
       activeImportMaxKilo - activeImportMinKilo,
@@ -127,13 +114,9 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculator
       0
     );
 
-    var price = Round(
-      calculationBasis.Price_EUR,
-      6);
+    var price = Round(calculationBasis.Price_EUR, 6);
 
-    var total = Round(
-      amountKilo * price,
-      2);
+    var total = Round(amountKilo * price, 2);
 
     return new UsageReactiveEnergyTotalRampedT0CalculationItemModel
     {

--- a/src/Ozds.Business/Finance/Implementations/BlueLowNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/BlueLowNetworkUserCalculationCalculator.cs
@@ -7,10 +7,14 @@ using Ozds.Business.Queries;
 
 namespace Ozds.Business.Finance.Implementations;
 
-public class BlueLowNetworkUserCalculationCalculator(
-  CalculationItemCalculator calculationItemCalculator,
-  ClockQueries clock
-) : NetworkUserCalculationCalculator<BlueLowNetworkUserCatalogueModel>
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
+public class
+  BlueLowNetworkUserCalculationCalculator(
+    CalculationItemCalculator calculationItemCalculator,
+    ClockQueries clock)
+  : NetworkUserCalculationCalculator<
+    BlueLowNetworkUserCatalogueModel>
 {
   private readonly CalculationItemCalculator _calculationItemCalculator =
     calculationItemCalculator;
@@ -67,7 +71,7 @@ public class BlueLowNetworkUserCalculationCalculator(
         }
       );
 
-    var usageFeeTotal = System.Math.Round(
+    var usageFeeTotal = Round(
       usageActiveEnergyTotalImportT0.Total
         + usageReactiveEnergyTotalRampedT0.Total
         + usageMeterFee.Total,
@@ -134,7 +138,7 @@ public class BlueLowNetworkUserCalculationCalculator(
         }
       );
 
-    var supplyFeeTotal = System.Math.Round(
+    var supplyFeeTotal = Round(
       supplyActiveEnergyTotalImportT1.Total
         + supplyActiveEnergyTotalImportT2.Total
         + supplyBusinessUsageFee.Total
@@ -142,7 +146,7 @@ public class BlueLowNetworkUserCalculationCalculator(
       2
     );
 
-    var total = System.Math.Round(usageFeeTotal + supplyFeeTotal, 2);
+    var total = Round(usageFeeTotal + supplyFeeTotal, 2);
 
     var now = clock.Timestamp();
 

--- a/src/Ozds.Business/Finance/Implementations/BlueLowNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/BlueLowNetworkUserCalculationCalculator.cs
@@ -9,12 +9,10 @@ namespace Ozds.Business.Finance.Implementations;
 
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
-public class
-  BlueLowNetworkUserCalculationCalculator(
-    CalculationItemCalculator calculationItemCalculator,
-    ClockQueries clock)
-  : NetworkUserCalculationCalculator<
-    BlueLowNetworkUserCatalogueModel>
+public class BlueLowNetworkUserCalculationCalculator(
+  CalculationItemCalculator calculationItemCalculator,
+  ClockQueries clock
+) : NetworkUserCalculationCalculator<BlueLowNetworkUserCatalogueModel>
 {
   private readonly CalculationItemCalculator _calculationItemCalculator =
     calculationItemCalculator;

--- a/src/Ozds.Business/Finance/Implementations/NetworkUserInvoiceCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/NetworkUserInvoiceCalculator.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Implementations;
 
 public class NetworkUserInvoiceCalculator(
@@ -23,7 +25,7 @@ public class NetworkUserInvoiceCalculator(
       .NetworkUserCalculationBases.Select(_calculationCalculator.Calculate)
       .ToList();
 
-    var usageActiveEnergyTotalImportT0Fee = System.Math.Round(
+    var usageActiveEnergyTotalImportT0Fee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -33,7 +35,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var usageActiveEnergyTotalImportT1Fee = System.Math.Round(
+    var usageActiveEnergyTotalImportT1Fee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -43,7 +45,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var usageActiveEnergyTotalImportT2Fee = System.Math.Round(
+    var usageActiveEnergyTotalImportT2Fee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -53,7 +55,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var usageActivePowerTotalImportT1PeakFee = System.Math.Round(
+    var usageActivePowerTotalImportT1PeakFee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -63,7 +65,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var usageReactiveEnergyTotalRampedT0Fee = System.Math.Round(
+    var usageReactiveEnergyTotalRampedT0Fee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -73,7 +75,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var usageMeterFee = System.Math.Round(
+    var usageMeterFee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -83,7 +85,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var usageFeeTotal = System.Math.Round(
+    var usageFeeTotal = Round(
       usageActiveEnergyTotalImportT0Fee
         + usageActiveEnergyTotalImportT1Fee
         + usageActiveEnergyTotalImportT2Fee
@@ -93,7 +95,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var supplyActiveEnergyTotalImportT1Fee = System.Math.Round(
+    var supplyActiveEnergyTotalImportT1Fee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -103,7 +105,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var supplyActiveEnergyTotalImportT2Fee = System.Math.Round(
+    var supplyActiveEnergyTotalImportT2Fee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -113,7 +115,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var supplyBusinessUsageFee = System.Math.Round(
+    var supplyBusinessUsageFee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -123,7 +125,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var supplyRenewableEnergyFee = System.Math.Round(
+    var supplyRenewableEnergyFee = Round(
       calculations
         .OfType<IMeteredNetworkUserCalculation>()
         .SelectMany(calculation =>
@@ -133,7 +135,7 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var supplyFeeTotal = System.Math.Round(
+    var supplyFeeTotal = Round(
       supplyActiveEnergyTotalImportT1Fee
         + supplyActiveEnergyTotalImportT2Fee
         + supplyBusinessUsageFee
@@ -141,13 +143,12 @@ public class NetworkUserInvoiceCalculator(
       2
     );
 
-    var total = System.Math.Round(usageFeeTotal + supplyFeeTotal, 2);
-    var taxRate = System.Math.Round(
+    var total = Round(usageFeeTotal + supplyFeeTotal, 2);
+    var taxRate = Round(
       basis.RegulatoryCatalogue.TaxRate_Percent,
-      2
-    );
-    var tax = System.Math.Round(total * taxRate / 100M, 2);
-    var totalWithTax = System.Math.Round(total + tax, 2);
+      2);
+    var tax = Round(total * taxRate / 100M, 2);
+    var totalWithTax = Round(total + tax, 2);
 
     var now = clock.Timestamp();
 

--- a/src/Ozds.Business/Finance/Implementations/NetworkUserInvoiceCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/NetworkUserInvoiceCalculator.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Abstractions;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Implementations;
@@ -144,9 +143,7 @@ public class NetworkUserInvoiceCalculator(
     );
 
     var total = Round(usageFeeTotal + supplyFeeTotal, 2);
-    var taxRate = Round(
-      basis.RegulatoryCatalogue.TaxRate_Percent,
-      2);
+    var taxRate = Round(basis.RegulatoryCatalogue.TaxRate_Percent, 2);
     var tax = Round(total * taxRate / 100M, 2);
     var totalWithTax = Round(total + tax, 2);
 

--- a/src/Ozds.Business/Finance/Implementations/RedLowNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/RedLowNetworkUserCalculationCalculator.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Implementations;

--- a/src/Ozds.Business/Finance/Implementations/RedLowNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/RedLowNetworkUserCalculationCalculator.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Implementations;
 
 public class RedLowNetworkUserCalculationCalculator(
@@ -97,7 +99,7 @@ public class RedLowNetworkUserCalculationCalculator(
         }
       );
 
-    var usageFeeTotal = System.Math.Round(
+    var usageFeeTotal = Round(
       usageActiveEnergyTotalImportT1.Total
         + usageActiveEnergyTotalImportT2.Total
         + usageActivePowerTotalImportT1Peak.Total
@@ -166,7 +168,7 @@ public class RedLowNetworkUserCalculationCalculator(
         }
       );
 
-    var supplyFeeTotal = System.Math.Round(
+    var supplyFeeTotal = Round(
       supplyActiveEnergyTotalImportT1.Total
         + supplyActiveEnergyTotalImportT2.Total
         + supplyBusinessUsageFee.Total
@@ -174,7 +176,7 @@ public class RedLowNetworkUserCalculationCalculator(
       2
     );
 
-    var total = System.Math.Round(usageFeeTotal + supplyFeeTotal, 2);
+    var total = Round(usageFeeTotal + supplyFeeTotal, 2);
 
     var now = clock.Timestamp();
 

--- a/src/Ozds.Business/Finance/Implementations/WhiteLowNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/WhiteLowNetworkUserCalculationCalculator.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Implementations;
 
 public class WhiteLowNetworkUserCalculationCalculator(
@@ -82,7 +84,7 @@ public class WhiteLowNetworkUserCalculationCalculator(
         }
       );
 
-    var usageFeeTotal = System.Math.Round(
+    var usageFeeTotal = Round(
       usageActiveEnergyTotalImportT1.Total
         + usageActiveEnergyTotalImportT2.Total
         + usageReactiveEnergyTotalRampedT0.Total
@@ -150,7 +152,7 @@ public class WhiteLowNetworkUserCalculationCalculator(
         }
       );
 
-    var supplyFeeTotal = System.Math.Round(
+    var supplyFeeTotal = Round(
       supplyActiveEnergyTotalImportT1.Total
         + supplyActiveEnergyTotalImportT2.Total
         + supplyBusinessUsageFee.Total
@@ -158,7 +160,7 @@ public class WhiteLowNetworkUserCalculationCalculator(
       2
     );
 
-    var total = System.Math.Round(usageFeeTotal + supplyFeeTotal, 2);
+    var total = Round(usageFeeTotal + supplyFeeTotal, 2);
 
     var now = clock.Timestamp();
 

--- a/src/Ozds.Business/Finance/Implementations/WhiteLowNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/WhiteLowNetworkUserCalculationCalculator.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Implementations;

--- a/src/Ozds.Business/Finance/Implementations/WhiteMediumNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/WhiteMediumNetworkUserCalculationCalculator.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Finance.Implementations;

--- a/src/Ozds.Business/Finance/Implementations/WhiteMediumNetworkUserCalculationCalculator.cs
+++ b/src/Ozds.Business/Finance/Implementations/WhiteMediumNetworkUserCalculationCalculator.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Finance.Implementations;
 
 public class WhiteMediumNetworkUserCalculationCalculator(
@@ -97,7 +99,7 @@ public class WhiteMediumNetworkUserCalculationCalculator(
         }
       );
 
-    var usageFeeTotal = System.Math.Round(
+    var usageFeeTotal = Round(
       usageActiveEnergyTotalImportT1.Total
         + usageActiveEnergyTotalImportT2.Total
         + usageActivePowerTotalImportT1Peak.Total
@@ -166,7 +168,7 @@ public class WhiteMediumNetworkUserCalculationCalculator(
         }
       );
 
-    var supplyFeeTotal = System.Math.Round(
+    var supplyFeeTotal = Round(
       supplyActiveEnergyTotalImportT1.Total
         + supplyActiveEnergyTotalImportT2.Total
         + supplyBusinessUsageFee.Total
@@ -174,7 +176,7 @@ public class WhiteMediumNetworkUserCalculationCalculator(
       2
     );
 
-    var total = System.Math.Round(usageFeeTotal + supplyFeeTotal, 2);
+    var total = Round(usageFeeTotal + supplyFeeTotal, 2);
 
     var now = clock.Timestamp();
 

--- a/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
@@ -11,6 +11,8 @@ using Ozds.Time.Queries.Abstractions;
 
 // NITPICK: test issuer and date
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance;
 
 public class BlueLowNetworkUserCalculationCalculatorTest
@@ -56,79 +58,62 @@ public class BlueLowNetworkUserCalculationCalculatorTest
 
         var faker = new Faker();
 
-        x.UsageActiveEnergyTotalImportT0.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageMeterFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageFeeTotal_EUR = System.Math.Round(
-          x.UsageActiveEnergyTotalImportT0.Total
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT0.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = System.Math.Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
+            2);
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = System.Math.Round(
-          x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-          2
-        );
+            2);
+          x.Total_EUR = Round(
+            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+            2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
@@ -46,8 +46,9 @@ public class BlueLowNetworkUserCalculationCalculatorTest
       )
       .Build<BlueLowNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select(x =>
+      .Select((x, i) =>
       {
+
         x.UsageNetworkUserCatalogueId =
           x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
         x.SupplyRegulatoryCatalogueId = x.ArchivedSupplyRegulatoryCatalogue.Id;
@@ -56,64 +57,71 @@ public class BlueLowNetworkUserCalculationCalculatorTest
         x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
         x.MeterId = x.ArchivedMeter.Id;
 
+        if (i == 0)
+        {
+          MidpointRoundingSentinel
+            .InjectMidpointRoundingSentinel(x);
+          return x;
+        }
+
         var faker = new Faker();
 
-          x.UsageActiveEnergyTotalImportT0.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT0.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.UsageMeterFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageMeterFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.SupplyBusinessUsageFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyBusinessUsageFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.SupplyRenewableEnergyFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyRenewableEnergyFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue),
+          2);
 
-          x.UsageFeeTotal_EUR = Round(
-            x.UsageActiveEnergyTotalImportT0.Total
-            + x.UsageReactiveEnergyTotalRampedT0.Total
-            + x.UsageMeterFee.Total,
-            2);
-          x.SupplyFeeTotal_EUR = Round(
-            x.SupplyActiveEnergyTotalImportT1.Total
-            + x.SupplyActiveEnergyTotalImportT2.Total
-            + x.SupplyBusinessUsageFee.Total
-            + x.SupplyRenewableEnergyFee.Total,
-            2);
-          x.Total_EUR = Round(
-            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-            2);
+        x.UsageFeeTotal_EUR = Round(
+          x.UsageActiveEnergyTotalImportT0.Total
+          + x.UsageReactiveEnergyTotalRampedT0.Total
+          + x.UsageMeterFee.Total,
+          2);
+        x.SupplyFeeTotal_EUR = Round(
+          x.SupplyActiveEnergyTotalImportT1.Total
+          + x.SupplyActiveEnergyTotalImportT2.Total
+          + x.SupplyBusinessUsageFee.Total
+          + x.SupplyRenewableEnergyFee.Total,
+          2);
+        x.Total_EUR = Round(
+          x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+          2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
@@ -7,6 +7,7 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
+using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
 
 // NITPICK: test issuer and date
@@ -60,7 +61,7 @@ public class BlueLowNetworkUserCalculationCalculatorTest
         if (i == 0)
         {
           MidpointRoundingSentinel
-            .InjectMidpointRoundingSentinel(x);
+            .InjectCalculationSentinel(x);
           return x;
         }
 

--- a/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/BlueLowNetworkUserCalculationCalculatorTest.cs
@@ -9,7 +9,6 @@ using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
-
 // NITPICK: test issuer and date
 
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
@@ -47,85 +46,100 @@ public class BlueLowNetworkUserCalculationCalculatorTest
       )
       .Build<BlueLowNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select((x, i) =>
-      {
-
-        x.UsageNetworkUserCatalogueId =
-          x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
-        x.SupplyRegulatoryCatalogueId = x.ArchivedSupplyRegulatoryCatalogue.Id;
-        x.NetworkUserMeasurementLocationId =
-          x.ArchivedNetworkUserMeasurementLocation.Id;
-        x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
-        x.MeterId = x.ArchivedMeter.Id;
-
-        if (i == 0)
+      .Select(
+        (x, i) =>
         {
-          MidpointRoundingSentinel
-            .InjectCalculationSentinel(x);
+          x.UsageNetworkUserCatalogueId =
+            x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
+          x.SupplyRegulatoryCatalogueId =
+            x.ArchivedSupplyRegulatoryCatalogue.Id;
+          x.NetworkUserMeasurementLocationId =
+            x.ArchivedNetworkUserMeasurementLocation.Id;
+          x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
+          x.MeterId = x.ArchivedMeter.Id;
+
+          if (i == 0)
+          {
+            MidpointRoundingSentinel.InjectCalculationSentinel(x);
+            return x;
+          }
+
+          var faker = new Faker();
+
+          x.UsageActiveEnergyTotalImportT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT0.Total
+              + x.UsageReactiveEnergyTotalRampedT0.Total
+              + x.UsageMeterFee.Total,
+            2
+          );
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
+              + x.SupplyActiveEnergyTotalImportT2.Total
+              + x.SupplyBusinessUsageFee.Total
+              + x.SupplyRenewableEnergyFee.Total,
+            2
+          );
+          x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
+
           return x;
         }
-
-        var faker = new Faker();
-
-        x.UsageActiveEnergyTotalImportT0.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.UsageMeterFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.SupplyBusinessUsageFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.SupplyRenewableEnergyFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue),
-          2);
-
-        x.UsageFeeTotal_EUR = Round(
-          x.UsageActiveEnergyTotalImportT0.Total
-          + x.UsageReactiveEnergyTotalRampedT0.Total
-          + x.UsageMeterFee.Total,
-          2);
-        x.SupplyFeeTotal_EUR = Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
-          + x.SupplyActiveEnergyTotalImportT2.Total
-          + x.SupplyBusinessUsageFee.Total
-          + x.SupplyRenewableEnergyFee.Total,
-          2);
-        x.Total_EUR = Round(
-          x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-          2);
-
-        return x;
-      });
+      );
   }
 
   [Test]

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest
     return new Faker<SupplyActiveEnergyTotalImportT1CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class SupplyActiveEnergyTotalImportT1CalculationItemCalculatorTest
     return new Faker<SupplyActiveEnergyTotalImportT1CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest
     return new Faker<SupplyActiveEnergyTotalImportT2CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class SupplyActiveEnergyTotalImportT2CalculationItemCalculatorTest
     return new Faker<SupplyActiveEnergyTotalImportT2CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyBusinessUsageCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyBusinessUsageCalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class SupplyBusinessUsageCalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class SupplyBusinessUsageCalculationItemCalculatorTest
     return new Faker<SupplyBusinessUsageCalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyBusinessUsageCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyBusinessUsageCalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class SupplyBusinessUsageCalculationItemCalculatorTest
     return new Faker<SupplyBusinessUsageCalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class SupplyRenewableEnergyCalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class SupplyRenewableEnergyCalculationItemCalculatorTest
     return new Faker<SupplyRenewableEnergyCalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/SupplyRenewableEnergyCalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class SupplyRenewableEnergyCalculationItemCalculatorTest
     return new Faker<SupplyRenewableEnergyCalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest
     return new Faker<UsageActiveEnergyTotalImportT0CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class UsageActiveEnergyTotalImportT0CalculationItemCalculatorTest
     return new Faker<UsageActiveEnergyTotalImportT0CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest
     return new Faker<UsageActiveEnergyTotalImportT1CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class UsageActiveEnergyTotalImportT1CalculationItemCalculatorTest
     return new Faker<UsageActiveEnergyTotalImportT1CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,31 +15,33 @@ public class UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest
     return new Faker<UsageActiveEnergyTotalImportT2CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kWh,
-        (_, m) => Round(
-          m.Max_kWh - m.Min_kWh,
-          0))
+        (f, m) =>
+          Round(f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue), 2)
+      )
+      .RuleFor(x => x.Amount_kWh, (_, m) => Round(m.Max_kWh - m.Min_kWh, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kWh * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kWh * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest
@@ -14,42 +16,31 @@ public class UsageActiveEnergyTotalImportT2CalculationItemCalculatorTest
     return new Faker<UsageActiveEnergyTotalImportT2CalculationItemModel>()
       .RuleFor(
         x => x.Min_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Max_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.Min_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.Amount_kWh,
-        (_, m) => System.Math.Round(m.Max_kWh - m.Min_kWh, 0)
-      )
+        (_, m) => Round(
+          m.Max_kWh - m.Min_kWh,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kWh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kWh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest
@@ -14,31 +16,26 @@ public class UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest
     return new Faker<UsageActivePowerTotalImportT1PeakCalculationItemModel>()
       .RuleFor(
         x => x.Peak_kW,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
-      .RuleFor(x => x.Amount_kW, (_, m) => System.Math.Round(m.Peak_kW, 0))
+        (f, m) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
+      .RuleFor(
+        x => x.Amount_kW,
+        (_, m) => Round(
+          m.Peak_kW,
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            3
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          3))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kW * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kW * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,26 +15,28 @@ public class UsageActivePowerTotalImportT1PeakCalculationItemCalculatorTest
     return new Faker<UsageActivePowerTotalImportT1PeakCalculationItemModel>()
       .RuleFor(
         x => x.Peak_kW,
-        (f, m) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
-      .RuleFor(
-        x => x.Amount_kW,
-        (_, m) => Round(
-          m.Peak_kW,
-          0))
+        (f, m) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
+      .RuleFor(x => x.Amount_kW, (_, m) => Round(m.Peak_kW, 0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          3))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kW * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            3
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_kW * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageMeterFeeCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageMeterFeeCalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class UsageMeterFeeCalculationItemCalculatorTest
@@ -15,19 +17,15 @@ public class UsageMeterFeeCalculationItemCalculatorTest
       .RuleFor(x => x.Amount_N, (_, m) => 1)
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            3
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          3))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_N * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_N * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageMeterFeeCalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageMeterFeeCalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -17,15 +16,16 @@ public class UsageMeterFeeCalculationItemCalculatorTest
       .RuleFor(x => x.Amount_N, (_, m) => 1)
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          3))
-      .RuleFor(
-        x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_N * m.Price_EUR,
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            3
+          )
+      )
+      .RuleFor(x => x.Total_EUR, (_, m) => Round(m.Amount_N * m.Price_EUR, 2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest.cs
@@ -5,6 +5,8 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 namespace Ozds.Business.Test.Finance.Complex;
 
 public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest
@@ -14,116 +16,74 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest
     return new Faker<UsageReactiveEnergyTotalRampedT0CalculationItemModel>()
       .RuleFor(
         x => x.ReactiveImportMin_kVARh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.ReactiveImportMax_kVARh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              m.ReactiveImportMin_kVARh,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(
+            m.ReactiveImportMin_kVARh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.ReactiveImportAmount_kVARh,
-        (_, m) =>
-          System.Math.Round(
-            m.ReactiveImportMax_kVARh - m.ReactiveImportMin_kVARh,
-            0
-          )
-      )
+        (_, m) => Round(
+          m.ReactiveImportMax_kVARh - m.ReactiveImportMin_kVARh,
+          0))
       .RuleFor(
         x => x.ReactiveExportMin_kVARh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.ReactiveExportMax_kVARh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              m.ReactiveExportMin_kVARh,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(
+            m.ReactiveExportMin_kVARh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.ReactiveExportAmount_kVARh,
-        (_, m) =>
-          System.Math.Round(
-            m.ReactiveExportMax_kVARh - m.ReactiveExportMin_kVARh,
-            0
-          )
-      )
+        (_, m) => Round(
+          m.ReactiveExportMax_kVARh - m.ReactiveExportMin_kVARh,
+          0))
       .RuleFor(
         x => x.ActiveImportMin_kWh,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            2
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.ActiveImportMax_kWh,
-        (f, m) =>
-          System.Math.Round(
-            f.Random.Decimal(m.ActiveImportMin_kWh, Constants.MaxEnergyValue),
-            2
-          )
-      )
+        (f, m) => Round(
+          f.Random.Decimal(m.ActiveImportMin_kWh, Constants.MaxEnergyValue),
+          2))
       .RuleFor(
         x => x.ActiveImportAmount_kWh,
-        (_, m) =>
-          System.Math.Round(m.ActiveImportMax_kWh - m.ActiveImportMin_kWh, 0)
-      )
+        (_, m) => Round(
+          m.ActiveImportMax_kWh - m.ActiveImportMin_kWh,
+          0))
       .RuleFor(
         x => x.Amount_kVARh,
-        (f, m) =>
-          System.Math.Round(
-            System.Math.Max(
-              System.Math.Abs(m.ReactiveImportAmount_kVARh)
-                + System.Math.Abs(m.ReactiveExportAmount_kVARh)
-                - 0.33M * m.ActiveImportAmount_kWh,
-              0
-            ),
-            0
-          )
-      )
+        (f, m) => Round(
+          System.Math.Max(
+            System.Math.Abs(m.ReactiveImportAmount_kVARh)
+            + System.Math.Abs(m.ReactiveExportAmount_kVARh)
+            - 0.33M * m.ActiveImportAmount_kWh,
+            0),
+          0))
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) =>
-          System.Math.Round(
-            f.Random.Decimal(
-              Constants.MinEnergyValue,
-              Constants.MaxEnergyValue
-            ),
-            6
-          )
-      )
+        (f, _) => Round(
+          f.Random.Decimal(
+            Constants.MinEnergyValue, Constants.MaxEnergyValue),
+          6))
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => System.Math.Round(m.Amount_kVARh * m.Price_EUR, 2)
-      )
+        (_, m) => Round(
+          m.Amount_kVARh * m.Price_EUR,
+          2))
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/Complex/UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest.cs
@@ -4,7 +4,6 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Models.Enums;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Finance.Complex;
@@ -16,74 +15,109 @@ public class UsageReactiveEnergyTotalRampedT0CalculationItemCalculatorTest
     return new Faker<UsageReactiveEnergyTotalRampedT0CalculationItemModel>()
       .RuleFor(
         x => x.ReactiveImportMin_kVARh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.ReactiveImportMax_kVARh,
-        (f, m) => Round(
-          f.Random.Decimal(
-            m.ReactiveImportMin_kVARh, Constants.MaxEnergyValue),
-          2))
+        (f, m) =>
+          Round(
+            f.Random.Decimal(
+              m.ReactiveImportMin_kVARh,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.ReactiveImportAmount_kVARh,
-        (_, m) => Round(
-          m.ReactiveImportMax_kVARh - m.ReactiveImportMin_kVARh,
-          0))
+        (_, m) =>
+          Round(m.ReactiveImportMax_kVARh - m.ReactiveImportMin_kVARh, 0)
+      )
       .RuleFor(
         x => x.ReactiveExportMin_kVARh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.ReactiveExportMax_kVARh,
-        (f, m) => Round(
-          f.Random.Decimal(
-            m.ReactiveExportMin_kVARh, Constants.MaxEnergyValue),
-          2))
+        (f, m) =>
+          Round(
+            f.Random.Decimal(
+              m.ReactiveExportMin_kVARh,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.ReactiveExportAmount_kVARh,
-        (_, m) => Round(
-          m.ReactiveExportMax_kVARh - m.ReactiveExportMin_kVARh,
-          0))
+        (_, m) =>
+          Round(m.ReactiveExportMax_kVARh - m.ReactiveExportMin_kVARh, 0)
+      )
       .RuleFor(
         x => x.ActiveImportMin_kWh,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          2))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            2
+          )
+      )
       .RuleFor(
         x => x.ActiveImportMax_kWh,
-        (f, m) => Round(
-          f.Random.Decimal(m.ActiveImportMin_kWh, Constants.MaxEnergyValue),
-          2))
+        (f, m) =>
+          Round(
+            f.Random.Decimal(m.ActiveImportMin_kWh, Constants.MaxEnergyValue),
+            2
+          )
+      )
       .RuleFor(
         x => x.ActiveImportAmount_kWh,
-        (_, m) => Round(
-          m.ActiveImportMax_kWh - m.ActiveImportMin_kWh,
-          0))
+        (_, m) => Round(m.ActiveImportMax_kWh - m.ActiveImportMin_kWh, 0)
+      )
       .RuleFor(
         x => x.Amount_kVARh,
-        (f, m) => Round(
-          System.Math.Max(
-            System.Math.Abs(m.ReactiveImportAmount_kVARh)
-            + System.Math.Abs(m.ReactiveExportAmount_kVARh)
-            - 0.33M * m.ActiveImportAmount_kWh,
-            0),
-          0))
+        (f, m) =>
+          Round(
+            System.Math.Max(
+              System.Math.Abs(m.ReactiveImportAmount_kVARh)
+                + System.Math.Abs(m.ReactiveExportAmount_kVARh)
+                - 0.33M * m.ActiveImportAmount_kWh,
+              0
+            ),
+            0
+          )
+      )
       .RuleFor(
         x => x.Price_EUR,
-        (f, _) => Round(
-          f.Random.Decimal(
-            Constants.MinEnergyValue, Constants.MaxEnergyValue),
-          6))
+        (f, _) =>
+          Round(
+            f.Random.Decimal(
+              Constants.MinEnergyValue,
+              Constants.MaxEnergyValue
+            ),
+            6
+          )
+      )
       .RuleFor(
         x => x.Total_EUR,
-        (_, m) => Round(
-          m.Amount_kVARh * m.Price_EUR,
-          2))
+        (_, m) => Round(m.Amount_kVARh * m.Price_EUR, 2)
+      )
       .GenerateLazy(Constants.DefaultFuzzCount);
   }
 

--- a/test/Ozds.Business.Test/Finance/MidpointRoundingSentinel.cs
+++ b/test/Ozds.Business.Test/Finance/MidpointRoundingSentinel.cs
@@ -1,0 +1,101 @@
+using Ozds.Business.Models;
+using Ozds.Business.Models.Base;
+using Ozds.Business.Models.Composite;
+
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
+namespace Ozds.Business.Test.Finance;
+
+public static class MidpointRoundingSentinel
+{
+
+  public static void InjectMidpointRoundingSentinel(
+      CalculatedNetworkUserInvoiceModel model,
+      decimal sentinel = 2.685M // NOTE: default sentinel value
+                                // that differs between bankers and away from zero rounding
+    )
+  {
+
+    model.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent = 0M;
+
+    var meteredCalculations = model
+      .Calculations
+      .OfType<MeteredNetworkUserCalculationModel>()
+      .ToList();
+
+    if (meteredCalculations.Count == 0)
+    {
+      return;
+    }
+
+    foreach (var calculation in meteredCalculations)
+    {
+      InjectMidpointRoundingSentinelInternal(calculation);
+    }
+
+    var target = meteredCalculations[0];
+    target.UsageMeterFee.Total_EUR = sentinel;
+
+    target.UsageFeeTotal_EUR = Round(sentinel, 2);
+    target.SupplyFeeTotal_EUR = 0M;
+    target.Total_EUR = target.UsageFeeTotal_EUR;
+  }
+
+  private static void InjectMidpointRoundingSentinelInternal(
+    MeteredNetworkUserCalculationModel model
+  )
+  {
+    model.UsageMeterFee.Total_EUR = 0M;
+
+    model.SupplyActiveEnergyTotalImportT1.Total_EUR = 0M;
+    model.SupplyActiveEnergyTotalImportT2.Total_EUR = 0M;
+    model.SupplyBusinessUsageFee.Total_EUR = 0M;
+    model.SupplyRenewableEnergyFee.Total_EUR = 0M;
+
+    switch (model)
+    {
+      case BlueLowNetworkUserCalculationModel c:
+        c.UsageActiveEnergyTotalImportT0.Total_EUR = 0M;
+        c.UsageReactiveEnergyTotalRampedT0.Total_EUR = 0M;
+        break;
+
+      case WhiteLowNetworkUserCalculationModel c:
+        c.UsageActiveEnergyTotalImportT1.Total_EUR = 0M;
+        c.UsageActiveEnergyTotalImportT2.Total_EUR = 0M;
+        c.UsageReactiveEnergyTotalRampedT0.Total_EUR = 0M;
+        break;
+
+      case RedLowNetworkUserCalculationModel c:
+        c.UsageActiveEnergyTotalImportT1.Total_EUR = 0M;
+        c.UsageActiveEnergyTotalImportT2.Total_EUR = 0M;
+        c.UsageReactiveEnergyTotalRampedT0.Total_EUR = 0M;
+        c.UsageActivePowerTotalImportT1Peak.Total_EUR = 0M;
+        break;
+
+      case WhiteMediumNetworkUserCalculationModel c:
+        c.UsageActiveEnergyTotalImportT1.Total_EUR = 0M;
+        c.UsageActiveEnergyTotalImportT2.Total_EUR = 0M;
+        c.UsageReactiveEnergyTotalRampedT0.Total_EUR = 0M;
+        c.UsageActivePowerTotalImportT1Peak.Total_EUR = 0M;
+        break;
+    }
+
+    model.UsageFeeTotal_EUR = 0M;
+    model.SupplyFeeTotal_EUR = 0M;
+    model.Total_EUR = 0M;
+  }
+
+  public static void InjectMidpointRoundingSentinel(
+    MeteredNetworkUserCalculationModel model,
+    decimal sentinel = 2.685M
+  )
+  {
+    InjectMidpointRoundingSentinelInternal(model);
+
+    model.UsageMeterFee.Total_EUR = sentinel;
+
+    model.UsageFeeTotal_EUR = Round(sentinel, 2);
+    model.SupplyFeeTotal_EUR = 0M;
+    model.Total_EUR = model.UsageFeeTotal_EUR;
+  }
+}

--- a/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
@@ -103,66 +103,66 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                  x.UsageActiveEnergyTotalImportT0.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageMeterFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT0.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyBusinessUsageFee.Total_EUR = Round(
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                x.UsageMeterFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.UsageFeeTotal_EUR = Round(
-                    x.UsageActiveEnergyTotalImportT0.Total
-                    + x.UsageReactiveEnergyTotalRampedT0.Total
-                    + x.UsageMeterFee.Total,
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.SupplyFeeTotal_EUR = Round(
-                    x.SupplyActiveEnergyTotalImportT1.Total
-                    + x.SupplyActiveEnergyTotalImportT2.Total
-                    + x.SupplyBusinessUsageFee.Total
-                    + x.SupplyRenewableEnergyFee.Total,
-                    2);
-                  x.Total_EUR = Round(
-                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                    2);
+
+                x.SupplyBusinessUsageFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.UsageFeeTotal_EUR = Round(
+                  x.UsageActiveEnergyTotalImportT0.Total
+                  + x.UsageReactiveEnergyTotalRampedT0.Total
+                  + x.UsageMeterFee.Total,
+                  2);
+                x.SupplyFeeTotal_EUR = Round(
+                  x.SupplyActiveEnergyTotalImportT1.Total
+                  + x.SupplyActiveEnergyTotalImportT2.Total
+                  + x.SupplyBusinessUsageFee.Total
+                  + x.SupplyRenewableEnergyFee.Total,
+                  2);
+                x.Total_EUR = Round(
+                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                  2);
 
                 return x;
               })
@@ -209,82 +209,82 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                  x.UsageActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageActivePowerTotalImportT1Peak.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageMeterFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyBusinessUsageFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.UsageFeeTotal_EUR = Round(
-                    x.UsageActiveEnergyTotalImportT1.Total
-                    + x.UsageActiveEnergyTotalImportT2.Total
-                    + x.UsageActivePowerTotalImportT1Peak.Total
-                    + x.UsageReactiveEnergyTotalRampedT0.Total
-                    + x.UsageMeterFee.Total,
+                x.UsageActivePowerTotalImportT1Peak.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.SupplyFeeTotal_EUR = Round(
-                    x.SupplyActiveEnergyTotalImportT1.Total
-                    + x.SupplyActiveEnergyTotalImportT2.Total
-                    + x.SupplyBusinessUsageFee.Total
-                    + x.SupplyRenewableEnergyFee.Total,
+
+                x.UsageMeterFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.Total_EUR = Round(
-                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
+
+                x.SupplyBusinessUsageFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.UsageFeeTotal_EUR = Round(
+                  x.UsageActiveEnergyTotalImportT1.Total
+                  + x.UsageActiveEnergyTotalImportT2.Total
+                  + x.UsageActivePowerTotalImportT1Peak.Total
+                  + x.UsageReactiveEnergyTotalRampedT0.Total
+                  + x.UsageMeterFee.Total,
+                  2);
+                x.SupplyFeeTotal_EUR = Round(
+                  x.SupplyActiveEnergyTotalImportT1.Total
+                  + x.SupplyActiveEnergyTotalImportT2.Total
+                  + x.SupplyBusinessUsageFee.Total
+                  + x.SupplyRenewableEnergyFee.Total,
+                  2);
+                x.Total_EUR = Round(
+                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                  2);
 
                 return x;
               })
@@ -331,74 +331,74 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                  x.UsageActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageMeterFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyBusinessUsageFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.UsageFeeTotal_EUR = Round(
-                    x.UsageActiveEnergyTotalImportT1.Total
-                    + x.UsageActiveEnergyTotalImportT2.Total
-                    + x.UsageReactiveEnergyTotalRampedT0.Total
-                    + x.UsageMeterFee.Total,
+                x.UsageMeterFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.SupplyFeeTotal_EUR = Round(
-                    x.SupplyActiveEnergyTotalImportT1.Total
-                    + x.SupplyActiveEnergyTotalImportT2.Total
-                    + x.SupplyBusinessUsageFee.Total
-                    + x.SupplyRenewableEnergyFee.Total,
+
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.Total_EUR = Round(
-                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                    2);
+
+                x.SupplyBusinessUsageFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.UsageFeeTotal_EUR = Round(
+                  x.UsageActiveEnergyTotalImportT1.Total
+                  + x.UsageActiveEnergyTotalImportT2.Total
+                  + x.UsageReactiveEnergyTotalRampedT0.Total
+                  + x.UsageMeterFee.Total,
+                  2);
+                x.SupplyFeeTotal_EUR = Round(
+                  x.SupplyActiveEnergyTotalImportT1.Total
+                  + x.SupplyActiveEnergyTotalImportT2.Total
+                  + x.SupplyBusinessUsageFee.Total
+                  + x.SupplyRenewableEnergyFee.Total,
+                  2);
+                x.Total_EUR = Round(
+                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                  2);
 
                 return x;
               })
@@ -445,82 +445,82 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                  x.UsageActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageActivePowerTotalImportT1Peak.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.UsageMeterFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                    Round(
-                      faker.Random.Decimal(
-                        Constants.MinTotalValue,
-                        Constants.MaxTotalValue),
-                      2);
-
-                  x.SupplyBusinessUsageFee.Total_EUR = Round(
+                x.UsageActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                  Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
                       Constants.MaxTotalValue),
                     2);
 
-                  x.UsageFeeTotal_EUR = Round(
-                    x.UsageActiveEnergyTotalImportT1.Total
-                    + x.UsageActiveEnergyTotalImportT2.Total
-                    + x.UsageActivePowerTotalImportT1Peak.Total
-                    + x.UsageReactiveEnergyTotalRampedT0.Total
-                    + x.UsageMeterFee.Total,
+                x.UsageActivePowerTotalImportT1Peak.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.SupplyFeeTotal_EUR = Round(
-                    x.SupplyActiveEnergyTotalImportT1.Total
-                    + x.SupplyActiveEnergyTotalImportT2.Total
-                    + x.SupplyBusinessUsageFee.Total
-                    + x.SupplyRenewableEnergyFee.Total,
+
+                x.UsageMeterFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
-                  x.Total_EUR = Round(
-                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                  Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
                     2);
+
+                x.SupplyBusinessUsageFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue),
+                  2);
+
+                x.UsageFeeTotal_EUR = Round(
+                  x.UsageActiveEnergyTotalImportT1.Total
+                  + x.UsageActiveEnergyTotalImportT2.Total
+                  + x.UsageActivePowerTotalImportT1Peak.Total
+                  + x.UsageReactiveEnergyTotalRampedT0.Total
+                  + x.UsageMeterFee.Total,
+                  2);
+                x.SupplyFeeTotal_EUR = Round(
+                  x.SupplyActiveEnergyTotalImportT1.Total
+                  + x.SupplyActiveEnergyTotalImportT2.Total
+                  + x.SupplyBusinessUsageFee.Total
+                  + x.SupplyRenewableEnergyFee.Total,
+                  2);
+                x.Total_EUR = Round(
+                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                  2);
 
                 return x;
               })
@@ -580,148 +580,150 @@ public class NetworkUserInvoiceCalculatorTest
           .ToList()
       )
       .CreateMany(2)
-      .Select(x =>
+      .Select((x, idx) =>
       {
+        if (idx == 0)
+        {
+          MidpointRoundingSentinel.InjectMidpointRoundingSentinel(x);
+        }
+
         x.Invoice.NetworkUserId = x.Invoice.ArchivedNetworkUser.Id;
         x.Invoice.Remark = x.Invoice.ArchivedNetworkUser.InvoiceRemark;
         x.Invoice.BillId = null;
 
-          x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR = Round(
+        x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR = Round(
+          x.Calculations
+            .OfType<MeteredNetworkUserCalculationModel>()
+            .SelectMany(
+              calculation => calculation.UsageItems
+                .OfType<
+                  UsageActiveEnergyTotalImportT0CalculationItemModel>())
+            .Sum(item => item.Total),
+          2);
+
+        x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR = Round(
+          x.Calculations
+            .OfType<MeteredNetworkUserCalculationModel>()
+            .SelectMany(
+              calculation => calculation.UsageItems
+                .OfType<
+                  UsageActiveEnergyTotalImportT1CalculationItemModel>())
+            .Sum(item => item.Total),
+          2);
+
+        x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR = Round(
+          x.Calculations
+            .OfType<MeteredNetworkUserCalculationModel>()
+            .SelectMany(
+              calculation => calculation.UsageItems
+                .OfType<
+                  UsageActiveEnergyTotalImportT2CalculationItemModel>())
+            .Sum(item => item.Total),
+          2);
+
+        x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR =
+          Round(
             x.Calculations
               .OfType<MeteredNetworkUserCalculationModel>()
               .SelectMany(
                 calculation => calculation.UsageItems
                   .OfType<
-                    UsageActiveEnergyTotalImportT0CalculationItemModel>())
+                    UsageActivePowerTotalImportT1PeakCalculationItemModel>())
               .Sum(item => item.Total),
             2);
 
-          x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR = Round(
+        x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR =
+          Round(
             x.Calculations
               .OfType<MeteredNetworkUserCalculationModel>()
               .SelectMany(
                 calculation => calculation.UsageItems
                   .OfType<
-                    UsageActiveEnergyTotalImportT1CalculationItemModel>())
+                    UsageReactiveEnergyTotalRampedT0CalculationItemModel>())
               .Sum(item => item.Total),
             2);
 
-          x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR = Round(
-            x.Calculations
-              .OfType<MeteredNetworkUserCalculationModel>()
-              .SelectMany(
-                calculation => calculation.UsageItems
-                  .OfType<
-                    UsageActiveEnergyTotalImportT2CalculationItemModel>())
-              .Sum(item => item.Total),
-            2);
+        x.Invoice.UsageMeterFee_EUR = Round(
+          x.Calculations
+            .OfType<MeteredNetworkUserCalculationModel>()
+            .SelectMany(
+              calculation => calculation.UsageItems
+                .OfType<UsageMeterFeeCalculationItemModel>())
+            .Sum(item => item.Total),
+          2);
 
-          x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR =
-            Round(
-              x.Calculations
-                .OfType<MeteredNetworkUserCalculationModel>()
-                .SelectMany(
-                  calculation => calculation.UsageItems
-                    .OfType<
-                      UsageActivePowerTotalImportT1PeakCalculationItemModel>())
-                .Sum(item => item.Total),
-              2);
+        x.Invoice.UsageFeeTotal_EUR = Round(
+          x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR
+          + x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR
+          + x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR
+          + x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR
+          + x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR
+          + x.Invoice.UsageMeterFee_EUR,
+          2 );
 
-          x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR =
-            Round(
-              x.Calculations
-                .OfType<MeteredNetworkUserCalculationModel>()
-                .SelectMany(
-                  calculation => calculation.UsageItems
-                    .OfType<
-                      UsageReactiveEnergyTotalRampedT0CalculationItemModel>())
-                .Sum(item => item.Total),
-              2);
-
-          x.Invoice.UsageMeterFee_EUR = Round(
-            x.Calculations
-              .OfType<MeteredNetworkUserCalculationModel>()
-              .SelectMany(
-                calculation => calculation.UsageItems
-                  .OfType<UsageMeterFeeCalculationItemModel>())
-              .Sum(item => item.Total),
-            2);
-
-          x.Invoice.UsageFeeTotal_EUR = Round(
-            x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR
-            + x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR
-            + x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR
-            + x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR
-            + x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR
-            + x.Invoice.UsageMeterFee_EUR,
-          2
-        );
-
-          x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR =
-            Round(
-              x.Calculations
-                .OfType<MeteredNetworkUserCalculationModel>()
-                .SelectMany(
-                  calculation => calculation.SupplyItems
-                    .OfType<
-                      SupplyActiveEnergyTotalImportT1CalculationItemModel>())
-                .Sum(item => item.Total),
-              2);
-
-          x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR =
-            Round(
-              x.Calculations
-                .OfType<MeteredNetworkUserCalculationModel>()
-                .SelectMany(
-                  calculation => calculation.SupplyItems
-                    .OfType<
-                      SupplyActiveEnergyTotalImportT2CalculationItemModel>())
-                .Sum(item => item.Total),
-              2);
-
-          x.Invoice.SupplyBusinessUsageFee_EUR = Round(
+        x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR =
+          Round(
             x.Calculations
               .OfType<MeteredNetworkUserCalculationModel>()
               .SelectMany(
                 calculation => calculation.SupplyItems
-                  .OfType<SupplyBusinessUsageCalculationItemModel>())
+                  .OfType<
+                    SupplyActiveEnergyTotalImportT1CalculationItemModel>())
               .Sum(item => item.Total),
             2);
 
-          x.Invoice.SupplyRenewableEnergyFee_EUR = Round(
+        x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR =
+          Round(
             x.Calculations
               .OfType<MeteredNetworkUserCalculationModel>()
               .SelectMany(
                 calculation => calculation.SupplyItems
-                  .OfType<SupplyRenewableEnergyCalculationItemModel>())
+                  .OfType<
+                    SupplyActiveEnergyTotalImportT2CalculationItemModel>())
               .Sum(item => item.Total),
             2);
 
-          x.Invoice.SupplyFeeTotal_EUR = Round(
-            x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR
-            + x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR
-            + x.Invoice.SupplyBusinessUsageFee_EUR
-            + x.Invoice.SupplyRenewableEnergyFee_EUR,
-          2
-        );
+        x.Invoice.SupplyBusinessUsageFee_EUR = Round(
+          x.Calculations
+            .OfType<MeteredNetworkUserCalculationModel>()
+            .SelectMany(
+              calculation => calculation.SupplyItems
+                .OfType<SupplyBusinessUsageCalculationItemModel>())
+            .Sum(item => item.Total),
+          2);
 
-          x.Invoice.Total_EUR = Round(
-            x.Invoice.UsageFeeTotal_EUR + x.Invoice.SupplyFeeTotal_EUR,
-            2);
-          x.Invoice.InvoiceTaxRate_Percent = Round(
-            x.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent,
-            2);
-          x.Invoice.InvoiceTax_EUR = Round(
-            x.Invoice.Total_EUR * x.Invoice.TaxRate_Percent / 100M,
-            2);
-          x.Invoice.InvoiceTotalWithTax_EUR = Round(
-            x.Invoice.Total_EUR + x.Invoice.Tax_EUR,
-            2);
+        x.Invoice.SupplyRenewableEnergyFee_EUR = Round(
+          x.Calculations
+            .OfType<MeteredNetworkUserCalculationModel>()
+            .SelectMany(
+              calculation => calculation.SupplyItems
+                .OfType<SupplyRenewableEnergyCalculationItemModel>())
+            .Sum(item => item.Total),
+          2);
+
+        x.Invoice.SupplyFeeTotal_EUR = Round(
+          x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR
+          + x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR
+          + x.Invoice.SupplyBusinessUsageFee_EUR
+          + x.Invoice.SupplyRenewableEnergyFee_EUR,
+          2 );
+
+        x.Invoice.Total_EUR = Round(
+          x.Invoice.UsageFeeTotal_EUR + x.Invoice.SupplyFeeTotal_EUR,
+          2);
+        x.Invoice.InvoiceTaxRate_Percent = Round(
+          x.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent,
+          2);
+        x.Invoice.InvoiceTax_EUR = Round(
+          x.Invoice.Total_EUR * x.Invoice.TaxRate_Percent / 100M,
+          2);
+        x.Invoice.InvoiceTotalWithTax_EUR = Round(
+          x.Invoice.Total_EUR + x.Invoice.Tax_EUR,
+          2);
 
         return x;
       });
   }
-
   [Test]
   [MethodDataSource(nameof(TestData))]
   public void CalculatesCorrectlyWithFuzzyAbbB2xMeter(

--- a/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
@@ -7,6 +7,7 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
+using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
 
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
@@ -584,7 +585,7 @@ public class NetworkUserInvoiceCalculatorTest
       {
         if (idx == 0)
         {
-          MidpointRoundingSentinel.InjectMidpointRoundingSentinel(x);
+          MidpointRoundingSentinel.InjectInvoiceSentinel(x);
         }
 
         x.Invoice.NetworkUserId = x.Invoice.ArchivedNetworkUser.Id;

--- a/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
@@ -9,7 +9,6 @@ using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 // NITPICK: test issuer and date
@@ -104,66 +103,79 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT0.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT0.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageMeterFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyBusinessUsageFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyRenewableEnergyFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageFeeTotal_EUR = Round(
                   x.UsageActiveEnergyTotalImportT0.Total
-                  + x.UsageReactiveEnergyTotalRampedT0.Total
-                  + x.UsageMeterFee.Total,
-                  2);
+                    + x.UsageReactiveEnergyTotalRampedT0.Total
+                    + x.UsageMeterFee.Total,
+                  2
+                );
                 x.SupplyFeeTotal_EUR = Round(
                   x.SupplyActiveEnergyTotalImportT1.Total
-                  + x.SupplyActiveEnergyTotalImportT2.Total
-                  + x.SupplyBusinessUsageFee.Total
-                  + x.SupplyRenewableEnergyFee.Total,
-                  2);
+                    + x.SupplyActiveEnergyTotalImportT2.Total
+                    + x.SupplyBusinessUsageFee.Total
+                    + x.SupplyRenewableEnergyFee.Total,
+                  2
+                );
                 x.Total_EUR = Round(
                   x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2);
+                  2
+                );
 
                 return x;
               })
@@ -210,82 +222,97 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageActivePowerTotalImportT1Peak.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActivePowerTotalImportT1Peak.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageMeterFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyBusinessUsageFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyRenewableEnergyFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageFeeTotal_EUR = Round(
                   x.UsageActiveEnergyTotalImportT1.Total
-                  + x.UsageActiveEnergyTotalImportT2.Total
-                  + x.UsageActivePowerTotalImportT1Peak.Total
-                  + x.UsageReactiveEnergyTotalRampedT0.Total
-                  + x.UsageMeterFee.Total,
-                  2);
+                    + x.UsageActiveEnergyTotalImportT2.Total
+                    + x.UsageActivePowerTotalImportT1Peak.Total
+                    + x.UsageReactiveEnergyTotalRampedT0.Total
+                    + x.UsageMeterFee.Total,
+                  2
+                );
                 x.SupplyFeeTotal_EUR = Round(
                   x.SupplyActiveEnergyTotalImportT1.Total
-                  + x.SupplyActiveEnergyTotalImportT2.Total
-                  + x.SupplyBusinessUsageFee.Total
-                  + x.SupplyRenewableEnergyFee.Total,
-                  2);
+                    + x.SupplyActiveEnergyTotalImportT2.Total
+                    + x.SupplyBusinessUsageFee.Total
+                    + x.SupplyRenewableEnergyFee.Total,
+                  2
+                );
                 x.Total_EUR = Round(
                   x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2);
+                  2
+                );
 
                 return x;
               })
@@ -332,74 +359,88 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageMeterFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyBusinessUsageFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyRenewableEnergyFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageFeeTotal_EUR = Round(
                   x.UsageActiveEnergyTotalImportT1.Total
-                  + x.UsageActiveEnergyTotalImportT2.Total
-                  + x.UsageReactiveEnergyTotalRampedT0.Total
-                  + x.UsageMeterFee.Total,
-                  2);
+                    + x.UsageActiveEnergyTotalImportT2.Total
+                    + x.UsageReactiveEnergyTotalRampedT0.Total
+                    + x.UsageMeterFee.Total,
+                  2
+                );
                 x.SupplyFeeTotal_EUR = Round(
                   x.SupplyActiveEnergyTotalImportT1.Total
-                  + x.SupplyActiveEnergyTotalImportT2.Total
-                  + x.SupplyBusinessUsageFee.Total
-                  + x.SupplyRenewableEnergyFee.Total,
-                  2);
+                    + x.SupplyActiveEnergyTotalImportT2.Total
+                    + x.SupplyBusinessUsageFee.Total
+                    + x.SupplyRenewableEnergyFee.Total,
+                  2
+                );
                 x.Total_EUR = Round(
                   x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2);
+                  2
+                );
 
                 return x;
               })
@@ -446,82 +487,97 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.UsageActivePowerTotalImportT1Peak.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.UsageActivePowerTotalImportT1Peak.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageMeterFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR =
-                  Round(
-                    faker.Random.Decimal(
-                      Constants.MinTotalValue,
-                      Constants.MaxTotalValue),
-                    2);
+                x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+                  faker.Random.Decimal(
+                    Constants.MinTotalValue,
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyBusinessUsageFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.SupplyRenewableEnergyFee.Total_EUR = Round(
                   faker.Random.Decimal(
                     Constants.MinTotalValue,
-                    Constants.MaxTotalValue),
-                  2);
+                    Constants.MaxTotalValue
+                  ),
+                  2
+                );
 
                 x.UsageFeeTotal_EUR = Round(
                   x.UsageActiveEnergyTotalImportT1.Total
-                  + x.UsageActiveEnergyTotalImportT2.Total
-                  + x.UsageActivePowerTotalImportT1Peak.Total
-                  + x.UsageReactiveEnergyTotalRampedT0.Total
-                  + x.UsageMeterFee.Total,
-                  2);
+                    + x.UsageActiveEnergyTotalImportT2.Total
+                    + x.UsageActivePowerTotalImportT1Peak.Total
+                    + x.UsageReactiveEnergyTotalRampedT0.Total
+                    + x.UsageMeterFee.Total,
+                  2
+                );
                 x.SupplyFeeTotal_EUR = Round(
                   x.SupplyActiveEnergyTotalImportT1.Total
-                  + x.SupplyActiveEnergyTotalImportT2.Total
-                  + x.SupplyBusinessUsageFee.Total
-                  + x.SupplyRenewableEnergyFee.Total,
-                  2);
+                    + x.SupplyActiveEnergyTotalImportT2.Total
+                    + x.SupplyBusinessUsageFee.Total
+                    + x.SupplyRenewableEnergyFee.Total,
+                  2
+                );
                 x.Total_EUR = Round(
                   x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2);
+                  2
+                );
 
                 return x;
               })
@@ -581,150 +637,148 @@ public class NetworkUserInvoiceCalculatorTest
           .ToList()
       )
       .CreateMany(2)
-      .Select((x, idx) =>
-      {
-        if (idx == 0)
+      .Select(
+        (x, idx) =>
         {
-          MidpointRoundingSentinel.InjectInvoiceSentinel(x);
+          if (idx == 0)
+          {
+            MidpointRoundingSentinel.InjectInvoiceSentinel(x);
+          }
+
+          x.Invoice.NetworkUserId = x.Invoice.ArchivedNetworkUser.Id;
+          x.Invoice.Remark = x.Invoice.ArchivedNetworkUser.InvoiceRemark;
+          x.Invoice.BillId = null;
+
+          x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.UsageItems.OfType<UsageActiveEnergyTotalImportT0CalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.UsageItems.OfType<UsageActiveEnergyTotalImportT1CalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.UsageItems.OfType<UsageActiveEnergyTotalImportT2CalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.UsageItems.OfType<UsageActivePowerTotalImportT1PeakCalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.UsageItems.OfType<UsageReactiveEnergyTotalRampedT0CalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.UsageMeterFee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.UsageItems.OfType<UsageMeterFeeCalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.UsageFeeTotal_EUR = Round(
+            x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR
+              + x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR
+              + x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR
+              + x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR
+              + x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR
+              + x.Invoice.UsageMeterFee_EUR,
+            2
+          );
+
+          x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.SupplyItems.OfType<SupplyActiveEnergyTotalImportT1CalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.SupplyItems.OfType<SupplyActiveEnergyTotalImportT2CalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.SupplyBusinessUsageFee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.SupplyItems.OfType<SupplyBusinessUsageCalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.SupplyRenewableEnergyFee_EUR = Round(
+            x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(calculation =>
+                calculation.SupplyItems.OfType<SupplyRenewableEnergyCalculationItemModel>()
+              )
+              .Sum(item => item.Total),
+            2
+          );
+
+          x.Invoice.SupplyFeeTotal_EUR = Round(
+            x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR
+              + x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR
+              + x.Invoice.SupplyBusinessUsageFee_EUR
+              + x.Invoice.SupplyRenewableEnergyFee_EUR,
+            2
+          );
+
+          x.Invoice.Total_EUR = Round(
+            x.Invoice.UsageFeeTotal_EUR + x.Invoice.SupplyFeeTotal_EUR,
+            2
+          );
+          x.Invoice.InvoiceTaxRate_Percent = Round(
+            x.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent,
+            2
+          );
+          x.Invoice.InvoiceTax_EUR = Round(
+            x.Invoice.Total_EUR * x.Invoice.TaxRate_Percent / 100M,
+            2
+          );
+          x.Invoice.InvoiceTotalWithTax_EUR = Round(
+            x.Invoice.Total_EUR + x.Invoice.Tax_EUR,
+            2
+          );
+
+          return x;
         }
-
-        x.Invoice.NetworkUserId = x.Invoice.ArchivedNetworkUser.Id;
-        x.Invoice.Remark = x.Invoice.ArchivedNetworkUser.InvoiceRemark;
-        x.Invoice.BillId = null;
-
-        x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR = Round(
-          x.Calculations
-            .OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(
-              calculation => calculation.UsageItems
-                .OfType<
-                  UsageActiveEnergyTotalImportT0CalculationItemModel>())
-            .Sum(item => item.Total),
-          2);
-
-        x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR = Round(
-          x.Calculations
-            .OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(
-              calculation => calculation.UsageItems
-                .OfType<
-                  UsageActiveEnergyTotalImportT1CalculationItemModel>())
-            .Sum(item => item.Total),
-          2);
-
-        x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR = Round(
-          x.Calculations
-            .OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(
-              calculation => calculation.UsageItems
-                .OfType<
-                  UsageActiveEnergyTotalImportT2CalculationItemModel>())
-            .Sum(item => item.Total),
-          2);
-
-        x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR =
-          Round(
-            x.Calculations
-              .OfType<MeteredNetworkUserCalculationModel>()
-              .SelectMany(
-                calculation => calculation.UsageItems
-                  .OfType<
-                    UsageActivePowerTotalImportT1PeakCalculationItemModel>())
-              .Sum(item => item.Total),
-            2);
-
-        x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR =
-          Round(
-            x.Calculations
-              .OfType<MeteredNetworkUserCalculationModel>()
-              .SelectMany(
-                calculation => calculation.UsageItems
-                  .OfType<
-                    UsageReactiveEnergyTotalRampedT0CalculationItemModel>())
-              .Sum(item => item.Total),
-            2);
-
-        x.Invoice.UsageMeterFee_EUR = Round(
-          x.Calculations
-            .OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(
-              calculation => calculation.UsageItems
-                .OfType<UsageMeterFeeCalculationItemModel>())
-            .Sum(item => item.Total),
-          2);
-
-        x.Invoice.UsageFeeTotal_EUR = Round(
-          x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR
-          + x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR
-          + x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR
-          + x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR
-          + x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR
-          + x.Invoice.UsageMeterFee_EUR,
-          2 );
-
-        x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR =
-          Round(
-            x.Calculations
-              .OfType<MeteredNetworkUserCalculationModel>()
-              .SelectMany(
-                calculation => calculation.SupplyItems
-                  .OfType<
-                    SupplyActiveEnergyTotalImportT1CalculationItemModel>())
-              .Sum(item => item.Total),
-            2);
-
-        x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR =
-          Round(
-            x.Calculations
-              .OfType<MeteredNetworkUserCalculationModel>()
-              .SelectMany(
-                calculation => calculation.SupplyItems
-                  .OfType<
-                    SupplyActiveEnergyTotalImportT2CalculationItemModel>())
-              .Sum(item => item.Total),
-            2);
-
-        x.Invoice.SupplyBusinessUsageFee_EUR = Round(
-          x.Calculations
-            .OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(
-              calculation => calculation.SupplyItems
-                .OfType<SupplyBusinessUsageCalculationItemModel>())
-            .Sum(item => item.Total),
-          2);
-
-        x.Invoice.SupplyRenewableEnergyFee_EUR = Round(
-          x.Calculations
-            .OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(
-              calculation => calculation.SupplyItems
-                .OfType<SupplyRenewableEnergyCalculationItemModel>())
-            .Sum(item => item.Total),
-          2);
-
-        x.Invoice.SupplyFeeTotal_EUR = Round(
-          x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR
-          + x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR
-          + x.Invoice.SupplyBusinessUsageFee_EUR
-          + x.Invoice.SupplyRenewableEnergyFee_EUR,
-          2 );
-
-        x.Invoice.Total_EUR = Round(
-          x.Invoice.UsageFeeTotal_EUR + x.Invoice.SupplyFeeTotal_EUR,
-          2);
-        x.Invoice.InvoiceTaxRate_Percent = Round(
-          x.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent,
-          2);
-        x.Invoice.InvoiceTax_EUR = Round(
-          x.Invoice.Total_EUR * x.Invoice.TaxRate_Percent / 100M,
-          2);
-        x.Invoice.InvoiceTotalWithTax_EUR = Round(
-          x.Invoice.Total_EUR + x.Invoice.Tax_EUR,
-          2);
-
-        return x;
-      });
+      );
   }
+
   [Test]
   [MethodDataSource(nameof(TestData))]
   public void CalculatesCorrectlyWithFuzzyAbbB2xMeter(

--- a/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/NetworkUserInvoiceCalculatorTest.cs
@@ -9,6 +9,8 @@ using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 // NITPICK: test issuer and date
 
 namespace Ozds.Business.Test.Finance;
@@ -101,80 +103,66 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT0.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT0.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  System.Math.Round(
+                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.UsageMeterFee.Total_EUR = Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
-                      Constants.MaxTotalValue
-                    ),
-                    2
-                  );
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.UsageMeterFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyBusinessUsageFee.Total_EUR = Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.UsageFeeTotal_EUR = System.Math.Round(
-                  x.UsageActiveEnergyTotalImportT0.Total
+                  x.UsageFeeTotal_EUR = Round(
+                    x.UsageActiveEnergyTotalImportT0.Total
                     + x.UsageReactiveEnergyTotalRampedT0.Total
                     + x.UsageMeterFee.Total,
-                  2
-                );
-                x.SupplyFeeTotal_EUR = System.Math.Round(
-                  x.SupplyActiveEnergyTotalImportT1.Total
+                    2);
+                  x.SupplyFeeTotal_EUR = Round(
+                    x.SupplyActiveEnergyTotalImportT1.Total
                     + x.SupplyActiveEnergyTotalImportT2.Total
                     + x.SupplyBusinessUsageFee.Total
                     + x.SupplyRenewableEnergyFee.Total,
-                  2
-                );
-                x.Total_EUR = System.Math.Round(
-                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2
-                );
+                    2);
+                  x.Total_EUR = Round(
+                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                    2);
 
                 return x;
               })
@@ -221,99 +209,82 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  System.Math.Round(
+                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.UsageActivePowerTotalImportT1Peak.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.UsageMeterFee.Total_EUR = Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
-                      Constants.MaxTotalValue
-                    ),
-                    2
-                  );
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.UsageActivePowerTotalImportT1Peak.Total_EUR =
-                  System.Math.Round(
+                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.SupplyBusinessUsageFee.Total_EUR = Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
-                      Constants.MaxTotalValue
-                    ),
-                    2
-                  );
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.UsageMeterFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.UsageFeeTotal_EUR = System.Math.Round(
-                  x.UsageActiveEnergyTotalImportT1.Total
+                  x.UsageFeeTotal_EUR = Round(
+                    x.UsageActiveEnergyTotalImportT1.Total
                     + x.UsageActiveEnergyTotalImportT2.Total
                     + x.UsageActivePowerTotalImportT1Peak.Total
                     + x.UsageReactiveEnergyTotalRampedT0.Total
                     + x.UsageMeterFee.Total,
-                  2
-                );
-                x.SupplyFeeTotal_EUR = System.Math.Round(
-                  x.SupplyActiveEnergyTotalImportT1.Total
+                    2);
+                  x.SupplyFeeTotal_EUR = Round(
+                    x.SupplyActiveEnergyTotalImportT1.Total
                     + x.SupplyActiveEnergyTotalImportT2.Total
                     + x.SupplyBusinessUsageFee.Total
                     + x.SupplyRenewableEnergyFee.Total,
-                  2
-                );
-                x.Total_EUR = System.Math.Round(
-                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2
-                );
+                    2);
+                  x.Total_EUR = Round(
+                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                    2);
 
                 return x;
               })
@@ -360,89 +331,74 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  System.Math.Round(
+                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.UsageMeterFee.Total_EUR = Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
-                      Constants.MaxTotalValue
-                    ),
-                    2
-                  );
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.UsageMeterFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyBusinessUsageFee.Total_EUR = Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.UsageFeeTotal_EUR = System.Math.Round(
-                  x.UsageActiveEnergyTotalImportT1.Total
+                  x.UsageFeeTotal_EUR = Round(
+                    x.UsageActiveEnergyTotalImportT1.Total
                     + x.UsageActiveEnergyTotalImportT2.Total
                     + x.UsageReactiveEnergyTotalRampedT0.Total
                     + x.UsageMeterFee.Total,
-                  2
-                );
-                x.SupplyFeeTotal_EUR = System.Math.Round(
-                  x.SupplyActiveEnergyTotalImportT1.Total
+                    2);
+                  x.SupplyFeeTotal_EUR = Round(
+                    x.SupplyActiveEnergyTotalImportT1.Total
                     + x.SupplyActiveEnergyTotalImportT2.Total
                     + x.SupplyBusinessUsageFee.Total
                     + x.SupplyRenewableEnergyFee.Total,
-                  2
-                );
-                x.Total_EUR = System.Math.Round(
-                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2
-                );
+                    2);
+                  x.Total_EUR = Round(
+                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                    2);
 
                 return x;
               })
@@ -489,99 +445,82 @@ public class NetworkUserInvoiceCalculatorTest
 
                 var faker = new Faker();
 
-                x.UsageActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.UsageActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
 
-                x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
-                  System.Math.Round(
+                  x.UsageReactiveEnergyTotalRampedT0.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.UsageActivePowerTotalImportT1Peak.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.UsageMeterFee.Total_EUR = Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
-                      Constants.MaxTotalValue
-                    ),
-                    2
-                  );
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.UsageActivePowerTotalImportT1Peak.Total_EUR =
-                  System.Math.Round(
+                  x.SupplyActiveEnergyTotalImportT1.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.SupplyActiveEnergyTotalImportT2.Total_EUR =
+                    Round(
+                      faker.Random.Decimal(
+                        Constants.MinTotalValue,
+                        Constants.MaxTotalValue),
+                      2);
+
+                  x.SupplyBusinessUsageFee.Total_EUR = Round(
                     faker.Random.Decimal(
                       Constants.MinTotalValue,
-                      Constants.MaxTotalValue
-                    ),
-                    2
-                  );
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.UsageMeterFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
+                  x.SupplyRenewableEnergyFee.Total_EUR = Round(
+                    faker.Random.Decimal(
+                      Constants.MinTotalValue,
+                      Constants.MaxTotalValue),
+                    2);
 
-                x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-                  faker.Random.Decimal(
-                    Constants.MinTotalValue,
-                    Constants.MaxTotalValue
-                  ),
-                  2
-                );
-
-                x.UsageFeeTotal_EUR = System.Math.Round(
-                  x.UsageActiveEnergyTotalImportT1.Total
+                  x.UsageFeeTotal_EUR = Round(
+                    x.UsageActiveEnergyTotalImportT1.Total
                     + x.UsageActiveEnergyTotalImportT2.Total
                     + x.UsageActivePowerTotalImportT1Peak.Total
                     + x.UsageReactiveEnergyTotalRampedT0.Total
                     + x.UsageMeterFee.Total,
-                  2
-                );
-                x.SupplyFeeTotal_EUR = System.Math.Round(
-                  x.SupplyActiveEnergyTotalImportT1.Total
+                    2);
+                  x.SupplyFeeTotal_EUR = Round(
+                    x.SupplyActiveEnergyTotalImportT1.Total
                     + x.SupplyActiveEnergyTotalImportT2.Total
                     + x.SupplyBusinessUsageFee.Total
                     + x.SupplyRenewableEnergyFee.Total,
-                  2
-                );
-                x.Total_EUR = System.Math.Round(
-                  x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-                  2
-                );
+                    2);
+                  x.Total_EUR = Round(
+                    x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+                    2);
 
                 return x;
               })
@@ -647,62 +586,69 @@ public class NetworkUserInvoiceCalculatorTest
         x.Invoice.Remark = x.Invoice.ArchivedNetworkUser.InvoiceRemark;
         x.Invoice.BillId = null;
 
-        x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.UsageItems.OfType<UsageActiveEnergyTotalImportT0CalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR = Round(
+            x.Calculations
+              .OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(
+                calculation => calculation.UsageItems
+                  .OfType<
+                    UsageActiveEnergyTotalImportT0CalculationItemModel>())
+              .Sum(item => item.Total),
+            2);
 
-        x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.UsageItems.OfType<UsageActiveEnergyTotalImportT1CalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR = Round(
+            x.Calculations
+              .OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(
+                calculation => calculation.UsageItems
+                  .OfType<
+                    UsageActiveEnergyTotalImportT1CalculationItemModel>())
+              .Sum(item => item.Total),
+            2);
 
-        x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.UsageItems.OfType<UsageActiveEnergyTotalImportT2CalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR = Round(
+            x.Calculations
+              .OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(
+                calculation => calculation.UsageItems
+                  .OfType<
+                    UsageActiveEnergyTotalImportT2CalculationItemModel>())
+              .Sum(item => item.Total),
+            2);
 
-        x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.UsageItems.OfType<UsageActivePowerTotalImportT1PeakCalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR =
+            Round(
+              x.Calculations
+                .OfType<MeteredNetworkUserCalculationModel>()
+                .SelectMany(
+                  calculation => calculation.UsageItems
+                    .OfType<
+                      UsageActivePowerTotalImportT1PeakCalculationItemModel>())
+                .Sum(item => item.Total),
+              2);
 
-        x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.UsageItems.OfType<UsageReactiveEnergyTotalRampedT0CalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.UsageReactiveEnergyTotalRampedT0Fee_EUR =
+            Round(
+              x.Calculations
+                .OfType<MeteredNetworkUserCalculationModel>()
+                .SelectMany(
+                  calculation => calculation.UsageItems
+                    .OfType<
+                      UsageReactiveEnergyTotalRampedT0CalculationItemModel>())
+                .Sum(item => item.Total),
+              2);
 
-        x.Invoice.UsageMeterFee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.UsageItems.OfType<UsageMeterFeeCalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.UsageMeterFee_EUR = Round(
+            x.Calculations
+              .OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(
+                calculation => calculation.UsageItems
+                  .OfType<UsageMeterFeeCalculationItemModel>())
+              .Sum(item => item.Total),
+            2);
 
-        x.Invoice.UsageFeeTotal_EUR = System.Math.Round(
-          x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR
+          x.Invoice.UsageFeeTotal_EUR = Round(
+            x.Invoice.UsageActiveEnergyTotalImportT0Fee_EUR
             + x.Invoice.UsageActiveEnergyTotalImportT1Fee_EUR
             + x.Invoice.UsageActiveEnergyTotalImportT2Fee_EUR
             + x.Invoice.UsageActivePowerTotalImportT1PeakFee_EUR
@@ -711,66 +657,66 @@ public class NetworkUserInvoiceCalculatorTest
           2
         );
 
-        x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.SupplyItems.OfType<SupplyActiveEnergyTotalImportT1CalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR =
+            Round(
+              x.Calculations
+                .OfType<MeteredNetworkUserCalculationModel>()
+                .SelectMany(
+                  calculation => calculation.SupplyItems
+                    .OfType<
+                      SupplyActiveEnergyTotalImportT1CalculationItemModel>())
+                .Sum(item => item.Total),
+              2);
 
-        x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.SupplyItems.OfType<SupplyActiveEnergyTotalImportT2CalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR =
+            Round(
+              x.Calculations
+                .OfType<MeteredNetworkUserCalculationModel>()
+                .SelectMany(
+                  calculation => calculation.SupplyItems
+                    .OfType<
+                      SupplyActiveEnergyTotalImportT2CalculationItemModel>())
+                .Sum(item => item.Total),
+              2);
 
-        x.Invoice.SupplyBusinessUsageFee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.SupplyItems.OfType<SupplyBusinessUsageCalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.SupplyBusinessUsageFee_EUR = Round(
+            x.Calculations
+              .OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(
+                calculation => calculation.SupplyItems
+                  .OfType<SupplyBusinessUsageCalculationItemModel>())
+              .Sum(item => item.Total),
+            2);
 
-        x.Invoice.SupplyRenewableEnergyFee_EUR = System.Math.Round(
-          x.Calculations.OfType<MeteredNetworkUserCalculationModel>()
-            .SelectMany(calculation =>
-              calculation.SupplyItems.OfType<SupplyRenewableEnergyCalculationItemModel>()
-            )
-            .Sum(item => item.Total),
-          2
-        );
+          x.Invoice.SupplyRenewableEnergyFee_EUR = Round(
+            x.Calculations
+              .OfType<MeteredNetworkUserCalculationModel>()
+              .SelectMany(
+                calculation => calculation.SupplyItems
+                  .OfType<SupplyRenewableEnergyCalculationItemModel>())
+              .Sum(item => item.Total),
+            2);
 
-        x.Invoice.SupplyFeeTotal_EUR = System.Math.Round(
-          x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR
+          x.Invoice.SupplyFeeTotal_EUR = Round(
+            x.Invoice.SupplyActiveEnergyTotalImportT1Fee_EUR
             + x.Invoice.SupplyActiveEnergyTotalImportT2Fee_EUR
             + x.Invoice.SupplyBusinessUsageFee_EUR
             + x.Invoice.SupplyRenewableEnergyFee_EUR,
           2
         );
 
-        x.Invoice.Total_EUR = System.Math.Round(
-          x.Invoice.UsageFeeTotal_EUR + x.Invoice.SupplyFeeTotal_EUR,
-          2
-        );
-        x.Invoice.InvoiceTaxRate_Percent = System.Math.Round(
-          x.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent,
-          2
-        );
-        x.Invoice.InvoiceTax_EUR = System.Math.Round(
-          x.Invoice.Total_EUR * x.Invoice.TaxRate_Percent / 100M,
-          2
-        );
-        x.Invoice.InvoiceTotalWithTax_EUR = System.Math.Round(
-          x.Invoice.Total_EUR + x.Invoice.Tax_EUR,
-          2
-        );
+          x.Invoice.Total_EUR = Round(
+            x.Invoice.UsageFeeTotal_EUR + x.Invoice.SupplyFeeTotal_EUR,
+            2);
+          x.Invoice.InvoiceTaxRate_Percent = Round(
+            x.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent,
+            2);
+          x.Invoice.InvoiceTax_EUR = Round(
+            x.Invoice.Total_EUR * x.Invoice.TaxRate_Percent / 100M,
+            2);
+          x.Invoice.InvoiceTotalWithTax_EUR = Round(
+            x.Invoice.Total_EUR + x.Invoice.Tax_EUR,
+            2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
@@ -8,7 +8,6 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 // NITPICK: test issuer and date
@@ -46,7 +45,7 @@ public class RedLowNetworkUserCalculationCalculatorTest
       )
       .Build<RedLowNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select(x =>
+      .Select((x, i) =>
       {
         x.UsageNetworkUserCatalogueId =
           x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
@@ -56,78 +55,103 @@ public class RedLowNetworkUserCalculationCalculatorTest
         x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
         x.MeterId = x.ArchivedMeter.Id;
 
+        if (i == 0)
+        {
+          MidpointRoundingSentinel
+            .InjectMidpointRoundingSentinel(x);
+          return x;
+        }
+
         var faker = new Faker();
 
-          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageMeterFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageMeterFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyBusinessUsageFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyBusinessUsageFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyRenewableEnergyFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyRenewableEnergyFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageFeeTotal_EUR = Round(
-            x.UsageActiveEnergyTotalImportT1.Total
+        x.UsageFeeTotal_EUR = Round(
+          x.UsageActiveEnergyTotalImportT1.Total
             + x.UsageActiveEnergyTotalImportT2.Total
             + x.UsageActivePowerTotalImportT1Peak.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-            2);
-          x.SupplyFeeTotal_EUR = Round(
-            x.SupplyActiveEnergyTotalImportT1.Total
+          2
+        );
+        x.SupplyFeeTotal_EUR = Round(
+          x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-            2);
-          x.Total_EUR = Round(
-            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-            2);
+          2
+        );
+        x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
@@ -46,116 +46,118 @@ public class RedLowNetworkUserCalculationCalculatorTest
       )
       .Build<RedLowNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select((x, i) =>
-      {
-        x.UsageNetworkUserCatalogueId =
-          x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
-        x.SupplyRegulatoryCatalogueId = x.ArchivedSupplyRegulatoryCatalogue.Id;
-        x.NetworkUserMeasurementLocationId =
-          x.ArchivedNetworkUserMeasurementLocation.Id;
-        x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
-        x.MeterId = x.ArchivedMeter.Id;
-
-        if (i == 0)
+      .Select(
+        (x, i) =>
         {
-          MidpointRoundingSentinel
-            .InjectCalculationSentinel(x);
+          x.UsageNetworkUserCatalogueId =
+            x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
+          x.SupplyRegulatoryCatalogueId =
+            x.ArchivedSupplyRegulatoryCatalogue.Id;
+          x.NetworkUserMeasurementLocationId =
+            x.ArchivedNetworkUserMeasurementLocation.Id;
+          x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
+          x.MeterId = x.ArchivedMeter.Id;
+
+          if (i == 0)
+          {
+            MidpointRoundingSentinel.InjectCalculationSentinel(x);
+            return x;
+          }
+
+          var faker = new Faker();
+
+          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT1.Total
+              + x.UsageActiveEnergyTotalImportT2.Total
+              + x.UsageActivePowerTotalImportT1Peak.Total
+              + x.UsageReactiveEnergyTotalRampedT0.Total
+              + x.UsageMeterFee.Total,
+            2
+          );
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
+              + x.SupplyActiveEnergyTotalImportT2.Total
+              + x.SupplyBusinessUsageFee.Total
+              + x.SupplyRenewableEnergyFee.Total,
+            2
+          );
+          x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
+
           return x;
         }
-
-        var faker = new Faker();
-
-        x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageMeterFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyBusinessUsageFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyRenewableEnergyFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageFeeTotal_EUR = Round(
-          x.UsageActiveEnergyTotalImportT1.Total
-            + x.UsageActiveEnergyTotalImportT2.Total
-            + x.UsageActivePowerTotalImportT1Peak.Total
-            + x.UsageReactiveEnergyTotalRampedT0.Total
-            + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
-            + x.SupplyActiveEnergyTotalImportT2.Total
-            + x.SupplyBusinessUsageFee.Total
-            + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
-
-        return x;
-      });
+      );
   }
 
   [Test]

--- a/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
@@ -7,6 +7,7 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
+using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
@@ -58,7 +59,7 @@ public class RedLowNetworkUserCalculationCalculatorTest
         if (i == 0)
         {
           MidpointRoundingSentinel
-            .InjectMidpointRoundingSentinel(x);
+            .InjectCalculationSentinel(x);
           return x;
         }
 

--- a/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/RedLowNetworkUserCalculationCalculatorTest.cs
@@ -9,6 +9,8 @@ using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 // NITPICK: test issuer and date
 
 namespace Ozds.Business.Test.Finance;
@@ -56,97 +58,76 @@ public class RedLowNetworkUserCalculationCalculatorTest
 
         var faker = new Faker();
 
-        x.UsageActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageActivePowerTotalImportT1Peak.Amount_kW = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageMeterFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageFeeTotal_EUR = System.Math.Round(
-          x.UsageActiveEnergyTotalImportT1.Total
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT1.Total
             + x.UsageActiveEnergyTotalImportT2.Total
             + x.UsageActivePowerTotalImportT1Peak.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = System.Math.Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
+            2);
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = System.Math.Round(
-          x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-          2
-        );
+            2);
+          x.Total_EUR = Round(
+            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+            2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
@@ -9,6 +9,8 @@ using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 // NITPICK: test issuer and date
 
 namespace Ozds.Business.Test.Finance;
@@ -56,88 +58,69 @@ public class WhiteLowNetworkUserCalculationCalculatorTest
 
         var faker = new Faker();
 
-        x.UsageActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageMeterFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageFeeTotal_EUR = System.Math.Round(
-          x.UsageActiveEnergyTotalImportT1.Total
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT1.Total
             + x.UsageActiveEnergyTotalImportT2.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = System.Math.Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
+            2);
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = System.Math.Round(
-          x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-          2
-        );
+            2);
+          x.Total_EUR = Round(
+            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+            2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
@@ -8,7 +8,6 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 // NITPICK: test issuer and date
@@ -46,7 +45,7 @@ public class WhiteLowNetworkUserCalculationCalculatorTest
       )
       .Build<WhiteLowNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select(x =>
+      .Select((x, i) =>
       {
         x.UsageNetworkUserCatalogueId =
           x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
@@ -56,71 +55,94 @@ public class WhiteLowNetworkUserCalculationCalculatorTest
         x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
         x.MeterId = x.ArchivedMeter.Id;
 
+        if (i == 0)
+        {
+          MidpointRoundingSentinel
+            .InjectMidpointRoundingSentinel(x);
+          return x;
+        }
+
         var faker = new Faker();
 
-          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageMeterFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageMeterFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyBusinessUsageFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyBusinessUsageFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyRenewableEnergyFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyRenewableEnergyFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageFeeTotal_EUR = Round(
-            x.UsageActiveEnergyTotalImportT1.Total
+        x.UsageFeeTotal_EUR = Round(
+          x.UsageActiveEnergyTotalImportT1.Total
             + x.UsageActiveEnergyTotalImportT2.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-            2);
-          x.SupplyFeeTotal_EUR = Round(
-            x.SupplyActiveEnergyTotalImportT1.Total
+          2
+        );
+        x.SupplyFeeTotal_EUR = Round(
+          x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-            2);
-          x.Total_EUR = Round(
-            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-            2);
+          2
+        );
+        x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
@@ -46,107 +46,109 @@ public class WhiteLowNetworkUserCalculationCalculatorTest
       )
       .Build<WhiteLowNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select((x, i) =>
-      {
-        x.UsageNetworkUserCatalogueId =
-          x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
-        x.SupplyRegulatoryCatalogueId = x.ArchivedSupplyRegulatoryCatalogue.Id;
-        x.NetworkUserMeasurementLocationId =
-          x.ArchivedNetworkUserMeasurementLocation.Id;
-        x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
-        x.MeterId = x.ArchivedMeter.Id;
-
-        if (i == 0)
+      .Select(
+        (x, i) =>
         {
-          MidpointRoundingSentinel
-            .InjectCalculationSentinel(x);
+          x.UsageNetworkUserCatalogueId =
+            x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
+          x.SupplyRegulatoryCatalogueId =
+            x.ArchivedSupplyRegulatoryCatalogue.Id;
+          x.NetworkUserMeasurementLocationId =
+            x.ArchivedNetworkUserMeasurementLocation.Id;
+          x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
+          x.MeterId = x.ArchivedMeter.Id;
+
+          if (i == 0)
+          {
+            MidpointRoundingSentinel.InjectCalculationSentinel(x);
+            return x;
+          }
+
+          var faker = new Faker();
+
+          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT1.Total
+              + x.UsageActiveEnergyTotalImportT2.Total
+              + x.UsageReactiveEnergyTotalRampedT0.Total
+              + x.UsageMeterFee.Total,
+            2
+          );
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
+              + x.SupplyActiveEnergyTotalImportT2.Total
+              + x.SupplyBusinessUsageFee.Total
+              + x.SupplyRenewableEnergyFee.Total,
+            2
+          );
+          x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
+
           return x;
         }
-
-        var faker = new Faker();
-
-        x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageMeterFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyBusinessUsageFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyRenewableEnergyFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageFeeTotal_EUR = Round(
-          x.UsageActiveEnergyTotalImportT1.Total
-            + x.UsageActiveEnergyTotalImportT2.Total
-            + x.UsageReactiveEnergyTotalRampedT0.Total
-            + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
-            + x.SupplyActiveEnergyTotalImportT2.Total
-            + x.SupplyBusinessUsageFee.Total
-            + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
-
-        return x;
-      });
+      );
   }
 
   [Test]

--- a/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteLowNetworkUserCalculationCalculatorTest.cs
@@ -7,6 +7,7 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
+using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
@@ -58,7 +59,7 @@ public class WhiteLowNetworkUserCalculationCalculatorTest
         if (i == 0)
         {
           MidpointRoundingSentinel
-            .InjectMidpointRoundingSentinel(x);
+            .InjectCalculationSentinel(x);
           return x;
         }
 

--- a/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
@@ -8,7 +8,6 @@ using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 // NITPICK: test issuer and date
@@ -46,7 +45,7 @@ public class WhiteMediumNetworkUserCalculationCalculatorTest
       )
       .Build<WhiteMediumNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select(x =>
+      .Select((x, i) =>
       {
         x.UsageNetworkUserCatalogueId =
           x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
@@ -56,78 +55,103 @@ public class WhiteMediumNetworkUserCalculationCalculatorTest
         x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
         x.MeterId = x.ArchivedMeter.Id;
 
+        if (i == 0)
+        {
+          MidpointRoundingSentinel
+            .InjectMidpointRoundingSentinel(x);
+          return x;
+        }
+
         var faker = new Faker();
 
-          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageMeterFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.UsageMeterFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyBusinessUsageFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyBusinessUsageFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.SupplyRenewableEnergyFee.Total_EUR = Round(
-            faker.Random.Decimal(
-              Constants.MinTotalValue,
-              Constants.MaxTotalValue),
-            2);
+        x.SupplyRenewableEnergyFee.Total_EUR = Round(
+          faker.Random.Decimal(
+            Constants.MinTotalValue,
+            Constants.MaxTotalValue
+          ),
+          2
+        );
 
-          x.UsageFeeTotal_EUR = Round(
-            x.UsageActiveEnergyTotalImportT1.Total
+        x.UsageFeeTotal_EUR = Round(
+          x.UsageActiveEnergyTotalImportT1.Total
             + x.UsageActiveEnergyTotalImportT2.Total
             + x.UsageActivePowerTotalImportT1Peak.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-            2);
-          x.SupplyFeeTotal_EUR = Round(
-            x.SupplyActiveEnergyTotalImportT1.Total
+          2
+        );
+        x.SupplyFeeTotal_EUR = Round(
+          x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-            2);
-          x.Total_EUR = Round(
-            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-            2);
+          2
+        );
+        x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
@@ -7,6 +7,7 @@ using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Complex;
 using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
+using Ozds.Business.Test.Sentinel;
 using Ozds.Time.Queries.Abstractions;
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
@@ -58,7 +59,7 @@ public class WhiteMediumNetworkUserCalculationCalculatorTest
         if (i == 0)
         {
           MidpointRoundingSentinel
-            .InjectMidpointRoundingSentinel(x);
+            .InjectCalculationSentinel(x);
           return x;
         }
 

--- a/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
@@ -46,116 +46,118 @@ public class WhiteMediumNetworkUserCalculationCalculatorTest
       )
       .Build<WhiteMediumNetworkUserCalculationModel>()
       .CreateMany(Constants.DefaultFuzzCount)
-      .Select((x, i) =>
-      {
-        x.UsageNetworkUserCatalogueId =
-          x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
-        x.SupplyRegulatoryCatalogueId = x.ArchivedSupplyRegulatoryCatalogue.Id;
-        x.NetworkUserMeasurementLocationId =
-          x.ArchivedNetworkUserMeasurementLocation.Id;
-        x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
-        x.MeterId = x.ArchivedMeter.Id;
-
-        if (i == 0)
+      .Select(
+        (x, i) =>
         {
-          MidpointRoundingSentinel
-            .InjectCalculationSentinel(x);
+          x.UsageNetworkUserCatalogueId =
+            x.ConcreteArchivedUsageNetworkUserCatalogue.Id;
+          x.SupplyRegulatoryCatalogueId =
+            x.ArchivedSupplyRegulatoryCatalogue.Id;
+          x.NetworkUserMeasurementLocationId =
+            x.ArchivedNetworkUserMeasurementLocation.Id;
+          x.Remark = x.ArchivedNetworkUserMeasurementLocation.CalculationRemark;
+          x.MeterId = x.ArchivedMeter.Id;
+
+          if (i == 0)
+          {
+            MidpointRoundingSentinel.InjectCalculationSentinel(x);
+            return x;
+          }
+
+          var faker = new Faker();
+
+          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue
+            ),
+            2
+          );
+
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT1.Total
+              + x.UsageActiveEnergyTotalImportT2.Total
+              + x.UsageActivePowerTotalImportT1Peak.Total
+              + x.UsageReactiveEnergyTotalRampedT0.Total
+              + x.UsageMeterFee.Total,
+            2
+          );
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
+              + x.SupplyActiveEnergyTotalImportT2.Total
+              + x.SupplyBusinessUsageFee.Total
+              + x.SupplyRenewableEnergyFee.Total,
+            2
+          );
+          x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
+
           return x;
         }
-
-        var faker = new Faker();
-
-        x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageMeterFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyBusinessUsageFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.SupplyRenewableEnergyFee.Total_EUR = Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
-
-        x.UsageFeeTotal_EUR = Round(
-          x.UsageActiveEnergyTotalImportT1.Total
-            + x.UsageActiveEnergyTotalImportT2.Total
-            + x.UsageActivePowerTotalImportT1Peak.Total
-            + x.UsageReactiveEnergyTotalRampedT0.Total
-            + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
-            + x.SupplyActiveEnergyTotalImportT2.Total
-            + x.SupplyBusinessUsageFee.Total
-            + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = Round(x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR, 2);
-
-        return x;
-      });
+      );
   }
 
   [Test]

--- a/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
+++ b/test/Ozds.Business.Test/Finance/WhiteMediumNetworkUserCalculationCalculatorTest.cs
@@ -9,6 +9,8 @@ using Ozds.Business.Models.Composite;
 using Ozds.Business.Queries;
 using Ozds.Time.Queries.Abstractions;
 
+using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
+
 // NITPICK: test issuer and date
 
 namespace Ozds.Business.Test.Finance;
@@ -56,97 +58,76 @@ public class WhiteMediumNetworkUserCalculationCalculatorTest
 
         var faker = new Faker();
 
-        x.UsageActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageReactiveEnergyTotalRampedT0.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageReactiveEnergyTotalRampedT0.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageActivePowerTotalImportT1Peak.Amount_kW = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageActivePowerTotalImportT1Peak.Amount_kW = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageMeterFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.UsageMeterFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT1.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT1.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyActiveEnergyTotalImportT2.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyActiveEnergyTotalImportT2.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyBusinessUsageFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyBusinessUsageFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.SupplyRenewableEnergyFee.Total_EUR = System.Math.Round(
-          faker.Random.Decimal(
-            Constants.MinTotalValue,
-            Constants.MaxTotalValue
-          ),
-          2
-        );
+          x.SupplyRenewableEnergyFee.Total_EUR = Round(
+            faker.Random.Decimal(
+              Constants.MinTotalValue,
+              Constants.MaxTotalValue),
+            2);
 
-        x.UsageFeeTotal_EUR = System.Math.Round(
-          x.UsageActiveEnergyTotalImportT1.Total
+          x.UsageFeeTotal_EUR = Round(
+            x.UsageActiveEnergyTotalImportT1.Total
             + x.UsageActiveEnergyTotalImportT2.Total
             + x.UsageActivePowerTotalImportT1Peak.Total
             + x.UsageReactiveEnergyTotalRampedT0.Total
             + x.UsageMeterFee.Total,
-          2
-        );
-        x.SupplyFeeTotal_EUR = System.Math.Round(
-          x.SupplyActiveEnergyTotalImportT1.Total
+            2);
+          x.SupplyFeeTotal_EUR = Round(
+            x.SupplyActiveEnergyTotalImportT1.Total
             + x.SupplyActiveEnergyTotalImportT2.Total
             + x.SupplyBusinessUsageFee.Total
             + x.SupplyRenewableEnergyFee.Total,
-          2
-        );
-        x.Total_EUR = System.Math.Round(
-          x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
-          2
-        );
+            2);
+          x.Total_EUR = Round(
+            x.SupplyFeeTotal_EUR + x.UsageFeeTotal_EUR,
+            2);
 
         return x;
       });

--- a/test/Ozds.Business.Test/Sentinel/MidpointRoundingSentinel.cs
+++ b/test/Ozds.Business.Test/Sentinel/MidpointRoundingSentinel.cs
@@ -1,27 +1,22 @@
 using Ozds.Business.Models;
 using Ozds.Business.Models.Base;
 using Ozds.Business.Models.Composite;
-
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
 namespace Ozds.Business.Test.Sentinel;
 
 public static class MidpointRoundingSentinel
 {
-
   public static void InjectInvoiceSentinel(
-      CalculatedNetworkUserInvoiceModel model,
-      decimal sentinel = 2.685M // NOTE: default sentinel value
-                                // that differs between bankers and away from zero rounding
-    )
+    CalculatedNetworkUserInvoiceModel model,
+    decimal sentinel = 2.685M // NOTE: default sentinel value
+  // that differs between bankers and away from zero rounding
+  )
   {
-
-    model.Invoice
-      .ArchivedRegulatoryCatalogue.TaxRate_Percent = 0M;
+    model.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent = 0M;
 
     var meteredCalculations = model
-      .Calculations
-      .OfType<MeteredNetworkUserCalculationModel>()
+      .Calculations.OfType<MeteredNetworkUserCalculationModel>()
       .ToList();
 
     if (meteredCalculations.Count == 0)
@@ -55,6 +50,7 @@ public static class MidpointRoundingSentinel
     model.SupplyFeeTotal_EUR = 0M;
     model.Total_EUR = model.UsageFeeTotal_EUR;
   }
+
   private static void InjectCalculationSentinelInternal(
     MeteredNetworkUserCalculationModel model
   )

--- a/test/Ozds.Business.Test/Sentinel/MidpointRoundingSentinel.cs
+++ b/test/Ozds.Business.Test/Sentinel/MidpointRoundingSentinel.cs
@@ -4,19 +4,20 @@ using Ozds.Business.Models.Composite;
 
 using static Ozds.Business.Extensions.PrimitiveRoundingExtensions;
 
-namespace Ozds.Business.Test.Finance;
+namespace Ozds.Business.Test.Sentinel;
 
 public static class MidpointRoundingSentinel
 {
 
-  public static void InjectMidpointRoundingSentinel(
+  public static void InjectInvoiceSentinel(
       CalculatedNetworkUserInvoiceModel model,
       decimal sentinel = 2.685M // NOTE: default sentinel value
                                 // that differs between bankers and away from zero rounding
     )
   {
 
-    model.Invoice.ArchivedRegulatoryCatalogue.TaxRate_Percent = 0M;
+    model.Invoice
+      .ArchivedRegulatoryCatalogue.TaxRate_Percent = 0M;
 
     var meteredCalculations = model
       .Calculations
@@ -30,7 +31,7 @@ public static class MidpointRoundingSentinel
 
     foreach (var calculation in meteredCalculations)
     {
-      InjectMidpointRoundingSentinelInternal(calculation);
+      InjectCalculationSentinelInternal(calculation);
     }
 
     var target = meteredCalculations[0];
@@ -41,7 +42,20 @@ public static class MidpointRoundingSentinel
     target.Total_EUR = target.UsageFeeTotal_EUR;
   }
 
-  private static void InjectMidpointRoundingSentinelInternal(
+  public static void InjectCalculationSentinel(
+    MeteredNetworkUserCalculationModel model,
+    decimal sentinel = 2.685M
+  )
+  {
+    InjectCalculationSentinelInternal(model);
+
+    model.UsageMeterFee.Total_EUR = sentinel;
+
+    model.UsageFeeTotal_EUR = Round(sentinel, 2);
+    model.SupplyFeeTotal_EUR = 0M;
+    model.Total_EUR = model.UsageFeeTotal_EUR;
+  }
+  private static void InjectCalculationSentinelInternal(
     MeteredNetworkUserCalculationModel model
   )
   {
@@ -83,19 +97,5 @@ public static class MidpointRoundingSentinel
     model.UsageFeeTotal_EUR = 0M;
     model.SupplyFeeTotal_EUR = 0M;
     model.Total_EUR = 0M;
-  }
-
-  public static void InjectMidpointRoundingSentinel(
-    MeteredNetworkUserCalculationModel model,
-    decimal sentinel = 2.685M
-  )
-  {
-    InjectMidpointRoundingSentinelInternal(model);
-
-    model.UsageMeterFee.Total_EUR = sentinel;
-
-    model.UsageFeeTotal_EUR = Round(sentinel, 2);
-    model.SupplyFeeTotal_EUR = 0M;
-    model.Total_EUR = model.UsageFeeTotal_EUR;
   }
 }


### PR DESCRIPTION
# Fix #268 
@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

What was causing this behavior was the type of rounding operation C# uses by default on `System.Math.Round()` static method. C# uses bankers type rounding which can provide different results than the more known away-from-zero method which almost everybody else uses. 

Example:

By default - bankers type rounding:
<img width="411" height="21" alt="image" src="https://github.com/user-attachments/assets/1160ec18-3796-45f5-98e2-9954dac47416" />
<img width="82" height="65" alt="image" src="https://github.com/user-attachments/assets/29b9c3c8-6d2f-4c9e-9dd8-e06a13b17814" />

Away-from-zero rounding:
<img width="715" height="92" alt="image" src="https://github.com/user-attachments/assets/bec89198-cf6e-4bf4-8a84-b75d82b2af8d" />
<img width="81" height="80" alt="image" src="https://github.com/user-attachments/assets/29fe8c2d-f018-43db-8237-3a43ebe16bb5" />

This caused data discrepancies between the generated invoice(s) and manually calculated values from db/excel.

## Testing

Also for testing, simple sentinel injector (`MidpointRoudingSentinel`) has been created which sets values on invoice and calculation models.

This sentinel just forces all predefined properties used in creating/calculating invoice to be set to so that this specific object can simulate rounding errors that happened. 

<img width="390" height="118" alt="image" src="https://github.com/user-attachments/assets/f47df1e5-bac0-46bc-a0a2-1433d9e01923" />






