### PR TITLE
278 add case sensitivity to table search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
   points from root of url to the swagger API
 
+### Added
+
+- Added small button onto `MappedTable` which toggles case sensitive search (on
+  by default)
+- In `Table.cs` added private property and logic to define case sensitivity on
+  table search
+
 ## [1.8.1] - 2025-02-26
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
   points from root of url to the swagger API
+- update mailkit
 
 ### Added
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
 
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
-    <PackageVersion Include="MailKit" Version="4.7.1.1" />
+    <PackageVersion Include="MailKit" Version="4.15.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="OpenAI" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -194,6 +194,7 @@ words:
   - "hmacsha"
   - "identifiables"
   - "direnv"
+  - "mailkit"
 
   # Croatian
   - "altibiz"

--- a/scripts/flake/ozds/deps.json
+++ b/scripts/flake/ozds/deps.json
@@ -86,8 +86,8 @@
   },
   {
     "pname": "BouncyCastle.Cryptography",
-    "version": "2.4.0",
-    "hash": "sha256-DoDZNWtYM+0OLIclOEZ+tjcGXymGlXvdvq2ZMPmiAJA="
+    "version": "2.6.2",
+    "hash": "sha256-Yjk2+x/RcVeccGOQOQcRKCiYzyx1mlFnhS5auCII+Ms="
   },
   {
     "pname": "Castle.Core",
@@ -156,8 +156,8 @@
   },
   {
     "pname": "MailKit",
-    "version": "4.7.1.1",
-    "hash": "sha256-g9VnuGYTPNUa6woEO/gVbxNfaidHgGtoQw2qOgYLK0o="
+    "version": "4.15.1",
+    "hash": "sha256-ZI2ASxX1dY53YxWRii0Dow4aojR8VCEWzCWZLrH7wPw="
   },
   {
     "pname": "MassTransit",
@@ -466,8 +466,8 @@
   },
   {
     "pname": "MimeKit",
-    "version": "4.7.1",
-    "hash": "sha256-yTUqWAFU1v8jo70D09A+l8tsc+pr6IMOORD9L8EDz9o="
+    "version": "4.15.1",
+    "hash": "sha256-MI4Wr+JWoxR9wsYhKmW8j1EdJ59W/O4jv5D9Zb8mEUw="
   },
   {
     "pname": "Mono.TextTemplating",
@@ -706,8 +706,8 @@
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "8.0.0",
-    "hash": "sha256-yqfIIeZchsII2KdcxJyApZNzxM/VKknjs25gDWlweBI="
+    "version": "10.0.0",
+    "hash": "sha256-d3sLG+LZ3+N/h/6gdJcVKOgbBO6wYb66NfXalAEDqnE="
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -6819,7 +6819,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 33
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 278 column 33
         From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
@@ -8594,8 +8594,8 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 129 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 47
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 105 column 47
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 231 column 49
       </Metadata>
       <Value>
         Delete
@@ -10281,7 +10281,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 138 column 18
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 254 column 49
       </Metadata>
       <Value>
         Forget
@@ -20245,7 +20245,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 120 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 232 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 242 column 49
       </Metadata>
       <Value>
         Restore
@@ -20506,8 +20506,8 @@
         Search
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 62 column 48
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 170 column 29
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 66 column 50
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 180 column 29
       </Metadata>
       <Value>
         Search
@@ -20616,7 +20616,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 41 column 42
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 156 column 46
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 161 column 46
         From file 'Ozds.Client/Pages/Administration/LocationsPage.razor' line 31 column 13
         From file 'Ozds.Client/Pages/Administration/UsersPage.razor' line 28 column 13
       </Metadata>

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -6818,7 +6818,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 186 column 14
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 268 column 33
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 278 column 33
         From file 'Ozds.Client/Pages/Administration/UserPage.razor' line 112 column 12
         From file 'Ozds.Client/Pages/Measurements/MessengerPage.razor' line 32 column 6
       </Metadata>
@@ -8593,8 +8593,8 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 129 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 100 column 47
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 221 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 105 column 47
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 231 column 49
       </Metadata>
       <Value>
         Arhiviraj
@@ -10280,7 +10280,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 138 column 18
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 244 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 254 column 49
       </Metadata>
       <Value>
         Izbriši
@@ -20289,7 +20289,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedMutating.razor' line 120 column 20
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 232 column 49
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 242 column 49
       </Metadata>
       <Value>
         Obnovi
@@ -20550,8 +20550,8 @@
         Search
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 62 column 48
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 170 column 29
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 66 column 50
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 180 column 29
       </Metadata>
       <Value>
         Pretraži
@@ -20660,7 +20660,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 41 column 42
-        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 156 column 46
+        From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 161 column 46
         From file 'Ozds.Client/Pages/Administration/LocationsPage.razor' line 31 column 13
         From file 'Ozds.Client/Pages/Administration/UsersPage.razor' line 28 column 13
       </Metadata>

--- a/src/Ozds.Client/Components/Streaming/MappedTable.razor
+++ b/src/Ozds.Client/Components/Streaming/MappedTable.razor
@@ -53,17 +53,22 @@
                              @if (typeof(T).IsAssignableTo(typeof(IIdentifiable))
                                || typeof(T).IsAssignableTo(typeof(IAnalysis)))
                              {
-                               <MudTextField
-                                 Class="my-4"
-                                 T="string"
-                                 Value="@searchString"
-                                 DebounceInterval="500"
-                                 OnDebounceIntervalElapsed="@OnPagingSearch"
-                                 Placeholder="@Translate("Search")"
-                                 Adornment="Adornment.Start"
-                                 Immediate="true"
-                                 AdornmentIcon="@Icons.Material.Filled.Search"
-                                 IconSize="Size.Medium"/>
+                               <div class="d-flex flex-row align-center my-4">
+                                 <MudIconButton Icon="@Icons.Material.Filled.TextFields"
+                                   Color="@(caseSensitive ? Color.Primary : Color.Default)"
+                                   OnClick="@OnCaseSensitiveToggleGrid"
+                                   Size="Size.Medium"/>
+                                 <MudTextField
+                                   T="string"
+                                   Value="@searchString"
+                                   DebounceInterval="500"
+                                   OnDebounceIntervalElapsed="@OnPagingSearch"
+                                   Placeholder="@Translate("Search")"
+                                   Adornment="Adornment.Start"
+                                   Immediate="true"
+                                   AdornmentIcon="@Icons.Material.Filled.Search"
+                                   IconSize="Size.Medium"/>
+                               </div>
                              }
                              <MappedPaging
                                T="T"
@@ -162,6 +167,11 @@
 
           @if (typeof(T).IsAssignableTo(typeof(IIdentifiable)) || typeof(T).IsAssignableTo(typeof(IAnalysis)))
           {
+            <MudIconButton
+              Icon="@Icons.Material.Filled.TextFields"
+              Color="@(caseSensitive ? Color.Primary : Color.Default)"
+              OnClick="@OnCaseSensitiveTogglePaging"
+              Size="Size.Medium"/>
             <MudTextField
               T="string"
               Value="@searchString"

--- a/src/Ozds.Client/Components/Streaming/Table.cs
+++ b/src/Ozds.Client/Components/Streaming/Table.cs
@@ -175,12 +175,6 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
     await FetchDataGrid();
   }
 
-  private async Task OnCaseSensitiveToggle()
-  {
-    caseSensitive = !caseSensitive;
-    await Fetch();
-  }
-
   private async Task OnCaseSensitiveTogglePaging()
   {
     caseSensitive = !caseSensitive;

--- a/src/Ozds.Client/Components/Streaming/Table.cs
+++ b/src/Ozds.Client/Components/Streaming/Table.cs
@@ -32,6 +32,8 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
 
   private string? searchString;
 
+  private bool caseSensitive = true;
+
   [CascadingParameter]
   public RepresentativeState RepresentativeState { get; set; } = default!;
 
@@ -171,6 +173,24 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
   {
     searchString = newSearchString;
     await FetchDataGrid();
+  }
+
+  private async Task OnCaseSensitiveToggle()
+  {
+    caseSensitive = !caseSensitive;
+    await Fetch();
+  }
+
+  private async Task OnCaseSensitiveTogglePaging()
+  {
+    caseSensitive = !caseSensitive;
+    await FetchPaging();
+  }
+
+  private async Task OnCaseSensitiveToggleGrid()
+  {
+    caseSensitive = !caseSensitive;
+    await FetchPaging();
   }
 
   private async Task<GridData<T>> OnDataGridServerData(GridState<T> state)
@@ -652,6 +672,10 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
       return false;
     }
 
+    var comparison = caseSensitive
+      ? StringComparison.Ordinal
+      : StringComparison.OrdinalIgnoreCase;
+
     if (_columnSearchMappers is { } searchFields)
     {
       foreach (var mapper in searchFields)
@@ -659,7 +683,7 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
         if (
           mapper(model) is { } mappedModel
           && mappedModel.ToString() is { } stringTransform
-          && stringTransform.Contains(searchString)
+          && stringTransform.Contains(searchString, comparison)
         )
         {
           return true;
@@ -670,7 +694,7 @@ public partial class MappedTable<T, TMapped> : OzdsComponentBase
     // fallback just for older way of identifying
     if (
       toFilter is IIdentifiable { Title: { } title }
-      && title.Contains(searchString)
+      && title.Contains(searchString, comparison)
     )
     {
       return true;


### PR DESCRIPTION
# Task
# Implementation

@HrvojeJuric
Fixes #278 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

- Added small button onto `MappedTable` which toggles case sensitive search (on
  by default)
- In `Table.cs` added private property and logic to define case sensitivity on
  table search

### Visual depiction:  
On 
<img width="668" height="87" alt="image" src="https://github.com/user-attachments/assets/ce980a86-d90e-4a9f-9903-4f249acd89b4" />

Off
<img width="651" height="170" alt="image" src="https://github.com/user-attachments/assets/e95be8ba-4d3b-42cf-a2fb-d923535271ee" />

For now it's not integrated inside search field, but in future or if this PR requires it, it can be done.  As well as improvement of adding label which pops up when user hovers over the icon.
 
## Testing

Fire up local server and test serach some of the mapped tables with case sensitivity turned on and off. 
