### PR TITLE
EF Rollback script fix + update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
   package suppression does not work
 - added new script `./scripts/database/migrate-generated.nu` for creating
   migration specific to generated SQL code (for procedures and non EF stuff)
+- Fix, `rollback.nu` missing db context fix
+- `rollback.nu` script uses new where instead of deprecated filter
 
 ### Added
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,10 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
+    <PackageVersion
+      Include="Altibiz.DependencyInjection.Extensions"
+      Version="1.0.10"
+    />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -22,25 +25,73 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Design"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Proxies"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.InMemory"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.NamingConventions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.BulkExtensions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
+      Version="8.0.4"
+    />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
+    <PackageVersion
+      Include="Quartz.Serialization.SystemTextJson"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.DependencyInjection"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.Hosting"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
+      Version="0.5.1"
+    />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
-    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+    <PackageVersion
+      Include="MassTransit.RabbitMQ"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.Azure.ServiceBus.Core"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.EntityFrameworkCore"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
+      Version="8.0.17"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.Cookies"
+      Version="2.3.0"
+    />
+    <PackageVersion
+      Include="Novell.Directory.Ldap.NETStandard"
+      Version="3.6.0"
+    />
     <PackageVersion Include="MudBlazor" Version="8.1.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
@@ -53,7 +104,10 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Mvc.Testing"
+      Version="8.0.17"
+    />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,10 +10,7 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion
-      Include="Altibiz.DependencyInjection.Extensions"
-      Version="1.0.10"
-    />
+    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -25,73 +22,25 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Design"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Proxies"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.InMemory"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.NamingConventions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.BulkExtensions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
-      Version="8.0.4"
-    />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion
-      Include="Quartz.Serialization.SystemTextJson"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.DependencyInjection"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.Hosting"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
-      Version="0.5.1"
-    />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion
-      Include="MassTransit.RabbitMQ"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.Azure.ServiceBus.Core"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.EntityFrameworkCore"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
-      Version="8.0.17"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.Cookies"
-      Version="2.3.0"
-    />
-    <PackageVersion
-      Include="Novell.Directory.Ldap.NETStandard"
-      Version="3.6.0"
-    />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
+    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
     <PackageVersion Include="MudBlazor" Version="8.1.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
@@ -104,10 +53,7 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Mvc.Testing"
-      Version="8.0.17"
-    />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/scripts/database/rollback.nu
+++ b/scripts/database/rollback.nu
@@ -20,7 +20,7 @@ def main [project_name: string, name: string] {
     | each { |x|
       let migrations = glob $"($x)/Migrations/*"
         | path basename | sort
-        | filter { |x| $x < $timestamp and $x =~ '\d{14}_[^\.]*\.cs' }
+        | where { |x| $x < $timestamp and $x =~ '\d{14}_[^\.]*\.cs' }
       if ($migrations | is-empty) {
         return null
       }
@@ -30,18 +30,22 @@ def main [project_name: string, name: string] {
         | split row "." | first
 
       let csproj = [$x $"($x | path basename).csproj"] | path join
-      { project: $x migration: $migration csproj: $csproj }
+      let context =   $"($x | path basename | split row '.' | last)DbContext"
+      { project: $x migration: $migration csproj: $csproj context: $context }
     }
-    | filter { |x| $x | is-not-empty }
+    | where { |x| $x | is-not-empty }
 
   for $project_migration in $project_migrations {
     let project = $project_migration.project
     let migration = $project_migration.migration
     let csproj = $project_migration.csproj
-    (dotnet ef
+    let context = $project_migration.context
+    print ($"Rolling back to migration '($migration)' for project '($project)'.")
+    (
+      dotnet ef database update $migration
       --startup-project $server_csproj
       --project $csproj
-      database update
-      $migration)
+      --context $context
+    )
   }
 }


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

When rollbacking migrations this error would occur: 

<img width="1151" height="54" alt="Snimka zaslona 2026-03-12 152538" src="https://github.com/user-attachments/assets/52b157f0-aba8-4109-bfde-3d1de1183a4b" />

This was fixed by adding context which is derived from project name:

```cs 
let context =   $"($x | path basename | split row '.' | last)DbContext"
```

Making the final command rollback command: 

```nu
 (
      dotnet ef database update $migration
      --startup-project $server_csproj
      --project $csproj
      --context $context
    )
```

Also added debug print which tells user which migration specific project should revert back to so it is easier to debug: 

```cs
print ($"Rolling back to migration '($migration)' for project '($project)'.")
```

Also warnings of using deprecated filter:

<img width="873" height="189" alt="Snimka zaslona 2026-03-12 152405" src="https://github.com/user-attachments/assets/0908887c-3b3a-4ea1-b46c-ad8bab0b7f13" />

This has been resolved by using updated `where`. Which also supports closure definition like `filter`.

## Testing

Simple test using `just rollback [Ozds.ProjectName] [MigrationToRevertTo]`