### PR TITLE
258 create users option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Fix `MaybeRepresentingUserModel` now has validation which prevents calling
+  edit/create while validation is not satisfied
+
+### Added
+
+- Users page now has "Create user" button to the Users administration page,
+  visible only to operators
+- Added `NewPasswordModel` class with full validation which is used for user
+  creation
+- Added `NewPasswordEntity` in `Ozds.Users` tailored for creating new user
+  particularly
+- Added `PasswordMutations.Create()` method which sets initial password
+- Added `PasswordField` now contains `For` parameter for validation messaging
+
 ## [1.8.1] - 2025-02-26
 
 ### Removed

--- a/docs/prd-identity-migration.md
+++ b/docs/prd-identity-migration.md
@@ -1,0 +1,356 @@
+# PRD: Identity Management Migration — Authelia/LDAP to ASP.NET Core Identity
+
+| Field          | Value                                      |
+| -------------- | ------------------------------------------ |
+| Author         | OZDS Engineering                           |
+| Status         | Draft                                      |
+| Created        | 2026-03-03                                 |
+| Target Release | TBD                                        |
+| Stakeholders   | Backend, DevOps, Security                  |
+
+---
+
+## 1. Problem Statement
+
+OZDS currently uses **Authelia** (OIDC provider) + **lldap** (LDAP user store)
+as two separate Docker containers for identity management. The `Ozds.Users`
+module bridges both via:
+
+- `Novell.Directory.Ldap` for user CRUD (create, read, update, delete, password
+  change)
+- `Microsoft.AspNetCore.Authentication.OpenIdConnect` for authentication flow
+
+### Pain Points
+
+- Two extra infrastructure services to maintain (Authelia + lldap containers)
+- LDAP is a legacy protocol with poor developer experience
+- No native .NET integration — manual LDAP operations for every user action
+- Dual data source complexity: identity in LDAP, business data in PostgreSQL
+- Limited extensibility (adding claims, roles, or OAuth providers requires
+  Authelia configuration changes)
+
+---
+
+## 2. Goals
+
+1. **Eliminate external identity infrastructure** — remove Authelia and lldap
+   Docker containers
+2. **Unify data storage** — all user data in the existing PostgreSQL database
+3. **Native .NET identity management** — use Microsoft-provided, first-party
+   APIs for user CRUD, authentication, and authorization
+4. **Enable social login** — support optional OAuth providers (Google, Facebook,
+   Microsoft) with minimal configuration
+5. **Preserve business data integrity** — existing `RepresentativeEntity`
+   references must continue to work without database migration
+6. **Self-hosted** — no cloud dependencies, no SaaS
+
+### Non-Goals
+
+- IoT messenger authentication (remains HMAC-based, untouched)
+- Authorization policy changes in `Ozds.Business`
+- Building a standalone identity service for external consumers (can be added
+  later via OpenIddict)
+- Multi-tenancy / realm separation
+
+---
+
+## 3. Current Integration Surface
+
+### 3.1 Architecture (Before)
+
+```
+┌──────────────┐   OIDC   ┌──────────────┐
+│   Authelia   │◄────────►│  Ozds.Server │
+│   (Docker)   │          └──────┬───────┘
+└──────┬───────┘                 │
+       │ LDAP              ┌────▼───────┐
+┌──────▼───────┐           │ Ozds.Users │
+│    lldap     │◄─────────►│  (Novell   │
+│   (Docker)   │  Novell   │   .Ldap)   │
+└──────────────┘  .Ldap    └────────────┘
+```
+
+### 3.2 File Inventory
+
+| Layer                    | Technology                        | Files                                             |
+| ------------------------ | --------------------------------- | ------------------------------------------------- |
+| OIDC Authentication      | Authelia, OpenIdConnect middleware | `Ozds.Users/Extensions/HostExtensions.cs`          |
+| User CRUD                | lldap, Novell.Directory.Ldap      | `Ozds.Users/Queries/UserQueries.cs`                |
+| User Mutations           | lldap, Novell.Directory.Ldap      | `Ozds.Users/Mutations/UserMutations.cs`            |
+| Password Management      | lldap, LDAP Extended Operation    | `Ozds.Users/Mutations/PasswordMutations.cs`        |
+| Configuration            | OIDC + LDAP connection strings    | `Ozds.Users/Options/OzdsUsersOptions.cs`           |
+| App Settings             | OIDC + LDAP sections              | `Ozds.Server/appsettings.Development.json`         |
+| Docker                   | authelia:4.39.4 + lldap:2025-05-19| `docker-compose.yml`                               |
+| Authelia Config          | OIDC client, LDAP backend         | `scripts/auth/configuration.yml`                   |
+| User Entity (identity)   | Simple DTO: Id, Name, Email       | `Ozds.Users/Entities/UserEntity.cs`                |
+| User Entity (business)   | RepresentativeEntity, string ID   | `Ozds.Data/Entities/RepresentativeEntity.cs`       |
+
+### 3.3 Key Coupling Point
+
+`RepresentativeEntity` in PostgreSQL stores the LDAP `uid` as its identifier
+(string). All business logic — invoices, locations, notifications — references
+users through this ID. The migration strategy must preserve this mapping.
+
+---
+
+## 4. Solution Evaluation
+
+### 4.1 Options Considered
+
+| Criterion             | ASP.NET Core Identity | Keycloak          | Duende IdentityServer | OpenIddict          | Entra ID        |
+| --------------------- | --------------------- | ----------------- | --------------------- | ------------------- | --------------- |
+| Embedded in .NET      | **Yes**               | No (Java/Docker)  | Yes                   | Yes                 | No (Cloud)      |
+| Self-hosted           | **Yes**               | Yes               | Yes                   | Yes                 | **No**          |
+| Free / OSS            | **MIT**               | Apache 2.0        | **RPL (Paid)**        | Apache 2.0          | Consumption     |
+| User CRUD API         | **UserManager\<T\>**  | Admin REST API    | None (needs Identity) | None (needs Identity)| Graph API      |
+| PostgreSQL support    | **Native (Npgsql)**   | Own DB required   | Via EF Core           | Via EF Core         | N/A             |
+| External OAuth        | **Built-in**          | Identity Brokering| Via Identity          | Via .NET handlers   | External IDs    |
+| Password management   | **Built-in**          | Built-in          | Via Identity          | Via Identity        | Built-in        |
+| Admin UI              | Must build            | **Built-in**      | Must build            | Must build          | Azure Portal    |
+| Setup complexity      | **Low**               | Medium            | High                  | Medium              | Low             |
+
+### 4.2 Decision
+
+**ASP.NET Core Identity** is the recommended solution.
+
+**Rationale:**
+
+- Only option that is embedded, free, and provides native user CRUD — all three
+  hard requirements
+- Keycloak eliminated: requires a separate Docker container (contradicts
+  "embedded" requirement)
+- Duende IdentityServer eliminated: commercial RPL license (contradicts
+  "free/OSS" requirement)
+- OpenIddict: not needed for Blazor Server cookie auth. Can be added later as a
+  non-breaking enhancement if OIDC endpoints are ever needed for external clients
+- Entra ID eliminated: cloud-only SaaS, not self-hostable
+
+---
+
+## 5. Proposed Solution: ASP.NET Core Identity
+
+### 5.1 Architecture (After)
+
+```
+┌──────────────────────────────────────┐
+│ Ozds.Server                          │
+│                                      │
+│   ASP.NET Core Identity              │
+│   ├─ UserManager<OzdsUser>   (CRUD)  │
+│   ├─ SignInManager<OzdsUser> (Auth)  │
+│   ├─ RoleManager<OzdsRole>  (Roles) │
+│   └─ Cookie Authentication           │
+│                                      │
+│   External OAuth (optional)          │
+│   ├─ Google                          │
+│   ├─ Facebook                        │
+│   └─ Microsoft Account               │
+│                                      │
+│   EF Core ──► PostgreSQL             │
+│   (Identity tables + business data)  │
+└──────────────────────────────────────┘
+```
+
+Two Docker containers eliminated. All identity data in PostgreSQL. Pure C#/.NET
+stack.
+
+### 5.2 Operation Mapping
+
+| Current (LDAP)                          | New (ASP.NET Core Identity)                    |
+| --------------------------------------- | ---------------------------------------------- |
+| `LdapConnection.Search()` find user     | `UserManager<T>.FindByIdAsync()`               |
+| `LdapConnection.Add()` create user      | `UserManager<T>.CreateAsync()`                 |
+| `LdapConnection.Modify()` update user   | `UserManager<T>.UpdateAsync()`                 |
+| `LdapConnection.Delete()` delete user   | `UserManager<T>.DeleteAsync()`                 |
+| LDAP Extended Op, change password       | `UserManager<T>.ChangePasswordAsync()`         |
+| Authelia OIDC, cookie auth              | `SignInManager<T>.PasswordSignInAsync()` + Cookie |
+| Claims from OIDC token                  | `UserManager<T>.GetClaimsAsync()` + `ClaimsPrincipal` |
+| LDAP search with pagination             | EF Core LINQ queries on `AspNetUsers`          |
+
+### 5.3 Custom User Entity
+
+```csharp
+using Microsoft.AspNetCore.Identity;
+
+public class OzdsUser : IdentityUser
+{
+  // IdentityUser.Id is string by default.
+  // Set to existing LDAP uid during migration to preserve
+  // RepresentativeEntity FK references.
+
+  public string DisplayName { get; set; } = string.Empty;
+}
+```
+
+Identity tables are created in the existing PostgreSQL database via a new EF
+Core migration. They can optionally use a separate schema (e.g. `identity.`) to
+avoid naming conflicts.
+
+### 5.4 External OAuth Providers
+
+Built-in NuGet packages, zero custom code:
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" />
+<PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" />
+<PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" />
+```
+
+Each provider is opt-in via configuration. No code changes needed to add or
+remove providers after initial setup.
+
+### 5.5 OpenIddict (Future Option)
+
+Not required for the Blazor Server UI. Add only if OZDS must later act as an
+OIDC provider for external applications (mobile app, third-party integrations).
+OpenIddict is Apache 2.0 licensed and integrates natively with ASP.NET Core
+Identity. Adding it is a non-breaking, additive change.
+
+---
+
+## 6. Migration Plan
+
+### 6.1 Data Migration (50-500 Users)
+
+**Source:** lldap (LDAP entries with `uid`, `cn`, `mail`)
+**Target:** ASP.NET Core Identity tables in PostgreSQL (`AspNetUsers`)
+
+| Step | Action                                                                                  |
+| ---- | --------------------------------------------------------------------------------------- |
+| 1    | Export all lldap users to JSON via LDAP search script                                   |
+| 2    | Create `OzdsUser` for each entry: `Id` = LDAP `uid`, `UserName` = `uid`, `Email` = `mail`, `DisplayName` = `cn` |
+| 3    | Set temporary passwords and flag for mandatory reset on first login                     |
+| 4    | Verify all `RepresentativeEntity.Id` values resolve to migrated `OzdsUser.Id`           |
+
+**Critical constraint:** By setting `IdentityUser.Id` to the existing LDAP
+`uid`, all `RepresentativeEntity` foreign key references are preserved without
+any changes to business data tables.
+
+**Password limitation:** LDAP password hashes cannot be exported from lldap. All
+migrated users must reset their passwords on first login after migration.
+
+### 6.2 Code Migration Scope
+
+| Module                                        | Action                                              | Effort  |
+| --------------------------------------------- | --------------------------------------------------- | ------- |
+| `Ozds.Users/Extensions/HostExtensions.cs`     | Rewrite: replace LDAP + OIDC with Identity DI setup | Medium  |
+| `Ozds.Users/Queries/UserQueries.cs`           | Rewrite: `LdapConnection` to `UserManager<T>`       | Medium  |
+| `Ozds.Users/Mutations/UserMutations.cs`       | Rewrite: LDAP add/modify/delete to `UserManager<T>` | Medium  |
+| `Ozds.Users/Mutations/PasswordMutations.cs`   | Rewrite: LDAP extended op to `ChangePasswordAsync`   | Low     |
+| `Ozds.Users/Options/OzdsUsersOptions.cs`      | Simplify: remove LDAP/OIDC connection string models | Low     |
+| `Ozds.Users/Entities/`                        | Remove or adapt (Identity provides its own entities) | Low     |
+| `Ozds.Users.csproj`                           | Remove `Novell.Directory.Ldap`, add `Microsoft.AspNetCore.Identity.EntityFrameworkCore` | Trivial |
+| Blazor login pages                            | Replace OIDC redirect with Identity login form       | Medium  |
+| EF Migration                                  | Add Identity tables to PostgreSQL                    | Low     |
+| `docker-compose.yml`                          | Remove `auth` + `ldap` services                     | Trivial |
+| `scripts/auth/`, `scripts/ldap/`              | Delete Authelia and lldap config/data                | Trivial |
+| `appsettings.*.json`                          | Remove `Ozds:Users:Ldap` + `Ozds:Users:Oidc`        | Trivial |
+
+### 6.3 Modules Not Affected
+
+| Module                          | Reason                                                       |
+| ------------------------------- | ------------------------------------------------------------ |
+| `Ozds.Business/Authorization/`  | HMAC-based IoT auth — completely independent                 |
+| `Ozds.Business/` (all)          | Consumes `ClaimsPrincipal` — source of claims is transparent |
+| `Ozds.Data/Entities/`           | `RepresentativeEntity.Id` unchanged (same string IDs)        |
+| `Ozds.Client/` (components)     | `OzdsComponentBase` reads `ClaimsPrincipal` — still works    |
+| `Ozds.Iot/`                     | No identity dependency                                       |
+
+---
+
+## 7. Rollback Strategy
+
+- Keep Authelia/lldap Docker definitions commented out (not deleted) until
+  migration is validated in production
+- Identity migration is additive — new tables only, no existing tables modified
+- `RepresentativeEntity` references unchanged (same string IDs)
+- If rollback needed: re-enable Docker services, revert `Ozds.Users` code, drop
+  Identity tables
+
+---
+
+## 8. Risks
+
+| Risk                                                | Likelihood   | Impact | Mitigation                                                            |
+| --------------------------------------------------- | ------------ | ------ | --------------------------------------------------------------------- |
+| ID mismatch during migration breaks business data   | Medium       | High   | Use LDAP `uid` as `IdentityUser.Id` — zero FK changes needed         |
+| Users lose passwords (LDAP hashes not exportable)   | **Certain**  | Medium | Force password reset for all migrated users; communicate in advance   |
+| Missing OIDC capability if future apps need it      | Low          | Low    | Add OpenIddict later — non-breaking, additive change                  |
+| Identity table naming conflicts with existing schema| Low          | Low    | Use separate schema (`identity.`) or prefixed table names             |
+| Blazor login UX regression (form vs redirect)       | Medium       | Low    | Build login page matching current UX; test with users before cutover  |
+
+---
+
+## 9. Effort Estimate
+
+| Phase                                       | Estimate   |
+| ------------------------------------------- | ---------- |
+| Identity + EF Core setup, DI registration   | 1-2 days   |
+| Rewrite `Ozds.Users` (queries, mutations)   | 2-3 days   |
+| User migration script                       | 1 day      |
+| Blazor login flow update                    | 1-2 days   |
+| External OAuth provider setup               | 0.5 day    |
+| Docker and config cleanup                   | 0.5 day    |
+| Testing and validation                      | 2-3 days   |
+| **Total**                                   | **8-12 days** |
+
+---
+
+## 10. Success Criteria
+
+- [ ] All existing users accessible via `UserManager<OzdsUser>` with preserved IDs
+- [ ] Login/logout works via ASP.NET Core Identity cookie authentication
+- [ ] User CRUD (create, read, update, delete) functional through `Ozds.Users`
+- [ ] Password change/reset functional
+- [ ] At least one external OAuth provider (Google) configurable and working
+- [ ] `RepresentativeEntity` and all dependent business logic unchanged
+- [ ] Authelia and lldap Docker containers removed from `docker-compose.yml`
+- [ ] `Novell.Directory.Ldap` package removed from solution
+- [ ] All existing tests pass (`just test-ci`)
+- [ ] No new `lsp_diagnostics` errors in modified files
+
+---
+
+## 11. Resolved Decisions
+
+| #  | Question                                           | Decision                        | Rationale                                                                                       |
+| -- | -------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1  | DbContext strategy for Identity tables              | **Separate `IdentityDbContext`** | Follows existing multi-context pattern (`DataDbContext`, `MessagingDbContext`, `JobsDbContext`). Clean separation of identity schema from business entities. Own migration history. |
+| 2  | Migration script tooling                            | **One-time console app**        | Throwaway script kept in `scripts/` for reference. No ongoing maintenance burden. Not worth integrating into `Ozds.Migration` for a single-use operation. |
+| 3  | Password reset communication                        | **Manual communication**        | Admin sends announcement via existing channels (email blast, internal comms) before cutover. No automated email flow needed. |
+| 4  | Additional LDAP attributes to migrate               | **Id, Name, Email only**        | Current `UserEntity` already captures everything needed. No additional LDAP attributes in use. |
+| 5  | "Remember me" / persistent cookies                  | **Yes**                         | Users can opt in to stay logged in across browser sessions. `SignInManager.PasswordSignInAsync(isPersistent: true)` with configurable cookie expiration. |
+
+### Implications of Decisions
+
+**Separate IdentityDbContext:**
+
+- New project or folder for the context (e.g. within `Ozds.Users` or a new
+  `Ozds.Identity` project)
+- EF Core migrations managed independently:
+  ```
+  dotnet ef migrations add <Name> \
+    --startup-project src/Ozds.Server/Ozds.Server.csproj \
+    --project src/Ozds.Users/Ozds.Users.csproj \
+    --context Ozds.Users.Context.IdentityDbContext
+  ```
+- Registration follows existing pattern in `HostExtensions.cs`:
+  ```csharp
+  builder.Services.AddDbContext<IdentityDbContext>(options =>
+    options.UseNpgsql(connectionString));
+  ```
+
+**One-time migration script:**
+
+- Located at `scripts/migrate-ldap-users/` as a standalone .NET console app
+- Reads lldap via LDAP, writes to `IdentityDbContext` via `UserManager<T>`
+- Sets `OzdsUser.Id` = LDAP `uid` to preserve `RepresentativeEntity` references
+- Assigns temporary passwords, does NOT send emails
+- Run once during cutover, kept in repo as historical reference
+
+**Persistent cookies:**
+
+- Login page includes "Remember me" checkbox
+- Persistent cookie expiration configurable via `appsettings.json`
+- Default: 30 days (standard for web applications)
+- Non-persistent sessions expire on browser close (default Identity behavior)

--- a/docs/prd-identity-migration.md
+++ b/docs/prd-identity-migration.md
@@ -1,12 +1,12 @@
 # PRD: Identity Management Migration — Authelia/LDAP to ASP.NET Core Identity
 
-| Field          | Value                                      |
-| -------------- | ------------------------------------------ |
-| Author         | OZDS Engineering                           |
-| Status         | Draft                                      |
-| Created        | 2026-03-03                                 |
-| Target Release | TBD                                        |
-| Stakeholders   | Backend, DevOps, Security                  |
+| Field          | Value                     |
+| -------------- | ------------------------- |
+| Author         | OZDS Engineering          |
+| Status         | Draft                     |
+| Created        | 2026-03-03                |
+| Target Release | TBD                       |
+| Stakeholders   | Backend, DevOps, Security |
 
 ---
 
@@ -72,18 +72,18 @@ module bridges both via:
 
 ### 3.2 File Inventory
 
-| Layer                    | Technology                        | Files                                             |
-| ------------------------ | --------------------------------- | ------------------------------------------------- |
-| OIDC Authentication      | Authelia, OpenIdConnect middleware | `Ozds.Users/Extensions/HostExtensions.cs`          |
-| User CRUD                | lldap, Novell.Directory.Ldap      | `Ozds.Users/Queries/UserQueries.cs`                |
-| User Mutations           | lldap, Novell.Directory.Ldap      | `Ozds.Users/Mutations/UserMutations.cs`            |
-| Password Management      | lldap, LDAP Extended Operation    | `Ozds.Users/Mutations/PasswordMutations.cs`        |
-| Configuration            | OIDC + LDAP connection strings    | `Ozds.Users/Options/OzdsUsersOptions.cs`           |
-| App Settings             | OIDC + LDAP sections              | `Ozds.Server/appsettings.Development.json`         |
-| Docker                   | authelia:4.39.4 + lldap:2025-05-19| `docker-compose.yml`                               |
-| Authelia Config          | OIDC client, LDAP backend         | `scripts/auth/configuration.yml`                   |
-| User Entity (identity)   | Simple DTO: Id, Name, Email       | `Ozds.Users/Entities/UserEntity.cs`                |
-| User Entity (business)   | RepresentativeEntity, string ID   | `Ozds.Data/Entities/RepresentativeEntity.cs`       |
+| Layer                  | Technology                         | Files                                        |
+| ---------------------- | ---------------------------------- | -------------------------------------------- |
+| OIDC Authentication    | Authelia, OpenIdConnect middleware | `Ozds.Users/Extensions/HostExtensions.cs`    |
+| User CRUD              | lldap, Novell.Directory.Ldap       | `Ozds.Users/Queries/UserQueries.cs`          |
+| User Mutations         | lldap, Novell.Directory.Ldap       | `Ozds.Users/Mutations/UserMutations.cs`      |
+| Password Management    | lldap, LDAP Extended Operation     | `Ozds.Users/Mutations/PasswordMutations.cs`  |
+| Configuration          | OIDC + LDAP connection strings     | `Ozds.Users/Options/OzdsUsersOptions.cs`     |
+| App Settings           | OIDC + LDAP sections               | `Ozds.Server/appsettings.Development.json`   |
+| Docker                 | authelia:4.39.4 + lldap:2025-05-19 | `docker-compose.yml`                         |
+| Authelia Config        | OIDC client, LDAP backend          | `scripts/auth/configuration.yml`             |
+| User Entity (identity) | Simple DTO: Id, Name, Email        | `Ozds.Users/Entities/UserEntity.cs`          |
+| User Entity (business) | RepresentativeEntity, string ID    | `Ozds.Data/Entities/RepresentativeEntity.cs` |
 
 ### 3.3 Key Coupling Point
 
@@ -97,17 +97,17 @@ users through this ID. The migration strategy must preserve this mapping.
 
 ### 4.1 Options Considered
 
-| Criterion             | ASP.NET Core Identity | Keycloak          | Duende IdentityServer | OpenIddict          | Entra ID        |
-| --------------------- | --------------------- | ----------------- | --------------------- | ------------------- | --------------- |
-| Embedded in .NET      | **Yes**               | No (Java/Docker)  | Yes                   | Yes                 | No (Cloud)      |
-| Self-hosted           | **Yes**               | Yes               | Yes                   | Yes                 | **No**          |
-| Free / OSS            | **MIT**               | Apache 2.0        | **RPL (Paid)**        | Apache 2.0          | Consumption     |
-| User CRUD API         | **UserManager\<T\>**  | Admin REST API    | None (needs Identity) | None (needs Identity)| Graph API      |
-| PostgreSQL support    | **Native (Npgsql)**   | Own DB required   | Via EF Core           | Via EF Core         | N/A             |
-| External OAuth        | **Built-in**          | Identity Brokering| Via Identity          | Via .NET handlers   | External IDs    |
-| Password management   | **Built-in**          | Built-in          | Via Identity          | Via Identity        | Built-in        |
-| Admin UI              | Must build            | **Built-in**      | Must build            | Must build          | Azure Portal    |
-| Setup complexity      | **Low**               | Medium            | High                  | Medium              | Low             |
+| Criterion           | ASP.NET Core Identity | Keycloak           | Duende IdentityServer | OpenIddict            | Entra ID     |
+| ------------------- | --------------------- | ------------------ | --------------------- | --------------------- | ------------ |
+| Embedded in .NET    | **Yes**               | No (Java/Docker)   | Yes                   | Yes                   | No (Cloud)   |
+| Self-hosted         | **Yes**               | Yes                | Yes                   | Yes                   | **No**       |
+| Free / OSS          | **MIT**               | Apache 2.0         | **RPL (Paid)**        | Apache 2.0            | Consumption  |
+| User CRUD API       | **UserManager\<T\>**  | Admin REST API     | None (needs Identity) | None (needs Identity) | Graph API    |
+| PostgreSQL support  | **Native (Npgsql)**   | Own DB required    | Via EF Core           | Via EF Core           | N/A          |
+| External OAuth      | **Built-in**          | Identity Brokering | Via Identity          | Via .NET handlers     | External IDs |
+| Password management | **Built-in**          | Built-in           | Via Identity          | Via Identity          | Built-in     |
+| Admin UI            | Must build            | **Built-in**       | Must build            | Must build            | Azure Portal |
+| Setup complexity    | **Low**               | Medium             | High                  | Medium                | Low          |
 
 ### 4.2 Decision
 
@@ -122,7 +122,8 @@ users through this ID. The migration strategy must preserve this mapping.
 - Duende IdentityServer eliminated: commercial RPL license (contradicts
   "free/OSS" requirement)
 - OpenIddict: not needed for Blazor Server cookie auth. Can be added later as a
-  non-breaking enhancement if OIDC endpoints are ever needed for external clients
+  non-breaking enhancement if OIDC endpoints are ever needed for external
+  clients
 - Entra ID eliminated: cloud-only SaaS, not self-hostable
 
 ---
@@ -156,16 +157,16 @@ stack.
 
 ### 5.2 Operation Mapping
 
-| Current (LDAP)                          | New (ASP.NET Core Identity)                    |
-| --------------------------------------- | ---------------------------------------------- |
-| `LdapConnection.Search()` find user     | `UserManager<T>.FindByIdAsync()`               |
-| `LdapConnection.Add()` create user      | `UserManager<T>.CreateAsync()`                 |
-| `LdapConnection.Modify()` update user   | `UserManager<T>.UpdateAsync()`                 |
-| `LdapConnection.Delete()` delete user   | `UserManager<T>.DeleteAsync()`                 |
-| LDAP Extended Op, change password       | `UserManager<T>.ChangePasswordAsync()`         |
-| Authelia OIDC, cookie auth              | `SignInManager<T>.PasswordSignInAsync()` + Cookie |
-| Claims from OIDC token                  | `UserManager<T>.GetClaimsAsync()` + `ClaimsPrincipal` |
-| LDAP search with pagination             | EF Core LINQ queries on `AspNetUsers`          |
+| Current (LDAP)                        | New (ASP.NET Core Identity)                           |
+| ------------------------------------- | ----------------------------------------------------- |
+| `LdapConnection.Search()` find user   | `UserManager<T>.FindByIdAsync()`                      |
+| `LdapConnection.Add()` create user    | `UserManager<T>.CreateAsync()`                        |
+| `LdapConnection.Modify()` update user | `UserManager<T>.UpdateAsync()`                        |
+| `LdapConnection.Delete()` delete user | `UserManager<T>.DeleteAsync()`                        |
+| LDAP Extended Op, change password     | `UserManager<T>.ChangePasswordAsync()`                |
+| Authelia OIDC, cookie auth            | `SignInManager<T>.PasswordSignInAsync()` + Cookie     |
+| Claims from OIDC token                | `UserManager<T>.GetClaimsAsync()` + `ClaimsPrincipal` |
+| LDAP search with pagination           | EF Core LINQ queries on `AspNetUsers`                 |
 
 ### 5.3 Custom User Entity
 
@@ -212,15 +213,15 @@ Identity. Adding it is a non-breaking, additive change.
 
 ### 6.1 Data Migration (50-500 Users)
 
-**Source:** lldap (LDAP entries with `uid`, `cn`, `mail`)
-**Target:** ASP.NET Core Identity tables in PostgreSQL (`AspNetUsers`)
+**Source:** lldap (LDAP entries with `uid`, `cn`, `mail`) **Target:** ASP.NET
+Core Identity tables in PostgreSQL (`AspNetUsers`)
 
-| Step | Action                                                                                  |
-| ---- | --------------------------------------------------------------------------------------- |
-| 1    | Export all lldap users to JSON via LDAP search script                                   |
+| Step | Action                                                                                                          |
+| ---- | --------------------------------------------------------------------------------------------------------------- |
+| 1    | Export all lldap users to JSON via LDAP search script                                                           |
 | 2    | Create `OzdsUser` for each entry: `Id` = LDAP `uid`, `UserName` = `uid`, `Email` = `mail`, `DisplayName` = `cn` |
-| 3    | Set temporary passwords and flag for mandatory reset on first login                     |
-| 4    | Verify all `RepresentativeEntity.Id` values resolve to migrated `OzdsUser.Id`           |
+| 3    | Set temporary passwords and flag for mandatory reset on first login                                             |
+| 4    | Verify all `RepresentativeEntity.Id` values resolve to migrated `OzdsUser.Id`                                   |
 
 **Critical constraint:** By setting `IdentityUser.Id` to the existing LDAP
 `uid`, all `RepresentativeEntity` foreign key references are preserved without
@@ -231,30 +232,30 @@ migrated users must reset their passwords on first login after migration.
 
 ### 6.2 Code Migration Scope
 
-| Module                                        | Action                                              | Effort  |
-| --------------------------------------------- | --------------------------------------------------- | ------- |
-| `Ozds.Users/Extensions/HostExtensions.cs`     | Rewrite: replace LDAP + OIDC with Identity DI setup | Medium  |
-| `Ozds.Users/Queries/UserQueries.cs`           | Rewrite: `LdapConnection` to `UserManager<T>`       | Medium  |
-| `Ozds.Users/Mutations/UserMutations.cs`       | Rewrite: LDAP add/modify/delete to `UserManager<T>` | Medium  |
-| `Ozds.Users/Mutations/PasswordMutations.cs`   | Rewrite: LDAP extended op to `ChangePasswordAsync`   | Low     |
-| `Ozds.Users/Options/OzdsUsersOptions.cs`      | Simplify: remove LDAP/OIDC connection string models | Low     |
-| `Ozds.Users/Entities/`                        | Remove or adapt (Identity provides its own entities) | Low     |
-| `Ozds.Users.csproj`                           | Remove `Novell.Directory.Ldap`, add `Microsoft.AspNetCore.Identity.EntityFrameworkCore` | Trivial |
-| Blazor login pages                            | Replace OIDC redirect with Identity login form       | Medium  |
-| EF Migration                                  | Add Identity tables to PostgreSQL                    | Low     |
-| `docker-compose.yml`                          | Remove `auth` + `ldap` services                     | Trivial |
-| `scripts/auth/`, `scripts/ldap/`              | Delete Authelia and lldap config/data                | Trivial |
-| `appsettings.*.json`                          | Remove `Ozds:Users:Ldap` + `Ozds:Users:Oidc`        | Trivial |
+| Module                                      | Action                                                                                  | Effort  |
+| ------------------------------------------- | --------------------------------------------------------------------------------------- | ------- |
+| `Ozds.Users/Extensions/HostExtensions.cs`   | Rewrite: replace LDAP + OIDC with Identity DI setup                                     | Medium  |
+| `Ozds.Users/Queries/UserQueries.cs`         | Rewrite: `LdapConnection` to `UserManager<T>`                                           | Medium  |
+| `Ozds.Users/Mutations/UserMutations.cs`     | Rewrite: LDAP add/modify/delete to `UserManager<T>`                                     | Medium  |
+| `Ozds.Users/Mutations/PasswordMutations.cs` | Rewrite: LDAP extended op to `ChangePasswordAsync`                                      | Low     |
+| `Ozds.Users/Options/OzdsUsersOptions.cs`    | Simplify: remove LDAP/OIDC connection string models                                     | Low     |
+| `Ozds.Users/Entities/`                      | Remove or adapt (Identity provides its own entities)                                    | Low     |
+| `Ozds.Users.csproj`                         | Remove `Novell.Directory.Ldap`, add `Microsoft.AspNetCore.Identity.EntityFrameworkCore` | Trivial |
+| Blazor login pages                          | Replace OIDC redirect with Identity login form                                          | Medium  |
+| EF Migration                                | Add Identity tables to PostgreSQL                                                       | Low     |
+| `docker-compose.yml`                        | Remove `auth` + `ldap` services                                                         | Trivial |
+| `scripts/auth/`, `scripts/ldap/`            | Delete Authelia and lldap config/data                                                   | Trivial |
+| `appsettings.*.json`                        | Remove `Ozds:Users:Ldap` + `Ozds:Users:Oidc`                                            | Trivial |
 
 ### 6.3 Modules Not Affected
 
-| Module                          | Reason                                                       |
-| ------------------------------- | ------------------------------------------------------------ |
-| `Ozds.Business/Authorization/`  | HMAC-based IoT auth — completely independent                 |
-| `Ozds.Business/` (all)          | Consumes `ClaimsPrincipal` — source of claims is transparent |
-| `Ozds.Data/Entities/`           | `RepresentativeEntity.Id` unchanged (same string IDs)        |
-| `Ozds.Client/` (components)     | `OzdsComponentBase` reads `ClaimsPrincipal` — still works    |
-| `Ozds.Iot/`                     | No identity dependency                                       |
+| Module                         | Reason                                                       |
+| ------------------------------ | ------------------------------------------------------------ |
+| `Ozds.Business/Authorization/` | HMAC-based IoT auth — completely independent                 |
+| `Ozds.Business/` (all)         | Consumes `ClaimsPrincipal` — source of claims is transparent |
+| `Ozds.Data/Entities/`          | `RepresentativeEntity.Id` unchanged (same string IDs)        |
+| `Ozds.Client/` (components)    | `OzdsComponentBase` reads `ClaimsPrincipal` — still works    |
+| `Ozds.Iot/`                    | No identity dependency                                       |
 
 ---
 
@@ -271,34 +272,35 @@ migrated users must reset their passwords on first login after migration.
 
 ## 8. Risks
 
-| Risk                                                | Likelihood   | Impact | Mitigation                                                            |
-| --------------------------------------------------- | ------------ | ------ | --------------------------------------------------------------------- |
-| ID mismatch during migration breaks business data   | Medium       | High   | Use LDAP `uid` as `IdentityUser.Id` — zero FK changes needed         |
-| Users lose passwords (LDAP hashes not exportable)   | **Certain**  | Medium | Force password reset for all migrated users; communicate in advance   |
-| Missing OIDC capability if future apps need it      | Low          | Low    | Add OpenIddict later — non-breaking, additive change                  |
-| Identity table naming conflicts with existing schema| Low          | Low    | Use separate schema (`identity.`) or prefixed table names             |
-| Blazor login UX regression (form vs redirect)       | Medium       | Low    | Build login page matching current UX; test with users before cutover  |
+| Risk                                                 | Likelihood  | Impact | Mitigation                                                           |
+| ---------------------------------------------------- | ----------- | ------ | -------------------------------------------------------------------- |
+| ID mismatch during migration breaks business data    | Medium      | High   | Use LDAP `uid` as `IdentityUser.Id` — zero FK changes needed         |
+| Users lose passwords (LDAP hashes not exportable)    | **Certain** | Medium | Force password reset for all migrated users; communicate in advance  |
+| Missing OIDC capability if future apps need it       | Low         | Low    | Add OpenIddict later — non-breaking, additive change                 |
+| Identity table naming conflicts with existing schema | Low         | Low    | Use separate schema (`identity.`) or prefixed table names            |
+| Blazor login UX regression (form vs redirect)        | Medium      | Low    | Build login page matching current UX; test with users before cutover |
 
 ---
 
 ## 9. Effort Estimate
 
-| Phase                                       | Estimate   |
-| ------------------------------------------- | ---------- |
-| Identity + EF Core setup, DI registration   | 1-2 days   |
-| Rewrite `Ozds.Users` (queries, mutations)   | 2-3 days   |
-| User migration script                       | 1 day      |
-| Blazor login flow update                    | 1-2 days   |
-| External OAuth provider setup               | 0.5 day    |
-| Docker and config cleanup                   | 0.5 day    |
-| Testing and validation                      | 2-3 days   |
-| **Total**                                   | **8-12 days** |
+| Phase                                     | Estimate      |
+| ----------------------------------------- | ------------- |
+| Identity + EF Core setup, DI registration | 1-2 days      |
+| Rewrite `Ozds.Users` (queries, mutations) | 2-3 days      |
+| User migration script                     | 1 day         |
+| Blazor login flow update                  | 1-2 days      |
+| External OAuth provider setup             | 0.5 day       |
+| Docker and config cleanup                 | 0.5 day       |
+| Testing and validation                    | 2-3 days      |
+| **Total**                                 | **8-12 days** |
 
 ---
 
 ## 10. Success Criteria
 
-- [ ] All existing users accessible via `UserManager<OzdsUser>` with preserved IDs
+- [ ] All existing users accessible via `UserManager<OzdsUser>` with preserved
+      IDs
 - [ ] Login/logout works via ASP.NET Core Identity cookie authentication
 - [ ] User CRUD (create, read, update, delete) functional through `Ozds.Users`
 - [ ] Password change/reset functional
@@ -313,13 +315,13 @@ migrated users must reset their passwords on first login after migration.
 
 ## 11. Resolved Decisions
 
-| #  | Question                                           | Decision                        | Rationale                                                                                       |
-| -- | -------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------- |
-| 1  | DbContext strategy for Identity tables              | **Separate `IdentityDbContext`** | Follows existing multi-context pattern (`DataDbContext`, `MessagingDbContext`, `JobsDbContext`). Clean separation of identity schema from business entities. Own migration history. |
-| 2  | Migration script tooling                            | **One-time console app**        | Throwaway script kept in `scripts/` for reference. No ongoing maintenance burden. Not worth integrating into `Ozds.Migration` for a single-use operation. |
-| 3  | Password reset communication                        | **Manual communication**        | Admin sends announcement via existing channels (email blast, internal comms) before cutover. No automated email flow needed. |
-| 4  | Additional LDAP attributes to migrate               | **Id, Name, Email only**        | Current `UserEntity` already captures everything needed. No additional LDAP attributes in use. |
-| 5  | "Remember me" / persistent cookies                  | **Yes**                         | Users can opt in to stay logged in across browser sessions. `SignInManager.PasswordSignInAsync(isPersistent: true)` with configurable cookie expiration. |
+| #   | Question                               | Decision                         | Rationale                                                                                                                                                                           |
+| --- | -------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | DbContext strategy for Identity tables | **Separate `IdentityDbContext`** | Follows existing multi-context pattern (`DataDbContext`, `MessagingDbContext`, `JobsDbContext`). Clean separation of identity schema from business entities. Own migration history. |
+| 2   | Migration script tooling               | **One-time console app**         | Throwaway script kept in `scripts/` for reference. No ongoing maintenance burden. Not worth integrating into `Ozds.Migration` for a single-use operation.                           |
+| 3   | Password reset communication           | **Manual communication**         | Admin sends announcement via existing channels (email blast, internal comms) before cutover. No automated email flow needed.                                                        |
+| 4   | Additional LDAP attributes to migrate  | **Id, Name, Email only**         | Current `UserEntity` already captures everything needed. No additional LDAP attributes in use.                                                                                      |
+| 5   | "Remember me" / persistent cookies     | **Yes**                          | Users can opt in to stay logged in across browser sessions. `SignInManager.PasswordSignInAsync(isPersistent: true)` with configurable cookie expiration.                            |
 
 ### Implications of Decisions
 

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -1260,6 +1260,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        ~NewPassword
+      </Key>
+      <Metadata>
+        Type 'Ozds.Business.Models.NewPasswordModel'
+      </Metadata>
+      <Value>
+        New password
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         ~Notification
       </Key>
       <Metadata>
@@ -6358,7 +6369,7 @@
         Change password
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 45 column 12
+        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 51 column 12
       </Metadata>
       <Value>
         Change password
@@ -6604,6 +6615,13 @@
         ConfirmNewPassword
       </Key>
       <Metadata>
+        Property 'ConfirmNewPassword' of type 'Ozds.Business.Models.NewPasswordModel' with overrides:
+        ~NewPasswordModel.ConfirmNewPassword
+        MaybeRepresentingUserModel.NewPassword.ConfirmNewPassword
+        ~MaybeRepresentingUserModel.NewPassword.ConfirmNewPassword
+        RepresentingUserModel.NewPassword.ConfirmNewPassword
+        ~RepresentingUserModel.NewPassword.ConfirmNewPassword
+
         Property 'ConfirmNewPassword' of type 'Ozds.Business.Models.PasswordModel' with overrides:
         ~PasswordModel.ConfirmNewPassword
       </Metadata>
@@ -6820,7 +6838,7 @@
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 33
-        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
+        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 118 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
       <Value>
@@ -6836,6 +6854,17 @@
       </Metadata>
       <Value>
         Generate bill
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        Create user
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Pages/Administration/UsersPage.razor' line 67 column 6
+      </Metadata>
+      <Value>
+        Create user
       </Value>
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
@@ -17038,8 +17067,22 @@
         NewPassword
       </Key>
       <Metadata>
+        Type 'Ozds.Business.Models.NewPasswordModel'
+
+        Property 'NewPassword' of type 'Ozds.Business.Models.NewPasswordModel' with overrides:
+        ~NewPasswordModel.NewPassword
+        MaybeRepresentingUserModel.NewPassword.NewPassword
+        ~MaybeRepresentingUserModel.NewPassword.NewPassword
+        RepresentingUserModel.NewPassword.NewPassword
+        ~RepresentingUserModel.NewPassword.NewPassword
+
         Property 'NewPassword' of type 'Ozds.Business.Models.PasswordModel' with overrides:
         ~PasswordModel.NewPassword
+
+        Property 'NewPassword' of type 'Ozds.Business.Models.Composite.MaybeRepresentingUserModel' with overrides:
+        ~MaybeRepresentingUserModel.NewPassword
+        RepresentingUserModel.NewPassword
+        ~RepresentingUserModel.NewPassword
       </Metadata>
       <Value>
         New password
@@ -23266,7 +23309,7 @@
         Update password
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 65 column 14
+        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 71 column 14
       </Metadata>
       <Value>
         Update password
@@ -23837,6 +23880,13 @@
         UserId
       </Key>
       <Metadata>
+        Property 'UserId' of type 'Ozds.Business.Models.NewPasswordModel' with overrides:
+        ~NewPasswordModel.UserId
+        MaybeRepresentingUserModel.NewPassword.UserId
+        ~MaybeRepresentingUserModel.NewPassword.UserId
+        RepresentingUserModel.NewPassword.UserId
+        ~RepresentingUserModel.NewPassword.UserId
+
         Property 'UserId' of type 'Ozds.Business.Models.PasswordModel' with overrides:
         ~PasswordModel.UserId
       </Metadata>

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -1260,6 +1260,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        ~NewPassword
+      </Key>
+      <Metadata>
+        Type 'Ozds.Business.Models.NewPasswordModel'
+      </Metadata>
+      <Value>
+        Nova lozinka
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         ~Notification
       </Key>
       <Metadata>
@@ -6357,7 +6368,7 @@
         Change password
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 45 column 12
+        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 51 column 12
       </Metadata>
       <Value>
         Promijeni lozinku
@@ -6603,6 +6614,13 @@
         ConfirmNewPassword
       </Key>
       <Metadata>
+        Property 'ConfirmNewPassword' of type 'Ozds.Business.Models.NewPasswordModel' with overrides:
+        ~NewPasswordModel.ConfirmNewPassword
+        MaybeRepresentingUserModel.NewPassword.ConfirmNewPassword
+        ~MaybeRepresentingUserModel.NewPassword.ConfirmNewPassword
+        RepresentingUserModel.NewPassword.ConfirmNewPassword
+        ~RepresentingUserModel.NewPassword.ConfirmNewPassword
+
         Property 'ConfirmNewPassword' of type 'Ozds.Business.Models.PasswordModel' with overrides:
         ~PasswordModel.ConfirmNewPassword
       </Metadata>
@@ -6819,7 +6837,7 @@
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 33
-        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
+        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 118 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
       <Value>
@@ -6835,6 +6853,17 @@
       </Metadata>
       <Value>
         Kreiraj račun
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        Create user
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Pages/Administration/UsersPage.razor' line 67 column 6
+      </Metadata>
+      <Value>
+        Kreiraj korisnika
       </Value>
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
@@ -17038,8 +17067,22 @@
         NewPassword
       </Key>
       <Metadata>
+        Type 'Ozds.Business.Models.NewPasswordModel'
+
+        Property 'NewPassword' of type 'Ozds.Business.Models.NewPasswordModel' with overrides:
+        ~NewPasswordModel.NewPassword
+        MaybeRepresentingUserModel.NewPassword.NewPassword
+        ~MaybeRepresentingUserModel.NewPassword.NewPassword
+        RepresentingUserModel.NewPassword.NewPassword
+        ~RepresentingUserModel.NewPassword.NewPassword
+
         Property 'NewPassword' of type 'Ozds.Business.Models.PasswordModel' with overrides:
         ~PasswordModel.NewPassword
+
+        Property 'NewPassword' of type 'Ozds.Business.Models.Composite.MaybeRepresentingUserModel' with overrides:
+        ~MaybeRepresentingUserModel.NewPassword
+        RepresentingUserModel.NewPassword
+        ~RepresentingUserModel.NewPassword
       </Metadata>
       <Value>
         Nova lozinka
@@ -23312,7 +23355,7 @@
         Update password
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 65 column 14
+        From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 71 column 14
       </Metadata>
       <Value>
         Ažuriraj lozinku
@@ -23880,6 +23923,13 @@
         UserId
       </Key>
       <Metadata>
+        Property 'UserId' of type 'Ozds.Business.Models.NewPasswordModel' with overrides:
+        ~NewPasswordModel.UserId
+        MaybeRepresentingUserModel.NewPassword.UserId
+        ~MaybeRepresentingUserModel.NewPassword.UserId
+        RepresentingUserModel.NewPassword.UserId
+        ~RepresentingUserModel.NewPassword.UserId
+
         Property 'UserId' of type 'Ozds.Business.Models.PasswordModel' with overrides:
         ~PasswordModel.UserId
       </Metadata>

--- a/src/Ozds.Business/Activation/Implementations/Administration/MaybeRepresentingUserModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Administration/MaybeRepresentingUserModelActivator.cs
@@ -4,15 +4,14 @@ using Ozds.Business.Models.Composite;
 
 namespace Ozds.Business.Activation.Implementations.Administration;
 
-public class MaybeRepresentingUserModelActivator
-  (IServiceProvider serviceProvider)
-  : ConcreteModelActivator<MaybeRepresentingUserModel>
+public class MaybeRepresentingUserModelActivator(
+  IServiceProvider serviceProvider
+) : ConcreteModelActivator<MaybeRepresentingUserModel>
 {
-
   private readonly ModelActivator modelActivator =
-  serviceProvider.GetRequiredService<ModelActivator>();
+    serviceProvider.GetRequiredService<ModelActivator>();
 
-  override public void Initialize(MaybeRepresentingUserModel model)
+  public override void Initialize(MaybeRepresentingUserModel model)
   {
     model.User = modelActivator.Activate<UserModel>();
     model.NewPassword = modelActivator.Activate<NewPasswordModel>();

--- a/src/Ozds.Business/Activation/Implementations/Administration/MaybeRepresentingUserModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Administration/MaybeRepresentingUserModelActivator.cs
@@ -1,0 +1,20 @@
+using Ozds.Business.Activation.Base;
+using Ozds.Business.Models;
+using Ozds.Business.Models.Composite;
+
+namespace Ozds.Business.Activation.Implementations.Administration;
+
+public class MaybeRepresentingUserModelActivator
+  (IServiceProvider serviceProvider)
+  : ConcreteModelActivator<MaybeRepresentingUserModel>
+{
+
+  private readonly ModelActivator modelActivator =
+  serviceProvider.GetRequiredService<ModelActivator>();
+
+  override public void Initialize(MaybeRepresentingUserModel model)
+  {
+    model.User = modelActivator.Activate<UserModel>();
+    model.Representative = modelActivator.Activate<RepresentativeModel>();
+  }
+}

--- a/src/Ozds.Business/Activation/Implementations/Administration/MaybeRepresentingUserModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Administration/MaybeRepresentingUserModelActivator.cs
@@ -15,6 +15,7 @@ public class MaybeRepresentingUserModelActivator
   override public void Initialize(MaybeRepresentingUserModel model)
   {
     model.User = modelActivator.Activate<UserModel>();
+    model.NewPassword = modelActivator.Activate<NewPasswordModel>();
     model.Representative = modelActivator.Activate<RepresentativeModel>();
   }
 }

--- a/src/Ozds.Business/Activation/Implementations/Administration/NewPasswordModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Administration/NewPasswordModelActivator.cs
@@ -1,0 +1,16 @@
+using Ozds.Business.Activation.Base;
+using Ozds.Business.Models;
+
+namespace Ozds.Business.Activation.Implementations.Administration;
+
+public class NewPasswordModelActivator : ConcreteModelActivator<NewPasswordModel>
+{
+  public override void Initialize(NewPasswordModel model)
+  {
+    base.Initialize(model);
+
+    model.UserId = string.Empty;
+    model.NewPassword = string.Empty;
+    model.ConfirmNewPassword = string.Empty;
+  }
+}

--- a/src/Ozds.Business/Activation/Implementations/Administration/NewPasswordModelActivator.cs
+++ b/src/Ozds.Business/Activation/Implementations/Administration/NewPasswordModelActivator.cs
@@ -3,7 +3,8 @@ using Ozds.Business.Models;
 
 namespace Ozds.Business.Activation.Implementations.Administration;
 
-public class NewPasswordModelActivator : ConcreteModelActivator<NewPasswordModel>
+public class NewPasswordModelActivator
+  : ConcreteModelActivator<NewPasswordModel>
 {
   public override void Initialize(NewPasswordModel model)
   {

--- a/src/Ozds.Business/Conversion/Implementations/Administration/NewPasswordModelEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Administration/NewPasswordModelEntityConverter.cs
@@ -1,0 +1,29 @@
+using Ozds.Business.Conversion.Base;
+using Ozds.Business.Models;
+using Ozds.Users.Entities;
+
+namespace Ozds.Business.Conversion.Implementations.Administration;
+
+public class NewPasswordModelEntityConverter
+  : ConcreteModelUserEntityConverter<NewPasswordModel, NewPasswordEntity>
+{
+  public override void InitializeEntity(
+    NewPasswordModel model,
+    NewPasswordEntity entity
+  )
+  {
+    base.InitializeEntity(model, entity);
+    entity.UserId = model.UserId;
+    entity.NewPassword = model.NewPassword;
+  }
+
+  public override void InitializeModel(
+    NewPasswordEntity entity,
+    NewPasswordModel model
+  )
+  {
+    base.InitializeModel(entity, model);
+    model.UserId = entity.UserId;
+    model.NewPassword = entity.NewPassword;
+  }
+}

--- a/src/Ozds.Business/Models/Composite/MaybeRepresentingUserModel.cs
+++ b/src/Ozds.Business/Models/Composite/MaybeRepresentingUserModel.cs
@@ -1,10 +1,60 @@
+using System.ComponentModel.DataAnnotations;
 using Ozds.Business.Models.Abstractions;
 
 namespace Ozds.Business.Models.Composite;
 
-public class MaybeRepresentingUserModel : IComposite
+public class MaybeRepresentingUserModel : IComposite, IValidatableObject
 {
   public UserModel User { get; set; } = default!;
 
+  // NOTE: only used during creation of a new account
+  public NewPasswordModel? NewPassword { get; set; } = default!;
+
   public RepresentativeModel? Representative { get; set; } = default!;
+
+  public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+  {
+    var userContext = new ValidationContext(
+      User,
+      validationContext,
+      validationContext.Items
+    );
+    var userResults = new List<ValidationResult>();
+    Validator.TryValidateObject(User, userContext, userResults, true);
+
+    foreach (var r in userResults)
+    {
+      yield return r;
+    }
+
+    if (NewPassword is { } pass)
+    {
+      var passContext = new ValidationContext(
+        pass,
+        validationContext,
+        validationContext.Items
+      );
+      var passResults = new List<ValidationResult>();
+      Validator.TryValidateObject(pass, passContext, passResults, true);
+      foreach (var r in passResults)
+      {
+        yield return r;
+      }
+    }
+
+    if (Representative is { } rep)
+    {
+      var repContext = new ValidationContext(
+        rep,
+        validationContext,
+        validationContext.Items
+      );
+      var repResults = new List<ValidationResult>();
+      Validator.TryValidateObject(rep, repContext, repResults, true);
+      foreach (var r in repResults)
+      {
+        yield return r;
+      }
+    }
+  }
 }

--- a/src/Ozds.Business/Models/Composite/MaybeRepresentingUserModel.cs
+++ b/src/Ozds.Business/Models/Composite/MaybeRepresentingUserModel.cs
@@ -12,7 +12,9 @@ public class MaybeRepresentingUserModel : IComposite, IValidatableObject
 
   public RepresentativeModel? Representative { get; set; } = default!;
 
-  public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+  public IEnumerable<ValidationResult> Validate(
+    ValidationContext validationContext
+  )
   {
     var userContext = new ValidationContext(
       User,

--- a/src/Ozds.Business/Models/NewPasswordModel.cs
+++ b/src/Ozds.Business/Models/NewPasswordModel.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Ozds.Business.Models;
+
+public class NewPasswordModel : Base.UserModel
+{
+  public required string UserId { get; set; }
+
+  [Required]
+  public required string NewPassword { get; set; }
+
+  [Required]
+  public required string ConfirmNewPassword { get; set; }
+
+  public override IEnumerable<ValidationResult> Validate(
+    ValidationContext validationContext
+  )
+  {
+    if (
+      (
+        validationContext.MemberName is null
+        || validationContext.MemberName == nameof(ConfirmNewPassword)
+      )
+      && NewPassword != ConfirmNewPassword
+    )
+    {
+      yield return new ValidationResult(
+        "Passwords do not match.",
+        new[] { nameof(ConfirmNewPassword) }
+      );
+    }
+
+    if (
+      validationContext.MemberName is null
+      || validationContext.MemberName == nameof(NewPassword)
+    )
+    {
+      if (NewPassword.Length < 8)
+      {
+        yield return new ValidationResult(
+          "Password must be at least 8 characters long.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+
+      if (NewPassword.Length > 128)
+      {
+        yield return new ValidationResult(
+          "Password must be at most 128 characters long.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+
+      if (!NewPassword.All(char.IsAscii))
+      {
+        yield return new ValidationResult(
+          "Password must be ASCII characters only.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+
+      if (
+        !NewPassword.All(@char =>
+          char.IsLetter(@char)
+          || char.IsDigit(@char)
+          || char.IsSymbol(@char)
+          || char.IsPunctuation(@char)
+        )
+      )
+      {
+        yield return new ValidationResult(
+          "Password characters must be letters, digits, symbols or punctuation.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+
+      if (!NewPassword.Any(char.IsLetter))
+      {
+        yield return new ValidationResult(
+          "Password must contain at least one letter.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+
+      if (!NewPassword.Any(char.IsDigit))
+      {
+        yield return new ValidationResult(
+          "Password must contain at least one digit.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+
+      if (
+        !NewPassword.Any(@char =>
+          char.IsSymbol(@char) || char.IsPunctuation(@char)
+        )
+      )
+      {
+        yield return new ValidationResult(
+          "Password must contain at least one symbol or punctuation.",
+          new[] { nameof(NewPassword) }
+        );
+      }
+    }
+  }
+}

--- a/src/Ozds.Business/Mutations/PasswordMutations.cs
+++ b/src/Ozds.Business/Mutations/PasswordMutations.cs
@@ -19,4 +19,13 @@ public class PasswordMutations(
     var entity = modelEntityConverter.ToEntity<PasswordEntity>(model);
     await userPasswordMutations.Update(entity, cancellationToken);
   }
+
+  public async Task Create(
+    NewPasswordModel model,
+    CancellationToken cancellationToken
+  )
+  {
+    var entity = modelEntityConverter.ToEntity<NewPasswordEntity>(model);
+    await userPasswordMutations.Create(entity, cancellationToken);
+  }
 }

--- a/src/Ozds.Client/Components/Fields/PasswordField.cs
+++ b/src/Ozds.Client/Components/Fields/PasswordField.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
@@ -17,10 +18,13 @@ public partial class PasswordField
   public string Label { get; set; } = default!;
 
   [Parameter]
-  public string Value { get; set; } = default!;
+  public string? Value { get; set; }
 
   [Parameter]
-  public EventCallback<string> ValueChanged { get; set; }
+  public EventCallback<string?> ValueChanged { get; set; }
+
+  [Parameter]
+  public Expression<Func<string?>>? For { get; set; }
 
   private void OnVisibilityClick()
   {

--- a/src/Ozds.Client/Components/Fields/PasswordField.razor
+++ b/src/Ozds.Client/Components/Fields/PasswordField.razor
@@ -9,4 +9,5 @@
   InputType="@inputType"
   Adornment="Adornment.End"
   AdornmentIcon="@inputIcon"
-  OnAdornmentClick="@OnVisibilityClick"/>
+  OnAdornmentClick="@OnVisibilityClick"
+  For="@For"/>

--- a/src/Ozds.Client/Components/Models/Base/OzdsEditComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsEditComponentBase.razor
@@ -186,7 +186,8 @@
     return @<PasswordField
               Label="@(Translate(Label(next)))"
               Value="@Get(nextFunc)"
-              ValueChanged="@Set(next)"/>;
+              ValueChanged="@Set(next)"
+              For="@For(next)"/>;
   }
 
   protected RenderFragment HtmlField(Expression<Func<TModel, string?>> next)

--- a/src/Ozds.Client/Components/Models/Implementations/Administration/NewPasswordEdit.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Administration/NewPasswordEdit.razor
@@ -1,11 +1,9 @@
 @namespace Ozds.Client.Components.Models.Implementations.Administration
 
 @typeparam TPrefix
-@typeparam TModel where TModel : Ozds.Business.Models.UserModel
+@typeparam TModel where TModel : Ozds.Business.Models.NewPasswordModel
 @inherits Ozds.Client.Components.Models.Base.OzdsEditComponentBase<TPrefix, TModel>
 
-@Field(x => x.Id)
+@PasswordField(x => x.NewPassword)
 
-@Field(x => x.Name)
-
-@Field(x => x.Email)
+@PasswordField(x => x.ConfirmNewPassword)

--- a/src/Ozds.Client/Pages/Administration/UserPage.cs
+++ b/src/Ozds.Client/Pages/Administration/UserPage.cs
@@ -38,9 +38,9 @@ public partial class UserPage
     base.OnInitialized();
 
     if (
-      Id is not null &&
-      RepresentativeState.Representative.Role
-      is RoleModel.OperatorRepresentative
+      Id is not null
+      && RepresentativeState.Representative.Role
+        is RoleModel.OperatorRepresentative
     )
     {
       var activator = ScopedServices.GetRequiredService<ModelActivator>();
@@ -51,16 +51,12 @@ public partial class UserPage
 
   private async Task OnUserCreateAsync(MaybeRepresentingUserModel model)
   {
-    var userMutations =
-      ScopedServices.GetRequiredService<UserMutations>();
+    var userMutations = ScopedServices.GetRequiredService<UserMutations>();
 
     var represenativeMutations =
       ScopedServices.GetRequiredService<TrackableMutations>();
 
-    var newId = await userMutations.Create(
-      model.User,
-      CancellationToken
-    );
+    var newId = await userMutations.Create(model.User, CancellationToken);
 
     if (model.NewPassword is { } newPwd && newId is { })
     {
@@ -74,8 +70,8 @@ public partial class UserPage
     {
       representative.Id = newId;
       await represenativeMutations.Create(
-       model.Representative,
-       CancellationToken
+        model.Representative,
+        CancellationToken
       );
     }
   }

--- a/src/Ozds.Client/Pages/Administration/UserPage.cs
+++ b/src/Ozds.Client/Pages/Administration/UserPage.cs
@@ -53,7 +53,7 @@ public partial class UserPage
   {
     var userMutations = ScopedServices.GetRequiredService<UserMutations>();
 
-    var represenativeMutations =
+    var representativeMutations =
       ScopedServices.GetRequiredService<TrackableMutations>();
 
     var newId = await userMutations.Create(model.User, CancellationToken);
@@ -69,7 +69,7 @@ public partial class UserPage
     if (model.Representative is { } representative && newId is { })
     {
       representative.Id = newId;
-      await represenativeMutations.Create(
+      await representativeMutations.Create(
         model.Representative,
         CancellationToken
       );

--- a/src/Ozds.Client/Pages/Administration/UserPage.cs
+++ b/src/Ozds.Client/Pages/Administration/UserPage.cs
@@ -38,9 +38,9 @@ public partial class UserPage
     base.OnInitialized();
 
     if (
-      Id is not null
-      && RepresentativeState.Representative.Role
-        is RoleModel.OperatorRepresentative
+      Id is not null &&
+      RepresentativeState.Representative.Role
+      is RoleModel.OperatorRepresentative
     )
     {
       var activator = ScopedServices.GetRequiredService<ModelActivator>();
@@ -51,7 +51,6 @@ public partial class UserPage
 
   private async Task OnUserCreateAsync(MaybeRepresentingUserModel model)
   {
-
     var userMutations =
       ScopedServices.GetRequiredService<UserMutations>();
 
@@ -62,6 +61,14 @@ public partial class UserPage
       model.User,
       CancellationToken
     );
+
+    if (model.NewPassword is { } newPwd && newId is { })
+    {
+      newPwd.UserId = newId;
+      var passwordMutations =
+        ScopedServices.GetRequiredService<PasswordMutations>();
+      await passwordMutations.Create(newPwd, CancellationToken);
+    }
 
     if (model.Representative is { } representative && newId is { })
     {

--- a/src/Ozds.Client/Pages/Administration/UserPage.cs
+++ b/src/Ozds.Client/Pages/Administration/UserPage.cs
@@ -49,6 +49,30 @@ public partial class UserPage
     }
   }
 
+  private async Task OnUserCreateAsync(MaybeRepresentingUserModel model)
+  {
+
+    var userMutations =
+      ScopedServices.GetRequiredService<UserMutations>();
+
+    var represenativeMutations =
+      ScopedServices.GetRequiredService<TrackableMutations>();
+
+    var newId = await userMutations.Create(
+      model.User,
+      CancellationToken
+    );
+
+    if (model.Representative is { } representative && newId is { })
+    {
+      representative.Id = newId;
+      await represenativeMutations.Create(
+       model.Representative,
+       CancellationToken
+      );
+    }
+  }
+
   private async Task<MaybeRepresentingUserModel?> OnUserLoadAsync()
   {
     if (Id is null)

--- a/src/Ozds.Client/Pages/Administration/UserPage.razor
+++ b/src/Ozds.Client/Pages/Administration/UserPage.razor
@@ -35,7 +35,10 @@
   <Edit>
     <PrefixedEdit Model="@context.Model" Prefix="@(x => x.User)"/>
 
-    <Edit Model="@password" />
+    @if (context.Created && context.Model.NewPassword is { })
+    {
+      <PrefixedEdit Model="@context.Model" Prefix="@(x => x.NewPassword)"/>
+    }
 
     <PrefixedEdit Model="@context.Model" Prefix="@(x => x.Representative)"/>
   </Edit>

--- a/src/Ozds.Client/Pages/Administration/UserPage.razor
+++ b/src/Ozds.Client/Pages/Administration/UserPage.razor
@@ -1,6 +1,6 @@
 @namespace Ozds.Client.Pages
 
-@page "/administration/user/{id}"
+@page "/administration/user/{id?}"
 @using Microsoft.AspNetCore.Components.Forms
 @using MudBlazor
 @using Ozds.Business.Models
@@ -19,6 +19,7 @@
   LoadAsync="OnUserLoadAsync"
   UpdateAsync="OnUserUpdateAsync"
   DeleteAsync="OnUserDeleteAsync"
+  CreateAsync="OnUserCreateAsync"
   Map="@(model => model.User)"
   WithHeading
   WithTitle
@@ -33,6 +34,8 @@
   </Details>
   <Edit>
     <PrefixedEdit Model="@context.Model" Prefix="@(x => x.User)"/>
+
+    <Edit Model="@password" />
 
     <PrefixedEdit Model="@context.Model" Prefix="@(x => x.Representative)"/>
   </Edit>

--- a/src/Ozds.Client/Pages/Administration/UsersPage.razor
+++ b/src/Ozds.Client/Pages/Administration/UsersPage.razor
@@ -55,3 +55,15 @@ Allows = [RoleModel.OperatorRepresentative])]
       Prefix="@(x => x.User)"/>
   </Columns>
 </MappedTable>
+
+@*// This if can be removed since it will return not found for incorrect role model*@
+@if (RepresentativeState.Representative.Role == RoleModel.OperatorRepresentative)
+{
+  <MudButton
+    Class="mt-4"
+    Variant="Variant.Outlined"
+    Color="Color.Primary"
+    Href="/administration/user">
+      @Translate("Create user")
+    </MudButton>
+}

--- a/src/Ozds.Client/Pages/Administration/UsersPage.razor
+++ b/src/Ozds.Client/Pages/Administration/UsersPage.razor
@@ -63,7 +63,7 @@ Allows = [RoleModel.OperatorRepresentative])]
     Class="mt-4"
     Variant="Variant.Outlined"
     Color="Color.Primary"
-    Href="/administration/user">
-      @Translate("Create user")
-    </MudButton>
+    Href="@(PageHref<UserPage>())">
+    @Translate("Create user")
+   </MudButton>
 }

--- a/src/Ozds.Users/Entities/NewPasswordEntity.cs
+++ b/src/Ozds.Users/Entities/NewPasswordEntity.cs
@@ -1,0 +1,8 @@
+namespace Ozds.Users.Entities;
+
+public class NewPasswordEntity
+{
+  public string UserId { get; set; } = default!;
+
+  public string NewPassword { get; set; } = default!;
+}

--- a/src/Ozds.Users/Mutations/PasswordMutations.cs
+++ b/src/Ozds.Users/Mutations/PasswordMutations.cs
@@ -96,4 +96,78 @@ public class PasswordMutations(
       logger.LogError(ex, "LDAP error during password update");
     }
   }
+
+  public async Task Create(
+    NewPasswordEntity entity,
+    CancellationToken cancellationToken
+  )
+  {
+    using var scope = serviceProvider.CreateAsyncScope();
+    var ldapConnection =
+      scope.ServiceProvider.GetRequiredService<LdapConnection>();
+
+    try
+    {
+      var idFilter = $"{options.Value.Ldap.UserIdAttribute}={entity.UserId}";
+      var ouFilter = $"objectClass={options.Value.Ldap.UserFilterObjectClass}";
+      var filter = $"(&({ouFilter})({idFilter}))";
+
+      string[] attributes =
+      {
+        options.Value.Ldap.UserIdAttribute,
+        options.Value.Ldap.UserNameAttribute,
+        options.Value.Ldap.UserEmailAttribute,
+      };
+
+      var searchResults = await Task.Run(
+        () =>
+          ldapConnection.Search(
+            options.Value.Ldap.BaseDn,
+            LdapConnection.ScopeSub,
+            filter,
+            attributes,
+            false
+          ),
+        cancellationToken
+      );
+
+      if (!searchResults.HasMore())
+      {
+        throw new InvalidOperationException(
+          $"User with id '{entity.UserId}' not found"
+        );
+      }
+
+      var entry = searchResults.Next();
+      var userDn = entry.Dn;
+
+      var sequence = new Asn1Sequence();
+      var idTag = new Asn1Tagged(
+        new Asn1Identifier(Asn1Identifier.Context, false, 0),
+        new Asn1OctetString(Encoding.UTF8.GetBytes(userDn)),
+        false
+      );
+      sequence.Add(idTag);
+      var newPasswordTag = new Asn1Tagged(
+        new Asn1Identifier(Asn1Identifier.Context, false, 2),
+        new Asn1OctetString(Encoding.UTF8.GetBytes(entity.NewPassword)),
+        false
+      );
+      sequence.Add(newPasswordTag);
+      var value = sequence.GetEncoding(new LberEncoder());
+      var passwordOperation = new LdapExtendedOperation(
+        PasswordModifyExtendedOperation,
+        value
+      );
+
+      await Task.Run(
+        () => ldapConnection.ExtendedOperation(passwordOperation),
+        cancellationToken
+      );
+    }
+    catch (Exception ex)
+    {
+      logger.LogError(ex, "LDAP error during password create");
+    }
+  }
 }


### PR DESCRIPTION
# Task

@HrvojeJuric
Fixes #258

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

- Fix `MaybeRepresentingUserModel` now has validation which prevents calling
  edit/create while validation is not satisfied
- Users page now has "Create user" button visible only to operators
- Added `NewPasswordModel` class with full validation which is used for user
  creation
- Added `NewPasswordEntity` in `Ozds.Users` tailored for creating new user
  particularly
- Added `PasswordMutations.Create()` method which sets initial password
- Added `PasswordField` now contains `For` parameter for validation messaging

## Appendix

### Noticed issues

Both password mutations and user mutations were swallowing up exceptions, leading to unsuccessful edits but window containing message that user has been modified.

Ldap problem with updating main user mail and cn are in read-only mode in LDAP:

<img width="519" height="74" alt="Snimka zaslona 2026-03-03 095651" src="https://github.com/user-attachments/assets/86073d4d-1667-4587-959d-5a3e1bdd5314" />

### Appended fixes 


## Testing

Localized tests with user creation / editing and validation testing.
