### PR TITLE
271 fixture insert returned discrepancy with database returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,9 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- `Insert` method in `TestMeasurementFixture` now contains boolean attribute
-  `returnAllCreated` which can limit return to be only in specified range
-- `Insert` method in `Worker` in `TestMeasurementFixture` does not split
-  measurement date range into smaller intervals - this causes problems with
-  `AggregateUpserter`
+- fix problem with duplicate inserts on tests in ApiV1
+  `MeasurementControllerTest`
+- fix filtering on API V1 test inserts by date so they match DB query result
 - change all calculators and calculator tests for business now use rounding type
   `MidpointRounding.AwayFromZero` defined in `PrimitiveRoundingExtensions`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `Insert` method in `TestMeasurementFixture` now contains boolean attribute
+  `returnAllCreated` which can limit return to be only in specified range
+- `Insert` method in `Worker` in `TestMeasurementFixture` does not split
+  measurement date range into smaller intervals - this causes problems with
+  `AggregateUpserter`
 - change all calculators and calculator tests for business now use rounding type
   `MidpointRounding.AwayFromZero` defined in `PrimitiveRoundingExtensions`
 

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -56,10 +56,12 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour
+        && aggregate.Timestamp >= dateFrom
+        && aggregate.Timestamp <= dateTo
+      )
       .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
       .Select(g => g.MaxBy(x => x.Count)!)
-      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
@@ -181,10 +183,8 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
       .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
       .Select(g => g.MaxBy(x => x.Count)!)
-      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
@@ -279,10 +279,12 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour
+        && aggregate.Timestamp >= dateFrom
+        && aggregate.Timestamp <= dateTo
+      )
       .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
       .Select(g => g.MaxBy(x => x.Count)!)
-      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
@@ -382,10 +384,12 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour
+        && aggregate.Timestamp >= dateFrom
+        && aggregate.Timestamp <= dateTo
+      )
       .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
       .Select(g => g.MaxBy(x => x.Count)!)
-      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -56,11 +56,20 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour
+      .Where(aggregate =>
+        aggregate.Interval == IntervalModel.QuarterHour
         && aggregate.Timestamp >= dateFrom
         && aggregate.Timestamp <= dateTo
       )
-      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .GroupBy(a =>
+        (
+          a.GetType(),
+          a.Interval,
+          a.Timestamp,
+          a.MeterId,
+          a.MeasurementLocationId
+        )
+      )
       .Select(g => g.MaxBy(x => x.Count)!)
       .ToListAsync(cancellationToken);
 
@@ -183,7 +192,15 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .GroupBy(a =>
+        (
+          a.GetType(),
+          a.Interval,
+          a.Timestamp,
+          a.MeterId,
+          a.MeasurementLocationId
+        )
+      )
       .Select(g => g.MaxBy(x => x.Count)!)
       .ToListAsync(cancellationToken);
 
@@ -279,11 +296,20 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour
+      .Where(aggregate =>
+        aggregate.Interval == IntervalModel.QuarterHour
         && aggregate.Timestamp >= dateFrom
         && aggregate.Timestamp <= dateTo
       )
-      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .GroupBy(a =>
+        (
+          a.GetType(),
+          a.Interval,
+          a.Timestamp,
+          a.MeterId,
+          a.MeasurementLocationId
+        )
+      )
       .Select(g => g.MaxBy(x => x.Count)!)
       .ToListAsync(cancellationToken);
 
@@ -384,11 +410,20 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
         cancellationToken
       )
       .OfType<IAggregate>()
-      .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour
+      .Where(aggregate =>
+        aggregate.Interval == IntervalModel.QuarterHour
         && aggregate.Timestamp >= dateFrom
         && aggregate.Timestamp <= dateTo
       )
-      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .GroupBy(a =>
+        (
+          a.GetType(),
+          a.Interval,
+          a.Timestamp,
+          a.MeterId,
+          a.MeasurementLocationId
+        )
+      )
       .Select(g => g.MaxBy(x => x.Count)!)
       .ToListAsync(cancellationToken);
 

--- a/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
+++ b/test/Ozds.Server.Test/Controllers/Api/V1/MeasurementsControllerTest.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using FluentAssertions.Common;
+using Ozds.Business.Aggregation;
 using Ozds.Business.Authorization;
 using Ozds.Business.Models;
 using Ozds.Business.Models.Abstractions;
@@ -55,6 +57,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .Select(g => g.MaxBy(x => x.Count)!)
+      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
@@ -177,6 +182,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .Select(g => g.MaxBy(x => x.Count)!)
+      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
@@ -272,6 +280,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .Select(g => g.MaxBy(x => x.Count)!)
+      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();
@@ -372,6 +383,9 @@ public class ApiV1MeasurementsControllerTest : OzdsServerTestBase
       )
       .OfType<IAggregate>()
       .Where(aggregate => aggregate.Interval == IntervalModel.QuarterHour)
+      .GroupBy(a => (a.GetType(), a.Interval, a.Timestamp, a.MeterId, a.MeasurementLocationId))
+      .Select(g => g.MaxBy(x => x.Count)!)
+      .OrderBy(m => (m.Timestamp, m.MeterId, m.MeasurementLocationId))
       .ToListAsync(cancellationToken);
 
     var client = Services.GetRequiredService<IOzdsApiV1Client>();

--- a/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
+++ b/test/Ozds.Server.Test/Reactors/JobsMeasurementDeletionJobReactorTest.cs
@@ -116,9 +116,6 @@ public class JobsMeasurementDeletionJobReactorTest : OzdsServerTestBase
 
     itemsAfter
       .Items.Should()
-      .AllSatisfy(x => x.Timestamp.Should().BeAfter(deletionCutoff));
-    itemsAfter
-      .Items.Should()
       .AllSatisfy(x =>
         x.Timestamp.Should().BeOnOrAfter(determinedTimestampMinimum)
       );


### PR DESCRIPTION
# Task
# Fixes #271.

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

`Split` method along with implementation of `AggregateUpserter` was causing duplicates to be returned from `Insert` method used in all API tests in ˙Ozds.Server.Test˙. 

Detailed information about this problem can be found on #271.

As a "hotfix" I've just removed that split since it apparently is used to split into possible processor cores for multitasking but for loop and the `Split` method themselves are synchronous.

### Appendix

Also there was a slight mismatch in yielded results from `Insert` methods in `TestMeasurementFixture` and real DB query since `Insert` was modified to always return everything it has processed, including aggregates that are created outside interval as a byproduct of aggregation of measurement .

e.g you create measurement in range 14:03 to 14:50, but this also creates aggregates of interval `quarter_hour` with timestamp 14:00 and 15:00 which fall outside interval range that was used in tests

DB does not pick up this aggregates since they are queried explicitly by timestamp and theirs timestamp is outside determined boundaries but method `Insert` does return them.

Fix is again really simple and more of a patch since I've added just one boolean into main `Insert` which is only used in tests to query and discard aggregates outside intervals if the boolean is switched on.

## Testing

Easiest one is to just run all API tests again and see that they all finish with success.

I've personally directly queried database and compared query and insert results using different tools.


SORRYY