### PR TITLE
Added generated migration script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -207,6 +207,26 @@ dotnet_diagnostic.S3246.severity = none
 # Prefer indexing instead of "Enumerable" methods on types implementing "IList"
 dotnet_diagnostic.S6608.severity = none
 
+# NOTE: most of these warnings are newer optimization warnings and will be
+# looked at eventually
+
+# Make member a static method/property
+dotnet_diagnostic.S2325.severity = none
+# "password" detected here, make sure this is not a hard-coded credential
+dotnet_diagnostic.S2068.severity = none
+# Remove the unused local variable
+dotnet_diagnostic.S1481.severity = none
+# Remove the unused private property
+dotnet_diagnostic.S1144.severity = none
+# Use 'Count' property here instead
+dotnet_diagnostic.S2971.severity = none
+# Loop should be simplified by calling Select
+dotnet_diagnostic.S3267.severity = none
+# Loop should be simplified by calling Select
+dotnet_diagnostic.S3267.severity = none
+# Loop should be simplified by calling Select
+dotnet_diagnostic.S3267.severity = none
+
 # TODO: put issues on github
 # Complete TODO
 dotnet_diagnostic.S1135.severity = none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
   points from root of url to the swagger API
 - update mailkit
+- updated sonar analyzer package
+- updated azure identity package
+- suppressed specific warnings because either they are new or .razor warning
+  suppression does not work
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - updated sonar analyzer package
 - updated azure identity package
 - suppressed specific warnings because either they are new or .razor warning
-  suppression does not work
+  package suppression does not work
+- added new script `./scripts/database/migrate-generated.nu` for creating
+  migration specific to generated SQL code (for procedures and non EF stuff)
 
 ### Added
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,9 @@
 
   <PropertyGroup>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+    <!-- NOTE: .editorconfig suppression doesn't work for some reason on Razor files in SonarAnalyzer v10.x -->
+    <!-- https://github.com/SonarSource/sonar-dotnet/issues/8050 -->
+    <NoWarn>$(NoWarn);S3358;S4136;S1144;S2971;S1481;S3267</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,10 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
+    <PackageVersion
+      Include="Altibiz.DependencyInjection.Extensions"
+      Version="1.0.10"
+    />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -22,25 +25,73 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Design"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Proxies"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.InMemory"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.NamingConventions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.BulkExtensions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
+      Version="8.0.4"
+    />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
+    <PackageVersion
+      Include="Quartz.Serialization.SystemTextJson"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.DependencyInjection"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.Hosting"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
+      Version="0.5.1"
+    />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
-    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+    <PackageVersion
+      Include="MassTransit.RabbitMQ"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.Azure.ServiceBus.Core"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.EntityFrameworkCore"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
+      Version="8.0.17"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.Cookies"
+      Version="2.3.0"
+    />
+    <PackageVersion
+      Include="Novell.Directory.Ldap.NETStandard"
+      Version="3.6.0"
+    />
     <PackageVersion Include="MudBlazor" Version="8.1.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
@@ -53,7 +104,10 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Mvc.Testing"
+      Version="8.0.17"
+    />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,15 +10,11 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion
-      Include="Altibiz.DependencyInjection.Extensions"
-      Version="1.0.10"
-    />
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
+    <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
-
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="MailKit" Version="4.15.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
@@ -26,73 +22,25 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Design"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Proxies"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.InMemory"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.NamingConventions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.BulkExtensions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
-      Version="8.0.4"
-    />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion
-      Include="Quartz.Serialization.SystemTextJson"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.DependencyInjection"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.Hosting"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
-      Version="0.5.1"
-    />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion
-      Include="MassTransit.RabbitMQ"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.Azure.ServiceBus.Core"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.EntityFrameworkCore"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
-      Version="8.0.17"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.Cookies"
-      Version="2.3.0"
-    />
-    <PackageVersion
-      Include="Novell.Directory.Ldap.NETStandard"
-      Version="3.6.0"
-    />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
+    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
     <PackageVersion Include="MudBlazor" Version="8.1.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
