### PR TITLE
277 API dead link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
+  points from root of url to the swagger API
+
 ## [1.8.1] - 2025-02-26
 
 ### Removed

--- a/src/Ozds.Client/Components/Base/OzdsComponentBaseNavigation.cs
+++ b/src/Ozds.Client/Components/Base/OzdsComponentBaseNavigation.cs
@@ -68,7 +68,7 @@ public abstract partial class OzdsComponentBase : DisposableComponentBase
 
   protected string ApiV1Href
   {
-    get { return BasedHref("/api/v1/openapi"); }
+    get { return "/api/v1/openapi"; }
   }
 
   protected string PageHref<T>(


### PR DESCRIPTION
# Task

@HrvojeJuric
Fixes #277 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
  points from root of url to the swagger API

The fix was ditching base url extension and just using typical string which is pasted onto root path.

```cs
  protected string ApiV1Href
  {
    get { return "/api/v1/openapi"; }
  }
```

## Testing

Click on the button titled API linked in Issue #277.
