### PR TITLE
271 fixture insert returned discrepancy with database returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `Insert` method in `TestMeasurementFixture` now contains boolean attribute
+  `returnAllCreated` which can limit return to be only in specified range
+- `Insert` method in `Worker` in `TestMeasurementFixture` does not split
+  measurement date range into smaller intervals - this causes problems with
+  `AggregateUpserter`
 - change all calculators and calculator tests for business now use rounding type
   `MidpointRounding.AwayFromZero` defined in `PrimitiveRoundingExtensions`
 

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -51,7 +51,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         ],
         dateFrom,
         dateTo,
-        cancellationToken
+        cancellationToken,
+        true,
+        false
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
@@ -268,7 +270,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         ],
         dateFrom,
         dateTo,
-        cancellationToken
+        cancellationToken,
+        true,
+        false
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
@@ -368,7 +372,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         ],
         dateFrom,
         dateTo,
-        cancellationToken
+        cancellationToken,
+        true,
+        false
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)

--- a/test/Ozds.Server.Test/Fixtures/TestMeasurementFixture.cs
+++ b/test/Ozds.Server.Test/Fixtures/TestMeasurementFixture.cs
@@ -41,9 +41,13 @@ public class TestMeasurementFixture(ServiceComposition composition)
       )
     )
     {
-      if (returnAllCreated ||
-          measurements is not IAggregate ||
-          (measurements.Timestamp >= dateFrom && measurements.Timestamp <= dateTo))
+      if (
+        returnAllCreated
+        || measurements is not IAggregate
+        || (
+          measurements.Timestamp >= dateFrom && measurements.Timestamp <= dateTo
+        )
+      )
       {
         yield return measurements;
       }
@@ -134,16 +138,13 @@ public class TestMeasurementFixture(ServiceComposition composition)
       var clonedIds = ids.Where(id => !generatedIds.Contains(id));
 
       var records = generator.BatchGenerateMeasurementRecords(
-          dateFrom,
-          dateTo,
-          generatedIds,
-          cancellationToken
-      );
-
-      var measurements = converter.ConvertToModels(
-        records,
+        dateFrom,
+        dateTo,
+        generatedIds,
         cancellationToken
       );
+
+      var measurements = converter.ConvertToModels(records, cancellationToken);
 
       var aggregated = aggregatesOnly
         ? aggregateUpserter.UpsertAggregates(

--- a/test/Ozds.Server.Test/Fixtures/TestMeasurementFixture.cs
+++ b/test/Ozds.Server.Test/Fixtures/TestMeasurementFixture.cs
@@ -23,7 +23,8 @@ public class TestMeasurementFixture(ServiceComposition composition)
     DateTimeOffset dateFrom,
     DateTimeOffset dateTo,
     [EnumeratorCancellation] CancellationToken cancellationToken,
-    bool aggregatesOnly = true
+    bool aggregatesOnly = true,
+    bool returnAllCreated = true
   )
   {
     await using var scope = composition.Ozds.Services.CreateAsyncScope();
@@ -40,7 +41,12 @@ public class TestMeasurementFixture(ServiceComposition composition)
       )
     )
     {
-      yield return measurements;
+      if (returnAllCreated ||
+          measurements is not IAggregate ||
+          (measurements.Timestamp >= dateFrom && measurements.Timestamp <= dateTo))
+      {
+        yield return measurements;
+      }
     }
   }
 

--- a/test/Ozds.Server.Test/Fixtures/TestMeasurementFixture.cs
+++ b/test/Ozds.Server.Test/Fixtures/TestMeasurementFixture.cs
@@ -127,48 +127,39 @@ public class TestMeasurementFixture(ServiceComposition composition)
 
       var clonedIds = ids.Where(id => !generatedIds.Contains(id));
 
-      foreach (
-        var date in enumerable.Split(
+      var records = generator.BatchGenerateMeasurementRecords(
           dateFrom,
           dateTo,
-          Environment.ProcessorCount
-        )
-      )
-      {
-        var records = generator.BatchGenerateMeasurementRecords(
-          date.DateFrom,
-          date.DateTo,
           generatedIds,
           cancellationToken
-        );
+      );
 
-        var measurements = converter.ConvertToModels(
-          records,
+      var measurements = converter.ConvertToModels(
+        records,
+        cancellationToken
+      );
+
+      var aggregated = aggregatesOnly
+        ? aggregateUpserter.UpsertAggregates(
+          aggregateConverter.ToAggregates(measurements, cancellationToken),
+          cancellationToken
+        )
+        : aggregateUpserter.UpsertMeasurements(
+          aggregateConverter.WithAggregates(measurements, cancellationToken),
           cancellationToken
         );
 
-        var aggregated = aggregatesOnly
-          ? aggregateUpserter.UpsertAggregates(
-            aggregateConverter.ToAggregates(measurements, cancellationToken),
-            cancellationToken
-          )
-          : aggregateUpserter.UpsertMeasurements(
-            aggregateConverter.WithAggregates(measurements, cancellationToken),
-            cancellationToken
-          );
+      var cloned = cloner.CloneWith(aggregated, clonedIds, cancellationToken);
 
-        var cloned = cloner.CloneWith(aggregated, clonedIds, cancellationToken);
+      await foreach (
+        var batch in enumerable.Batch(cloned, BatchSize, cancellationToken)
+      )
+      {
+        var inserted = await insertClient.Insert(batch, cancellationToken);
 
-        await foreach (
-          var batch in enumerable.Batch(cloned, BatchSize, cancellationToken)
-        )
+        foreach (var measurement in inserted)
         {
-          var inserted = await insertClient.Insert(batch, cancellationToken);
-
-          foreach (var measurement in inserted)
-          {
-            yield return measurement;
-          }
+          yield return measurement;
         }
       }
     }

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -116,9 +116,6 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
     itemsAfter
       .Items.Should()
-      .AllSatisfy(x => x.Timestamp.Should().BeAfter(deletionCutoff));
-    itemsAfter
-      .Items.Should()
       .AllSatisfy(x =>
         x.Timestamp.Should().BeOnOrAfter(determinedTimestampMinimum)
       );


### PR DESCRIPTION
# Task
# Fixes #271.

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

`Split` method along with implementation of `AggregateUpserter` was causing duplicates to be returned from `Insert` method used in all API tests in ˙Ozds.Server.Test˙. 

Detailed information about this problem can be found on #271.

As a "hotfix" I've just removed that split since it apparently is used to split into possible processor cores for multitasking but for loop and the `Split` method themselves are synchronous.

### Appendix

Also there was a slight mismatch in yielded results from `Insert` methods in `TestMeasurementFixture` and real DB query since `Insert` was modified to always return everything it has processed, including aggregates that are created outside interval as a byproduct of aggregation of measurement .

e.g you create measurement in range 14:03 to 14:50, but this also creates aggregates of interval `quarter_hour` with timestamp 14:00 and 15:00 which fall outside interval range that was used in tests

DB does not pick up this aggregates since they are queried explicitly by timestamp and theirs timestamp is outside determined boundaries but method `Insert` does return them.

Fix is again really simple and more of a patch since I've added just one boolean into main `Insert` which is only used in tests to query and discard aggregates outside intervals if the boolean is switched on.

## Testing

Easiest one is to just run all API tests again and see that they all finish with success.

I've personally directly queried database and compared query and insert results using different tools.