@@ -105,16 +53,13 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Mvc.Testing"
-      Version="8.0.17"
-    />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageVersion Include="System.Runtime.Caching" Version="9.0.10" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.28.0.94264" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.20.0.135146" />
   </ItemGroup>
 </Project>

--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ isdatabaseready := absolute_path('scripts/database/isready.nu')
 isllmready := absolute_path('scripts/llm/isready.nu')
 rewind := absolute_path('scripts/database/rewind.nu')
 rollback := absolute_path('scripts/database/rollback.nu')
+migrategenerated := absolute_path('scripts/database/migrate-generated.nu')
 validate := absolute_path('scripts/database/validate.nu')
 measurements := absolute_path('scripts/database/measurements.nu')
 playwright := absolute_path('src/Ozds.Server/bin/Debug/net8.0/playwright.ps1')
@@ -489,6 +490,10 @@ rewind *args:
 [confirm("This will clean docker containers. Do you want to continue?")]
 rollback *args:
     {{ rollback }} {{ args }}
+
+[confirm("This will clean docker containers. Do you want to continue?")]
+migrate-generated *args:
+  {{ migrategenerated }} {{ args }}
 
 [confirm("This will clean docker containers. Do you want to continue?")]
 validate *args:

--- a/justfile
+++ b/justfile
@@ -493,7 +493,7 @@ rollback *args:
 
 [confirm("This will clean docker containers. Do you want to continue?")]
 migrate-generated *args:
-  {{ migrategenerated }} {{ args }}
+    {{ migrategenerated }} {{ args }}
 
 [confirm("This will clean docker containers. Do you want to continue?")]
 validate *args:

--- a/scripts/database/migrate-generated.nu
+++ b/scripts/database/migrate-generated.nu
@@ -1,0 +1,42 @@
+#!/usr/bin/env nu
+
+let root = $env.FILE_PWD | path dirname --num-levels 2
+let src = [$root "src"] | path join
+let server_csproj = glob $"(glob $"($src)/**/Program.cs" | first | path dirname)/*.csproj" | first
+
+def main [project_name: string, project_context: string, migration_name: string] {
+
+  print "Adding dummy migration file..."
+
+  (^dotnet ef migrations add $migration_name
+    --startup-project $server_csproj
+    --project $"($src)/($project_name)"
+    --context $project_context | str join "")
+
+  let createdMigrationFile = (ls $"($src)/($project_name)/Migrations"
+  | get name
+  | path basename
+  | where { |x| $x =~ '\d{14}_[^\.]*\.cs'}
+  | sort
+  | last
+  )
+
+  print $"Created migration file: ($createdMigrationFile)"
+
+  print "Using created file to generate custom insert migration..."
+
+  (just migration generate
+  -o $"../../src/($project_name)/Migrations/($createdMigrationFile)"
+  -n $migration_name)
+
+  print "Migration generated successfully, continuing migration process..."
+
+  (just migrate-continue
+   $project_name
+   $project_context
+   $migration_name
+  )
+
+  print "Process finished."
+}
+

