### PR TITLE
Smaller fixes on energy card generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Fix, `rollback.nu` missing db context fix
 - `rollback.nu` script uses new where instead of deprecated filter
 - Fix, `CsvSerialization.cs` now has ',' separator instead of ';' which is used
-  by default in the importers
+  by default in the readers
 - Fix, missing mapping field in `EnergyCardModelReportEntityConverter` for field
   `ActiveEnergyTotalImportT0_kWh` in method `InitializeModel`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
   migration specific to generated SQL code (for procedures and non EF stuff)
 - Fix, `rollback.nu` missing db context fix
 - `rollback.nu` script uses new where instead of deprecated filter
+- Fix, `CsvSerialization.cs` now has ',' separator instead of ';' which is used
+  by default in the importers
+- Fix, missing mapping field in `EnergyCardModelReportEntityConverter` for field
+  `ActiveEnergyTotalImportT0_kWh` in method `InitializeModel`
 
 ### Added
 

--- a/src/Ozds.Business/Conversion/Implementations/Report/EnergyCardModelReportEntityConverter.cs
+++ b/src/Ozds.Business/Conversion/Implementations/Report/EnergyCardModelReportEntityConverter.cs
@@ -53,6 +53,7 @@ public class EnergyCardModelReportEntityConverter
     model.LocationPostalCode = entity.LocationPostalCode;
     model.Year = entity.Year;
     model.BillingPeriod = entity.BillingPeriod;
+    model.ActiveEnergyTotalImportT0_kWh = entity.ActiveEnergyTotalImportT0_kWh;
     model.ActiveEnergyTotalImportT1_kWh = entity.ActiveEnergyTotalImportT1_kWh;
     model.ActiveEnergyTotalImportT2_kWh = entity.ActiveEnergyTotalImportT2_kWh;
     model.ReactiveEnergyTotalImportT0_kVARh =

--- a/src/Ozds.Report/Serialization/Implementations/CsvSerialization.cs
+++ b/src/Ozds.Report/Serialization/Implementations/CsvSerialization.cs
@@ -16,7 +16,7 @@ public class CsvSerialization(IServiceProvider serviceProvider)
   : IExporter,
     IImporter
 {
-  private const char Separator = ';';
+  private const char Separator = ';'; // TODO: find if this can be safely replaced by ','
 
   private const char Newline = '\n';
 

--- a/src/Ozds.Report/Serialization/Implementations/CsvSerialization.cs
+++ b/src/Ozds.Report/Serialization/Implementations/CsvSerialization.cs
@@ -16,7 +16,7 @@ public class CsvSerialization(IServiceProvider serviceProvider)
   : IExporter,
     IImporter
 {
-  private const char Separator = ';'; // TODO: find if this can be safely replaced by ','
+  private const char Separator = ',';
 
   private const char Newline = '\n';
 


### PR DESCRIPTION
@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Smaller fixes on the CSV energy card generator: 

Fix 1: 
Missing mapping field in `EnergyCardModelReportEntityConverter` for field `ActiveEnergyTotalImportT0_kWh` in method `InitializeModel`. 

Fix 2:

Replaced separator on CSV importer/exporter -> `private const char Separator = ','`

### Reason for this change: 

Our importers: 
```cs
public IImportStreamer<T> Import<T>(CultureInfo culture, Stream csvStream)
{
  var streamReader = new StreamReader(csvStream);
  var config = new CsvConfiguration(CultureInfo.InvariantCulture);
  var csvReader = new CsvReader(streamReader, config);
  return new CsvImportStreamer<T>(
    serviceProvider,
    culture,
    streamReader,
    csvReader
  );
}
```
Use culture info only for translating the headers from csv files, but for real data conversion `CsvReader` uses `CultureInfo.InvariantCulture` which by default takes `,` as separator. Same goes for our exporters, they only use culture for translating header rows when writing into CSV files.

This also fixes some import problems on some applications which import csv using invariant cultures as well (such as nushell integrated csv reader and excel).

## Testing

For second fix you can export energy card for specific network user and open it in Excel.