--- a/scripts/flake/ozds/deps.json
+++ b/scripts/flake/ozds/deps.json
@@ -56,8 +56,8 @@
   },
   {
     "pname": "Azure.Core",
-    "version": "1.50.0",
-    "hash": "sha256-8Pjz0/2wTLK5uY7G5qrxQr4CsmrjiR8gL4g6zJymj5s="
+    "version": "1.51.1",
+    "hash": "sha256-aNwDKJfkYC/QFaP8tCrwG+hFp+ubK6kUvEu4KhpgPTc="
   },
   {
     "pname": "Azure.Core.Amqp",
@@ -66,8 +66,8 @@
   },
   {
     "pname": "Azure.Identity",
-    "version": "1.17.1",
-    "hash": "sha256-pjNnhL/sCFy+BWNMAgj+l6aGoOp4ngrFO/61RIgzBEU="
+    "version": "1.19.0",
+    "hash": "sha256-8Sd9voC74wnW84qy8IxEYmbAdDOZYsGLgSudXYIjrh8="
   },
   {
     "pname": "Azure.Messaging.ServiceBus",
@@ -211,13 +211,13 @@
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "6.0.0",
-    "hash": "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU="
+    "version": "10.0.2",
+    "hash": "sha256-3lrCf7HOpbkZkQx4/JSpKi8Rl+hp9NAaRi9dp6xqMaQ="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "8.0.0",
-    "hash": "sha256-9aWmiwMJKrKr9ohD1KSuol37y+jdDxPGJct3m2/Bknw="
+    "version": "6.0.0",
+    "hash": "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Analyzers",
@@ -371,13 +371,13 @@
   },
   {
     "pname": "Microsoft.Identity.Client",
-    "version": "4.78.0",
-    "hash": "sha256-gvGU0Q6xwXZHVE6L0jz9uerBm3Rd5VucaXxiYlepp7s="
+    "version": "4.83.1",
+    "hash": "sha256-WDt1xgK5hdxSYg6cIK5wXtY4/PB+BaT393gNLawzE8A="
   },
   {
     "pname": "Microsoft.Identity.Client.Extensions.Msal",
-    "version": "4.78.0",
-    "hash": "sha256-0s9wa8HkFhnzmAz+TGxtA3qTX3dZiIoPcTWGLgY8mAg="
+    "version": "4.83.1",
+    "hash": "sha256-t4hG5KSzfBfhfZ7dJDBS2wr7v2nnDwRjPs78ZziM/b8="
   },
   {
     "pname": "Microsoft.IdentityModel.Abstractions",
@@ -576,8 +576,8 @@
   },
   {
     "pname": "SonarAnalyzer.CSharp",
-    "version": "9.28.0.94264",
-    "hash": "sha256-lG8+16cWHYNhO0MFjUHv0zQGj5mipRmUr57z3CaO1wk="
+    "version": "10.20.0.135146",
+    "hash": "sha256-cF13/AdM9mzwPagUsO/2CIaW1Vm30GoiMEtMU2xJJ9k="
   },
   {
     "pname": "SQLitePCLRaw.core",
@@ -616,8 +616,8 @@
   },
   {
     "pname": "System.ClientModel",
-    "version": "1.8.0",
-    "hash": "sha256-ZWVhuw3IRk9rZXkXERhesEET2KMMzHjUH/HDI288WK8="
+    "version": "1.9.0",
+    "hash": "sha256-8/feim+EOvZj0MU+ghFz257QzNUN+ila9p7eCAOCpug="
   },
   {
     "pname": "System.CodeDom",
@@ -696,8 +696,8 @@
   },
   {
     "pname": "System.Memory.Data",
-    "version": "8.0.1",
-    "hash": "sha256-cxYZL0Trr6RBplKmECv94ORuyjrOM6JB0D/EwmBSisg="
+    "version": "10.0.1",
+    "hash": "sha256-C4AaCiuS1BLljZq+3VUTJyHRA6IFPIO0gWZKw2hbt5o="
   },
   {
     "pname": "System.Runtime.Caching",


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Added new nushell script which does the procedure/function migrations in more automatic way. Also runs generated migration on specified db context.

Script location: `./scripts/database/migrate-generated.nu`.

The script creates new 'dummy' migration with designer and afterwards runs created generate script which will inject SQL insertion queries (yes this nukes the content of the created migration file so it's not multiple migration compatible for now) for structures not tracked by EF into existing migration. 

After that process is done the script runs `just migrate-continue` to apply pending migration to database.

## Testing

Test by using command `just migrate-generated Ozds.[Name] [DbContext] [MigrationName]`.

This will prompt you for Yes/No answer to determine if you want to proceed with this migration procedure.