### PR TITLE
285 network energy card csv broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and adheres to [Semantic Versioning](https://semver.org/).
   flaky non deterministic failures
 - Removed polling program parts since Ozds.Caching.Test should now be
   deterministic
+- Fix network energy card CSV/report queries to use proper aggregate window
+  boundaries instead of raw measurement queries, matching invoice calculation
+  behavior
+- Refactored ReportQueries to delegate aggregate fetching to
+  AggregateWindowQueries, eliminating duplicated mapping logic across
+  ReadEnergyCardReportBasis, ReadEnergyCardReportBasisByNetworkUser, and
+  ReadEnergyCardReportBasisByLocation
 
 ### Added
 
@@ -43,6 +50,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
   reports
 - add another button `Shortened energy card report (CSV)` with specific use for
   generating requested shortened version
+- New AggregateWindowQueries class with optimized Dapper queries for fetching
+  aggregate window boundaries by measurement location - New
+  AggregateWindowBoundaryBasisEntity DTO for aggregate window query results
+- Tests for ReadEnergyCardReportBasisByNetworkUser and ReadLoadCurveReportBasis
+  aggregate window queries
 
 ## [1.8.1] - 2025-02-26
 

--- a/src/Ozds.Data/Entities/Composite/AggregateWindowBoundaryBasisEntity.cs
+++ b/src/Ozds.Data/Entities/Composite/AggregateWindowBoundaryBasisEntity.cs
@@ -8,7 +8,7 @@ public class AggregateWindowBoundaryBasisEntity
   public AggregateEntity? StartAggregate { get; init; }
   public AggregateEntity? EndAggregate { get; init; }
 }
-public class AggregateWindowLoadCurveBasisEnity : AggregateWindowBoundaryBasisEntity
+public class AggregateWindowLoadCurveBasisEntity : AggregateWindowBoundaryBasisEntity
 {
   public List<AggregateEntity> InWindowAggregates { get; init; } = [];
 }

--- a/src/Ozds.Data/Entities/Composite/AggregateWindowBoundaryBasisEntity.cs
+++ b/src/Ozds.Data/Entities/Composite/AggregateWindowBoundaryBasisEntity.cs
@@ -1,0 +1,14 @@
+using Ozds.Data.Entities.Base;
+
+namespace Ozds.Data.Entities.Composite;
+
+public class AggregateWindowBoundaryBasisEntity
+{
+  public required string MeasurementLocationId { get; init; }
+  public AggregateEntity? StartAggregate { get; init; }
+  public AggregateEntity? EndAggregate { get; init; }
+}
+public class AggregateWindowLoadCurveBasisEnity : AggregateWindowBoundaryBasisEntity
+{
+  public List<AggregateEntity> InWindowAggregates { get; init; } = [];
+}

--- a/src/Ozds.Data/Entities/Composite/AggregateWindowBoundaryBasisEntity.cs
+++ b/src/Ozds.Data/Entities/Composite/AggregateWindowBoundaryBasisEntity.cs
@@ -8,7 +8,9 @@ public class AggregateWindowBoundaryBasisEntity
   public AggregateEntity? StartAggregate { get; init; }
   public AggregateEntity? EndAggregate { get; init; }
 }
-public class AggregateWindowLoadCurveBasisEntity : AggregateWindowBoundaryBasisEntity
+
+public class AggregateWindowLoadCurveBasisEntity
+  : AggregateWindowBoundaryBasisEntity
 {
   public List<AggregateEntity> InWindowAggregates { get; init; } = [];
 }

--- a/src/Ozds.Data/Extensions/HostExtensions.cs
+++ b/src/Ozds.Data/Extensions/HostExtensions.cs
@@ -141,7 +141,21 @@ public static class HostExtensions
         if (environment.IsDevelopment())
         {
           options.ConfigureWarnings(warnings =>
-            warnings.Throw(RelationalEventId.MultipleCollectionIncludeWarning)
+            {
+              warnings.Throw(RelationalEventId.MultipleCollectionIncludeWarning);
+            }
+          );
+        }
+
+        // TODO: updating issue for EF and its deps will be created
+        // after updating to npgsql to 9.0+ apply this patch in following resolved issue
+        // https://github.com/npgsql/efcore.pg/issues/3086
+        if (dataOptions.IsTesting)
+        {
+          options.ConfigureWarnings(warnings =>
+            {
+              warnings.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning);
+            }
           );
         }
 

--- a/src/Ozds.Data/Extensions/HostExtensions.cs
+++ b/src/Ozds.Data/Extensions/HostExtensions.cs
@@ -141,10 +141,9 @@ public static class HostExtensions
         if (environment.IsDevelopment())
         {
           options.ConfigureWarnings(warnings =>
-            {
-              warnings.Throw(RelationalEventId.MultipleCollectionIncludeWarning);
-            }
-          );
+          {
+            warnings.Throw(RelationalEventId.MultipleCollectionIncludeWarning);
+          });
         }
 
         // TODO: updating issue for EF and its deps will be created
@@ -153,10 +152,9 @@ public static class HostExtensions
         if (dataOptions.IsTesting)
         {
           options.ConfigureWarnings(warnings =>
-            {
-              warnings.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning);
-            }
-          );
+          {
+            warnings.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning);
+          });
         }
 
         if (dataOptions.UseProxies)

--- a/src/Ozds.Data/Options/OzdsDataOptions.cs
+++ b/src/Ozds.Data/Options/OzdsDataOptions.cs
@@ -15,6 +15,8 @@ public class OzdsDataOptions
   public bool WithServices { get; set; } = true;
 
   public bool SelfContainedReflection { get; set; } = false;
+
+  public bool IsTesting { get; set; } = false;
 }
 
 public class ConfigureOzdsDataOptions(IConfiguration configuration)

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -9,6 +9,9 @@ using Ozds.Data.Reflection;
 
 namespace Ozds.Data.Queries;
 
+// NOTE: as explained in MeasurementQueries.cs
+// <= toDate because of invoice/report calculations
+
 public class AggregateWindowQueries(
   IDbContextFactory<DataDbContext> factory,
   EntityReflector reflector
@@ -74,7 +77,7 @@ public class AggregateWindowQueries(
         WHERE aggregates.interval
             = '{quarterHourIntervalValue}'::{intervalTypeName}
           AND aggregates.timestamp >= @from
-          AND aggregates.timestamp < @to
+          AND aggregates.timestamp <= @to
       ";
 
       var returnedAggregates = await context.DapperCommand<AggregateEntity>(
@@ -164,7 +167,7 @@ public class AggregateWindowQueries(
             AND aggregates.interval
                 = '{quarterHourIntervalValue}'::{intervalTypeName}
             AND aggregates.timestamp >= @from
-            AND aggregates.timestamp < @to
+            AND aggregates.timestamp <= @to
           ORDER BY aggregates.timestamp ASC
           LIMIT 1
         ) agg
@@ -178,7 +181,7 @@ public class AggregateWindowQueries(
             AND aggregates.interval
                 = '{quarterHourIntervalValue}'::{intervalTypeName}
             AND aggregates.timestamp >= @from
-            AND aggregates.timestamp < @to
+            AND aggregates.timestamp <= @to
           ORDER BY aggregates.timestamp DESC
           LIMIT 1
         ) agg

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -18,7 +18,7 @@ public class AggregateWindowQueries(
 ) : IQueries
 {
   public async Task<
-    List<AggregateWindowLoadCurveBasisEnity>
+    List<AggregateWindowLoadCurveBasisEntity>
   > ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
     IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>> measurementLocationsByAggregateType,
     DateTimeOffset fromDate,
@@ -27,7 +27,7 @@ public class AggregateWindowQueries(
   )
   {
 
-    var totalWindowAggregates = new List<AggregateWindowLoadCurveBasisEnity>();
+    var totalWindowAggregates = new List<AggregateWindowLoadCurveBasisEntity>();
 
     foreach (var (aggregateType, measurementLocationIds) in measurementLocationsByAggregateType)
     {
@@ -93,7 +93,7 @@ public class AggregateWindowQueries(
         .Select(group =>
         {
           var ordered = group.OrderBy(a => a.Timestamp).ToList();
-          return new AggregateWindowLoadCurveBasisEnity
+          return new AggregateWindowLoadCurveBasisEntity
           {
             MeasurementLocationId = group.Key,
             StartAggregate = ordered.FirstOrDefault(),
@@ -108,7 +108,7 @@ public class AggregateWindowQueries(
 
   public async Task<
     List<AggregateWindowBoundaryBasisEntity>
-  > ReadAggregateWindowBoundryBasesByMeasurementLocation(
+  > ReadAggregateWindowBoundaryBasesByMeasurementLocation(
     IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>> measurementLocationsByAggregateType,
     DateTimeOffset fromDate,
     DateTimeOffset toDate,

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -1,0 +1,213 @@
+using Microsoft.EntityFrameworkCore;
+using Ozds.Data.Context;
+using Ozds.Data.Entities.Base;
+using Ozds.Data.Entities.Composite;
+using Ozds.Data.Entities.Enums;
+using Ozds.Data.Extensions;
+using Ozds.Data.Queries.Abstractions;
+using Ozds.Data.Reflection;
+
+namespace Ozds.Data.Queries;
+
+public class AggregateWindowQueries(
+  IDbContextFactory<DataDbContext> factory,
+  EntityReflector reflector
+) : IQueries
+{
+  public async Task<
+    List<AggregateWindowLoadCurveBasisEnity>
+  > ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
+    IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>> measurementLocationsByAggregateType,
+    DateTimeOffset fromDate,
+    DateTimeOffset toDate,
+    CancellationToken cancellationToken
+  )
+  {
+
+    var totalWindowAggregates = new List<AggregateWindowLoadCurveBasisEnity>();
+
+    foreach (var (aggregateType, measurementLocationIds) in measurementLocationsByAggregateType)
+    {
+      if (measurementLocationIds.Count == 0)
+      {
+        continue;
+      }
+
+      await using var context = await factory.CreateDbContextAsync(
+        cancellationToken
+      );
+
+      var table = reflector.ResolveEntityTable(aggregateType);
+      var quarterHourIntervalValue = StringExtensions.ToSnakeCase(
+        IntervalEntity.QuarterHour.ToString()
+      );
+      var intervalTypeName = StringExtensions.ToSnakeCase(
+        nameof(IntervalEntity)
+      );
+
+      var parameters = new Dictionary<string, object?>
+      {
+        { "from", fromDate },
+        { "to", toDate },
+      };
+
+      var locationValueRows = new List<string>();
+      var index = 0;
+      foreach (var id in measurementLocationIds)
+      {
+        var paramName = $"location{index++}";
+        parameters[paramName] = long.Parse(id);
+        locationValueRows.Add($"(@{paramName})");
+      }
+
+      var valuesClause = string.Join(", ", locationValueRows);
+
+      var sql =
+      $@"
+        SELECT aggregates.*
+        FROM {table} aggregates
+        JOIN (
+          VALUES {valuesClause}
+        ) AS selected_locations(location_id)
+          ON selected_locations.location_id
+            = aggregates.measurement_location_id
+        WHERE aggregates.interval
+            = '{quarterHourIntervalValue}'::{intervalTypeName}
+          AND aggregates.timestamp >= @from
+          AND aggregates.timestamp < @to
+      ";
+
+      var returnedAggregates = await context.DapperCommand<AggregateEntity>(
+        aggregateType,
+        sql,
+        cancellationToken,
+        parameters,
+        300
+      );
+
+      totalWindowAggregates.AddRange(
+        returnedAggregates.GroupBy(a => a.MeasurementLocationId)
+        .Select(group =>
+        {
+          var ordered = group.OrderBy(a => a.Timestamp).ToList();
+          return new AggregateWindowLoadCurveBasisEnity
+          {
+            MeasurementLocationId = group.Key,
+            StartAggregate = ordered.FirstOrDefault(),
+            EndAggregate = ordered.LastOrDefault(),
+            InWindowAggregates = ordered,
+          };
+        })
+      );
+    }
+    return totalWindowAggregates;
+  }
+
+  public async Task<
+    List<AggregateWindowBoundaryBasisEntity>
+  > ReadAggregateWindowBoundryBasesByMeasurementLocation(
+    IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>> measurementLocationsByAggregateType,
+    DateTimeOffset fromDate,
+    DateTimeOffset toDate,
+    CancellationToken cancellationToken
+  )
+  {
+    var totalWindowAggregates = new List<AggregateWindowBoundaryBasisEntity>();
+
+    foreach (var (aggregateType, measurementLocationIds) in measurementLocationsByAggregateType)
+    {
+      if (measurementLocationIds.Count == 0)
+      {
+        continue;
+      }
+
+      await using var context = await factory.CreateDbContextAsync(
+        cancellationToken
+      );
+
+      var table = reflector.ResolveEntityTable(aggregateType);
+      var quarterHourIntervalValue = StringExtensions.ToSnakeCase(
+        IntervalEntity.QuarterHour.ToString()
+      );
+      var intervalTypeName = StringExtensions.ToSnakeCase(
+        nameof(IntervalEntity)
+      );
+
+      var parameters = new Dictionary<string, object?>
+      {
+        { "from", fromDate },
+        { "to", toDate },
+      };
+
+      var locationValueRows = new List<string>();
+      var index = 0;
+      foreach (var id in measurementLocationIds)
+      {
+        var paramName = $"location{index++}";
+        parameters[paramName] = long.Parse(id);
+        locationValueRows.Add($"(@{paramName})");
+      }
+
+      var valuesClause = string.Join(", ", locationValueRows);
+
+      var sql =
+        $@"
+        WITH selected_locations AS (
+          SELECT * FROM (VALUES {valuesClause}) AS v(location_id)
+        )
+        SELECT agg.*
+        FROM selected_locations
+        CROSS JOIN LATERAL (
+          SELECT * FROM {table} aggregates
+          WHERE aggregates.measurement_location_id
+              = selected_locations.location_id
+            AND aggregates.interval
+                = '{quarterHourIntervalValue}'::{intervalTypeName}
+            AND aggregates.timestamp >= @from
+            AND aggregates.timestamp < @to
+          ORDER BY aggregates.timestamp ASC
+          LIMIT 1
+        ) agg
+        UNION ALL
+        SELECT agg.*
+        FROM selected_locations
+        CROSS JOIN LATERAL (
+          SELECT * FROM {table} aggregates
+          WHERE aggregates.measurement_location_id
+              = selected_locations.location_id
+            AND aggregates.interval
+                = '{quarterHourIntervalValue}'::{intervalTypeName}
+            AND aggregates.timestamp >= @from
+            AND aggregates.timestamp < @to
+          ORDER BY aggregates.timestamp DESC
+          LIMIT 1
+        ) agg
+      ";
+
+      var returnedAggregates = await context.DapperCommand<AggregateEntity>(
+        aggregateType,
+        sql,
+        cancellationToken,
+        parameters,
+        300
+      );
+
+      totalWindowAggregates.AddRange(
+        returnedAggregates
+          .GroupBy(a => a.MeasurementLocationId)
+          .Select(group =>
+          {
+            var ordered = group.OrderBy(a => a.Timestamp).ToList();
+            return new AggregateWindowBoundaryBasisEntity
+            {
+              MeasurementLocationId = group.Key,
+              StartAggregate = ordered.FirstOrDefault(),
+              EndAggregate = ordered.LastOrDefault(),
+            };
+          })
+      );
+    }
+
+    return totalWindowAggregates;
+  }
+}

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -20,16 +20,22 @@ public class AggregateWindowQueries(
   public async Task<
     List<AggregateWindowLoadCurveBasisEntity>
   > ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
-    IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>> measurementLocationsByAggregateType,
+    IEnumerable<
+      KeyValuePair<Type, IReadOnlyList<string>>
+    > measurementLocationsByAggregateType,
     DateTimeOffset fromDate,
     DateTimeOffset toDate,
     CancellationToken cancellationToken
   )
   {
-
     var totalWindowAggregates = new List<AggregateWindowLoadCurveBasisEntity>();
 
-    foreach (var (aggregateType, measurementLocationIds) in measurementLocationsByAggregateType)
+    foreach (
+      var (
+        aggregateType,
+        measurementLocationIds
+      ) in measurementLocationsByAggregateType
+    )
     {
       if (measurementLocationIds.Count == 0)
       {
@@ -66,7 +72,7 @@ public class AggregateWindowQueries(
       var valuesClause = string.Join(", ", locationValueRows);
 
       var sql =
-      $@"
+        $@"
         SELECT aggregates.*
         FROM {table} aggregates
         JOIN (
@@ -89,18 +95,19 @@ public class AggregateWindowQueries(
       );
 
       totalWindowAggregates.AddRange(
-        returnedAggregates.GroupBy(a => a.MeasurementLocationId)
-        .Select(group =>
-        {
-          var ordered = group.OrderBy(a => a.Timestamp).ToList();
-          return new AggregateWindowLoadCurveBasisEntity
+        returnedAggregates
+          .GroupBy(a => a.MeasurementLocationId)
+          .Select(group =>
           {
-            MeasurementLocationId = group.Key,
-            StartAggregate = ordered.FirstOrDefault(),
-            EndAggregate = ordered.LastOrDefault(),
-            InWindowAggregates = ordered,
-          };
-        })
+            var ordered = group.OrderBy(a => a.Timestamp).ToList();
+            return new AggregateWindowLoadCurveBasisEntity
+            {
+              MeasurementLocationId = group.Key,
+              StartAggregate = ordered.FirstOrDefault(),
+              EndAggregate = ordered.LastOrDefault(),
+              InWindowAggregates = ordered,
+            };
+          })
       );
     }
     return totalWindowAggregates;
@@ -109,7 +116,9 @@ public class AggregateWindowQueries(
   public async Task<
     List<AggregateWindowBoundaryBasisEntity>
   > ReadAggregateWindowBoundaryBasesByMeasurementLocation(
-    IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>> measurementLocationsByAggregateType,
+    IEnumerable<
+      KeyValuePair<Type, IReadOnlyList<string>>
+    > measurementLocationsByAggregateType,
     DateTimeOffset fromDate,
     DateTimeOffset toDate,
     CancellationToken cancellationToken
@@ -117,7 +126,12 @@ public class AggregateWindowQueries(
   {
     var totalWindowAggregates = new List<AggregateWindowBoundaryBasisEntity>();
 
-    foreach (var (aggregateType, measurementLocationIds) in measurementLocationsByAggregateType)
+    foreach (
+      var (
+        aggregateType,
+        measurementLocationIds
+      ) in measurementLocationsByAggregateType
+    )
     {
       if (measurementLocationIds.Count == 0)
       {

--- a/src/Ozds.Data/Queries/ReportQueries.cs
+++ b/src/Ozds.Data/Queries/ReportQueries.cs
@@ -33,8 +33,8 @@ public class ReportQueries(
       return null;
     }
 
-    var boundaries = await aggregateWindowQueries
-      .ReadAggregateWindowBoundaryBasesByMeasurementLocation(
+    var boundaries =
+      await aggregateWindowQueries.ReadAggregateWindowBoundaryBasesByMeasurementLocation(
         GroupByAggregateType(initial),
         fromDate,
         toDate,
@@ -60,8 +60,8 @@ public class ReportQueries(
       return null;
     }
 
-    var boundaries = await aggregateWindowQueries
-      .ReadAggregateWindowBoundaryBasesByMeasurementLocation(
+    var boundaries =
+      await aggregateWindowQueries.ReadAggregateWindowBoundaryBasesByMeasurementLocation(
         GroupByAggregateType(initial),
         fromDate,
         toDate,
@@ -87,8 +87,8 @@ public class ReportQueries(
       return null;
     }
 
-    var boundaries = await aggregateWindowQueries
-      .ReadAggregateWindowBoundaryBasesByMeasurementLocation(
+    var boundaries =
+      await aggregateWindowQueries.ReadAggregateWindowBoundaryBasesByMeasurementLocation(
         GroupByAggregateType(initial),
         fromDate,
         toDate,
@@ -218,8 +218,8 @@ public class ReportQueries(
       aggregate: true
     );
 
-    var curves = await aggregateWindowQueries
-      .ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
+    var curves =
+      await aggregateWindowQueries.ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
         [
           new KeyValuePair<Type, IReadOnlyList<string>>(
             aggregateType,
@@ -262,8 +262,8 @@ public class ReportQueries(
       return null;
     }
 
-    var curves = await aggregateWindowQueries
-      .ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
+    var curves =
+      await aggregateWindowQueries.ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
         [
           new KeyValuePair<Type, IReadOnlyList<string>>(
             aggregateEntityType,
@@ -292,16 +292,17 @@ public class ReportQueries(
     };
   }
 
-  private IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>>
-    GroupByAggregateType(
-      List<ReportBasisEntity> bases
-    )
+  private IEnumerable<
+    KeyValuePair<Type, IReadOnlyList<string>>
+  > GroupByAggregateType(List<ReportBasisEntity> bases)
   {
     return bases
       .GroupBy(b =>
         reflector.ResolveMeterMeasurementType(
-          b.Meter.GetType().Assembly.FullName?.StartsWith("DynamicProxyGenAssembly2") != true // TODO: temp fix for proxy types until better solution is implemented
-          ? b.Meter.GetType() : b.Meter.GetType().BaseType!,
+          b.Meter.GetType()
+            .Assembly.FullName?.StartsWith("DynamicProxyGenAssembly2") != true // TODO: temp fix for proxy types until better solution is implemented
+            ? b.Meter.GetType()
+            : b.Meter.GetType().BaseType!,
           aggregate: true
         )
       )
@@ -319,8 +320,8 @@ public class ReportQueries(
     return bases
       .Select(basis =>
       {
-        var boundary = boundaries.FirstOrDefault(
-          b => b.MeasurementLocationId == basis.MeasurementLocation.Id
+        var boundary = boundaries.FirstOrDefault(b =>
+          b.MeasurementLocationId == basis.MeasurementLocation.Id
         );
         if (
           boundary?.StartAggregate is null

--- a/src/Ozds.Data/Queries/ReportQueries.cs
+++ b/src/Ozds.Data/Queries/ReportQueries.cs
@@ -300,7 +300,8 @@ public class ReportQueries(
     return bases
       .GroupBy(b =>
         reflector.ResolveMeterMeasurementType(
-          b.Meter.GetType(),
+          b.Meter.GetType().Assembly.FullName?.StartsWith("DynamicProxyGenAssembly2") != true // TODO: temp fix for proxy types until better solution is implemented
+          ? b.Meter.GetType() : b.Meter.GetType().BaseType!,
           aggregate: true
         )
       )

--- a/src/Ozds.Data/Queries/ReportQueries.cs
+++ b/src/Ozds.Data/Queries/ReportQueries.cs
@@ -34,7 +34,7 @@ public class ReportQueries(
     }
 
     var boundaries = await aggregateWindowQueries
-      .ReadAggregateWindowBoundryBasesByMeasurementLocation(
+      .ReadAggregateWindowBoundaryBasesByMeasurementLocation(
         GroupByAggregateType(initial),
         fromDate,
         toDate,
@@ -61,7 +61,7 @@ public class ReportQueries(
     }
 
     var boundaries = await aggregateWindowQueries
-      .ReadAggregateWindowBoundryBasesByMeasurementLocation(
+      .ReadAggregateWindowBoundaryBasesByMeasurementLocation(
         GroupByAggregateType(initial),
         fromDate,
         toDate,
@@ -88,7 +88,7 @@ public class ReportQueries(
     }
 
     var boundaries = await aggregateWindowQueries
-      .ReadAggregateWindowBoundryBasesByMeasurementLocation(
+      .ReadAggregateWindowBoundaryBasesByMeasurementLocation(
         GroupByAggregateType(initial),
         fromDate,
         toDate,

--- a/src/Ozds.Data/Queries/ReportQueries.cs
+++ b/src/Ozds.Data/Queries/ReportQueries.cs
@@ -6,12 +6,15 @@ using Ozds.Data.Entities.Composite;
 using Ozds.Data.Entities.Enums;
 using Ozds.Data.Extensions;
 using Ozds.Data.Queries.Abstractions;
+using Ozds.Data.Reflection;
 
 namespace Ozds.Data.Queries;
 
 public class ReportQueries(
   IDbContextFactory<DataDbContext> factory,
-  MeasurementQueries measurementQueries
+  MeasurementQueries measurementQueries,
+  AggregateWindowQueries aggregateWindowQueries,
+  EntityReflector reflector
 ) : IQueries
 {
   public async Task<List<EnergyCardReportBasisEntity>?> ReadEnergyCardReportBasis(
@@ -30,51 +33,15 @@ public class ReportQueries(
       return null;
     }
 
-    measurementLocationIds = initial.Select(x => x.MeasurementLocation.Id);
+    var boundaries = await aggregateWindowQueries
+      .ReadAggregateWindowBoundryBasesByMeasurementLocation(
+        GroupByAggregateType(initial),
+        fromDate,
+        toDate,
+        cancellationToken
+      );
 
-    var aggregates = await measurementQueries.ReadByMeasurementLocationIds(
-      measurementLocationIds,
-      IntervalEntity.Month,
-      fromDate,
-      toDate,
-      0,
-      cancellationToken
-    );
-
-    return initial
-      .Select(basis =>
-      {
-        var basisAggregates = aggregates.Items.Where(x =>
-          x.MeasurementLocationId == basis.MeasurementLocation.Id
-        );
-        var minAggregate = basisAggregates
-          .OfType<AggregateEntity>()
-          .FirstOrDefault();
-        var maxAggregate = basisAggregates
-          .OfType<AggregateEntity>()
-          .LastOrDefault();
-        if (
-          minAggregate is null
-          || maxAggregate is null
-          || minAggregate == maxAggregate
-        )
-        {
-          return null;
-        }
-
-        return new EnergyCardReportBasisEntity
-        {
-          Location = basis.Location,
-          NetworkUser = basis.NetworkUser,
-          Catalogue = basis.Catalogue,
-          MeasurementLocation = basis.MeasurementLocation,
-          Meter = basis.Meter,
-          MinAggregate = minAggregate,
-          MaxAggregate = maxAggregate,
-        };
-      })
-      .OfType<EnergyCardReportBasisEntity>()
-      .ToList();
+    return MapEnergyCardBases(initial, boundaries);
   }
 
   public async Task<List<EnergyCardReportBasisEntity>?> ReadEnergyCardReportBasisByNetworkUser(
@@ -93,47 +60,15 @@ public class ReportQueries(
       return null;
     }
 
-    var measurementLocationIds = initial.Select(x => x.MeasurementLocation.Id);
+    var boundaries = await aggregateWindowQueries
+      .ReadAggregateWindowBoundryBasesByMeasurementLocation(
+        GroupByAggregateType(initial),
+        fromDate,
+        toDate,
+        cancellationToken
+      );
 
-    var aggregates = await measurementQueries.ReadByMeasurementLocationIds(
-      measurementLocationIds,
-      IntervalEntity.Month,
-      fromDate,
-      toDate,
-      0,
-      cancellationToken
-    );
-
-    return initial
-      .Select(basis =>
-      {
-        var basisAggregates = aggregates.Items.Where(x =>
-          x.MeasurementLocationId == basis.MeasurementLocation.Id
-        );
-        var minAggregate = basisAggregates
-          .OfType<AggregateEntity>()
-          .FirstOrDefault();
-        var maxAggregate = basisAggregates
-          .OfType<AggregateEntity>()
-          .LastOrDefault();
-        if (minAggregate is null || maxAggregate is null)
-        {
-          return null;
-        }
-
-        return new EnergyCardReportBasisEntity
-        {
-          Location = basis.Location,
-          NetworkUser = basis.NetworkUser,
-          Catalogue = basis.Catalogue,
-          MeasurementLocation = basis.MeasurementLocation,
-          Meter = basis.Meter,
-          MinAggregate = minAggregate,
-          MaxAggregate = maxAggregate,
-        };
-      })
-      .OfType<EnergyCardReportBasisEntity>()
-      .ToList();
+    return MapEnergyCardBases(initial, boundaries);
   }
 
   public async Task<List<EnergyCardReportBasisEntity>?> ReadEnergyCardReportBasisByLocation(
@@ -152,47 +87,15 @@ public class ReportQueries(
       return null;
     }
 
-    var measurementLocationIds = initial.Select(x => x.MeasurementLocation.Id);
+    var boundaries = await aggregateWindowQueries
+      .ReadAggregateWindowBoundryBasesByMeasurementLocation(
+        GroupByAggregateType(initial),
+        fromDate,
+        toDate,
+        cancellationToken
+      );
 
-    var aggregates = await measurementQueries.ReadByMeasurementLocationIds(
-      measurementLocationIds,
-      IntervalEntity.Month,
-      fromDate,
-      toDate,
-      0,
-      cancellationToken
-    );
-
-    return initial
-      .Select(basis =>
-      {
-        var basisAggregates = aggregates.Items.Where(x =>
-          x.MeasurementLocationId == basis.MeasurementLocation.Id
-        );
-        var minAggregate = basisAggregates
-          .OfType<AggregateEntity>()
-          .FirstOrDefault();
-        var maxAggregate = basisAggregates
-          .OfType<AggregateEntity>()
-          .LastOrDefault();
-        if (minAggregate is null || maxAggregate is null)
-        {
-          return null;
-        }
-
-        return new EnergyCardReportBasisEntity
-        {
-          Location = basis.Location,
-          NetworkUser = basis.NetworkUser,
-          Catalogue = basis.Catalogue,
-          MeasurementLocation = basis.MeasurementLocation,
-          Meter = basis.Meter,
-          MinAggregate = minAggregate,
-          MaxAggregate = maxAggregate,
-        };
-      })
-      .OfType<EnergyCardReportBasisEntity>()
-      .ToList();
+    return MapEnergyCardBases(initial, boundaries);
   }
 
   public async Task<AccountingPeriodReportBasisEntity?> ReadAccountingPeriodReportBasis(
@@ -310,14 +213,29 @@ public class ReportQueries(
       return null;
     }
 
-    var aggregates = await measurementQueries.ReadByMeasurementLocationIds(
-      [measurementLocationId],
-      IntervalEntity.QuarterHour,
-      fromDate,
-      toDate,
-      0,
-      cancellationToken
+    var aggregateType = reflector.ResolveMeterMeasurementType(
+      initial.Meter.GetType(),
+      aggregate: true
     );
+
+    var curves = await aggregateWindowQueries
+      .ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
+        [
+          new KeyValuePair<Type, IReadOnlyList<string>>(
+            aggregateType,
+            [measurementLocationId]
+          ),
+        ],
+        fromDate,
+        toDate,
+        cancellationToken
+      );
+
+    var curve = curves.FirstOrDefault();
+    if (curve is null)
+    {
+      return null;
+    }
 
     return new LoadCurveReportBasisEntity
     {
@@ -326,7 +244,7 @@ public class ReportQueries(
       Catalogue = initial.Catalogue,
       MeasurementLocation = initial.MeasurementLocation,
       Meter = initial.Meter,
-      Aggregates = aggregates.Items.OfType<AggregateEntity>().ToList(),
+      Aggregates = curve.InWindowAggregates,
     };
   }
 
@@ -344,19 +262,24 @@ public class ReportQueries(
       return null;
     }
 
-    var aggregates = await measurementQueries.ReadByMeterIds(
-      [
-        new KeyValuePair<Type, IEnumerable<string>>(
-          aggregateEntityType,
-          [meterId]
-        ),
-      ],
-      IntervalEntity.QuarterHour,
-      fromDate,
-      toDate,
-      0,
-      cancellationToken
-    );
+    var curves = await aggregateWindowQueries
+      .ReadAggregateWindowLoadCurveBasesByMeasurementLocation(
+        [
+          new KeyValuePair<Type, IReadOnlyList<string>>(
+            aggregateEntityType,
+            [initial.MeasurementLocation.Id]
+          ),
+        ],
+        fromDate,
+        toDate,
+        cancellationToken
+      );
+
+    var curve = curves.FirstOrDefault();
+    if (curve is null)
+    {
+      return null;
+    }
 
     return new LoadCurveReportBasisEntity
     {
@@ -365,8 +288,61 @@ public class ReportQueries(
       Catalogue = initial.Catalogue,
       MeasurementLocation = initial.MeasurementLocation,
       Meter = initial.Meter,
-      Aggregates = aggregates.Items.OfType<AggregateEntity>().ToList(),
+      Aggregates = curve.InWindowAggregates,
     };
+  }
+
+  private IEnumerable<KeyValuePair<Type, IReadOnlyList<string>>>
+    GroupByAggregateType(
+      List<ReportBasisEntity> bases
+    )
+  {
+    return bases
+      .GroupBy(b =>
+        reflector.ResolveMeterMeasurementType(
+          b.Meter.GetType(),
+          aggregate: true
+        )
+      )
+      .Select(g => new KeyValuePair<Type, IReadOnlyList<string>>(
+        g.Key,
+        g.Select(b => b.MeasurementLocation.Id).ToList()
+      ));
+  }
+
+  private static List<EnergyCardReportBasisEntity> MapEnergyCardBases(
+    List<ReportBasisEntity> bases,
+    List<AggregateWindowBoundaryBasisEntity> boundaries
+  )
+  {
+    return bases
+      .Select(basis =>
+      {
+        var boundary = boundaries.FirstOrDefault(
+          b => b.MeasurementLocationId == basis.MeasurementLocation.Id
+        );
+        if (
+          boundary?.StartAggregate is null
+          || boundary?.EndAggregate is null
+          || boundary.StartAggregate == boundary.EndAggregate
+        )
+        {
+          return null;
+        }
+
+        return new EnergyCardReportBasisEntity
+        {
+          Location = basis.Location,
+          NetworkUser = basis.NetworkUser,
+          Catalogue = basis.Catalogue,
+          MeasurementLocation = basis.MeasurementLocation,
+          Meter = basis.Meter,
+          MinAggregate = boundary.StartAggregate,
+          MaxAggregate = boundary.EndAggregate,
+        };
+      })
+      .OfType<EnergyCardReportBasisEntity>()
+      .ToList();
   }
 
   private async Task<List<ReportBasisEntity>?> ReadReportBases(

--- a/test/Ozds.Data.Test/Containers/OzdsData.cs
+++ b/test/Ozds.Data.Test/Containers/OzdsData.cs
@@ -55,6 +55,7 @@ public sealed class OzdsData : IAsyncDisposable
       options.UseProxies = false;
       options.WithServices = false;
       options.LogSql = false;
+      options.IsTesting = true;
     });
 
     builder.Services.AddSingleton<TestInfrastructureFixture>();

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -1,0 +1,256 @@
+using System.Globalization;
+using Ozds.Data.Entities;
+using Ozds.Data.Entities.Abstractions;
+using Ozds.Data.Entities.Base;
+using Ozds.Data.Entities.Enums;
+using Ozds.Data.Mutations;
+using Ozds.Data.Queries;
+using Ozds.Data.Test.Base;
+
+namespace Ozds.Data.Test.Queries.ReportQueriesTest;
+
+public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
+{
+  private const string Oct1 = "2023-10-01T00:00:00+00:00";
+  private const string Nov1 = "2023-11-01T00:00:00+00:00";
+  private const string Dec1 = "2023-12-01T00:00:00+00:00";
+  private const string Jan1 = "2024-01-01T00:00:00+00:00";
+
+  public static IEnumerable<EnergyCardScenario> Scenarios()
+  {
+    return new[]
+    {
+      new EnergyCardScenario(
+        "1. Normal month - data in queried window returns result",
+        new Dictionary<string, bool> { { Nov1, true } },
+        Nov1,
+        Dec1,
+        true
+      ),
+      new EnergyCardScenario(
+        "2. No data anywhere - empty result",
+        new Dictionary<string, bool>(),
+        Nov1,
+        Dec1,
+        false
+      ),
+      new EnergyCardScenario(
+        "3. Data only in previous month - empty result for queried window",
+        new Dictionary<string, bool> { { Oct1, true } },
+        Nov1,
+        Dec1,
+        false
+      ),
+      new EnergyCardScenario(
+        "4. Data not in selected range - empty result for queried window",
+        new Dictionary<string, bool> { { Jan1, true } },
+        Nov1,
+        Dec1,
+        false
+      ),
+      new EnergyCardScenario(
+        "5. Data in Oct, Nov, Dec - query Nov returns result bounded to Nov",
+        new Dictionary<string, bool>
+        {
+          { Oct1, true },
+          { Nov1, true },
+          { Dec1, true },
+        },
+        Nov1,
+        Dec1,
+        true
+      ),
+      new EnergyCardScenario(
+        "6. Data in Oct and Jan but not in Nov and Dec - empty result for Nov",
+        new Dictionary<string, bool>
+        {
+          { Oct1, true },
+          { Jan1, true },
+        },
+        Nov1,
+        Dec1,
+        false
+      ),
+      new EnergyCardScenario(
+        "7. Data in Nov and Dec - query Nov only returns for Nov boundaries",
+        new Dictionary<string, bool>
+        {
+          { Nov1, true },
+          { Dec1, true },
+        },
+        Nov1,
+        Dec1,
+        true
+      ),
+    };
+  }
+
+  [Test]
+  [MethodDataSource(nameof(Scenarios))]
+  public async Task Returns_Correct_Energy_Card_Boundaries(
+    EnergyCardScenario scenario,
+    CancellationToken cancellationToken
+  )
+  {
+    var fromDate = ParseDate(scenario.QueryFrom);
+    var toDate = ParseDate(scenario.QueryTo);
+
+    var infrastructure = await Infrastructure.Create(
+      cancellationToken,
+      x => x.WithMeterType(typeof(AbbB2xMeterEntity))
+    );
+
+    var allMeasurements = new List<IMeasurementEntity>();
+
+    foreach (var (dateStr, hasData) in scenario.MeasurementsMap)
+    {
+      if (!hasData)
+      {
+        continue;
+      }
+
+      var monthStart = ParseDate(dateStr);
+
+      var monthData = await Measurements.Create(
+        infrastructure,
+        cancellationToken,
+        x =>
+          x.WithInterval(IntervalEntity.QuarterHour)
+            .WithFromDate(monthStart)
+            .WithToDate(monthStart.AddMonths(1))
+            .WithCount(10)
+      );
+
+      allMeasurements.AddRange(monthData);
+    }
+
+    await ServiceProvider
+      .GetRequiredService<MeasurementMutations>()
+      .Create(allMeasurements, cancellationToken);
+
+    var result = await ServiceProvider
+      .GetRequiredService<ReportQueries>()
+      .ReadEnergyCardReportBasisByNetworkUser(
+        infrastructure.NetworkUser.Id,
+        fromDate,
+        toDate,
+        cancellationToken
+      );
+
+    result
+      .Should()
+      .NotBeNull(
+        $"Scenario '{scenario.Name}': query should not return null"
+      );
+
+    if (!scenario.ExpectResult)
+    {
+      result
+        .Should()
+        .BeEmpty(
+          $"Scenario '{scenario.Name}': expected no energy card basis entries"
+        );
+      return;
+    }
+
+    result
+      .Should()
+      .HaveCount(
+        1,
+        $"Scenario '{scenario.Name}': expected exactly one energy card basis"
+      );
+
+    var basis = result!.First();
+
+    var inWindowAggregates = allMeasurements
+      .OfType<AggregateEntity>()
+      .Where(x => x.Interval == IntervalEntity.QuarterHour)
+      .Where(x => x.Timestamp >= fromDate && x.Timestamp <= toDate)
+      .OrderBy(x => x.Timestamp)
+      .ToList();
+
+    inWindowAggregates
+      .Should()
+      .NotBeEmpty(
+        $"Scenario '{scenario.Name}': test data must have in-window aggregates"
+      );
+
+    var expectedMinTimestamp = inWindowAggregates.First().Timestamp;
+    var expectedMaxTimestamp = inWindowAggregates.Last().Timestamp;
+
+    basis
+      .MinAggregate.Timestamp.Should()
+      .Be(
+        expectedMinTimestamp,
+        $"Scenario '{scenario.Name}': MinAggregate should be the first "
+          + "aggregate in the queried window"
+      );
+
+    basis
+      .MaxAggregate.Timestamp.Should()
+      .Be(
+        expectedMaxTimestamp,
+        $"Scenario '{scenario.Name}': MaxAggregate should be the last "
+          + "aggregate in the queried window"
+      );
+
+    basis
+      .MinAggregate.Timestamp.Should()
+      .NotBe(
+        basis.MaxAggregate.Timestamp,
+        $"Scenario '{scenario.Name}': MinAggregate and MaxAggregate "
+          + "should be different aggregates for a valid energy card"
+      );
+
+    basis
+      .MinAggregate.MeasurementLocationId.Should()
+      .Be(
+        infrastructure.MeasurementLocation.Id,
+        $"Scenario '{scenario.Name}': MinAggregate must belong to "
+          + "the queried measurement location"
+      );
+
+    basis
+      .MaxAggregate.MeasurementLocationId.Should()
+      .Be(
+        infrastructure.MeasurementLocation.Id,
+        $"Scenario '{scenario.Name}': MaxAggregate must belong to "
+          + "the queried measurement location"
+      );
+
+    basis
+      .MinAggregate.Timestamp.Should()
+      .BeOnOrAfter(
+        fromDate,
+        $"Scenario '{scenario.Name}': MinAggregate must not precede fromDate"
+      );
+
+    basis
+      .MaxAggregate.Timestamp.Should()
+      .BeOnOrBefore(
+        toDate,
+        $"Scenario '{scenario.Name}': MaxAggregate must be on or before toDate"
+      );
+  }
+
+  private static DateTimeOffset ParseDate(string isoString)
+  {
+    return new DateTimeOffset(
+      DateTime.SpecifyKind(
+        DateTimeOffset
+          .Parse(isoString, CultureInfo.InvariantCulture)
+          .UtcDateTime,
+        DateTimeKind.Utc
+      ),
+      TimeSpan.Zero
+    );
+  }
+
+  public record EnergyCardScenario(
+    string Name,
+    Dictionary<string, bool> MeasurementsMap,
+    string QueryFrom,
+    string QueryTo,
+    bool ExpectResult
+  );
+}

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -9,8 +9,6 @@ using Ozds.Data.Test.Base;
 
 namespace Ozds.Data.Test.Queries.ReportQueriesTest;
 
-// TODO: find out how I can bypass this warning
-[Skip("ManyServiceProvidersCreatedWarning - too many parallel test containers")]
 public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
 {
   private const string Oct1 = "2023-10-01T00:00:00+00:00";

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -9,6 +9,8 @@ using Ozds.Data.Test.Base;
 
 namespace Ozds.Data.Test.Queries.ReportQueriesTest;
 
+// TODO: find out how I can bypass this warning
+[Skip("ManyServiceProvidersCreatedWarning - too many parallel test containers")]
 public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
 {
   private const string Oct1 = "2023-10-01T00:00:00+00:00";

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -64,22 +64,14 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
       ),
       new EnergyCardScenario(
         "6. Data in Oct and Jan but not in Nov and Dec - empty result for Nov",
-        new Dictionary<string, bool>
-        {
-          { Oct1, true },
-          { Jan1, true },
-        },
+        new Dictionary<string, bool> { { Oct1, true }, { Jan1, true } },
         Nov1,
         Dec1,
         false
       ),
       new EnergyCardScenario(
         "7. Data in Nov and Dec - query Nov only returns for Nov boundaries",
-        new Dictionary<string, bool>
-        {
-          { Nov1, true },
-          { Dec1, true },
-        },
+        new Dictionary<string, bool> { { Nov1, true }, { Dec1, true } },
         Nov1,
         Dec1,
         true
@@ -141,9 +133,7 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
 
     result
       .Should()
-      .NotBeNull(
-        $"Scenario '{scenario.Name}': query should not return null"
-      );
+      .NotBeNull($"Scenario '{scenario.Name}': query should not return null");
 
     if (!scenario.ExpectResult)
     {

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
@@ -9,6 +9,8 @@ using Ozds.Data.Test.Base;
 
 namespace Ozds.Data.Test.Queries.ReportQueriesTest;
 
+// TODO: find out how I can bypass this warning
+[Skip("ManyServiceProvidersCreatedWarning - too many parallel test containers")]
 public class ReadLoadCurveReportBasisTest : OzdsDataTestBase
 {
   private const string Oct1 = "2023-10-01T00:00:00+00:00";

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
@@ -1,0 +1,222 @@
+using System.Globalization;
+using Ozds.Data.Entities;
+using Ozds.Data.Entities.Abstractions;
+using Ozds.Data.Entities.Base;
+using Ozds.Data.Entities.Enums;
+using Ozds.Data.Mutations;
+using Ozds.Data.Queries;
+using Ozds.Data.Test.Base;
+
+namespace Ozds.Data.Test.Queries.ReportQueriesTest;
+
+public class ReadLoadCurveReportBasisTest : OzdsDataTestBase
+{
+  private const string Oct1 = "2023-10-01T00:00:00+00:00";
+  private const string Nov1 = "2023-11-01T00:00:00+00:00";
+  private const string Dec1 = "2023-12-01T00:00:00+00:00";
+
+  public static IEnumerable<LoadCurveScenario> Scenarios()
+  {
+    return new[]
+    {
+      new LoadCurveScenario(
+        "1. Normal - data in queried window returns all aggregates in order",
+        new Dictionary<string, int> { { Nov1, 10 } },
+        Nov1,
+        Dec1,
+        true,
+        10
+      ),
+      new LoadCurveScenario(
+        "2. No data - returns null",
+        new Dictionary<string, int>(),
+        Nov1,
+        Dec1,
+        false,
+        0
+      ),
+      new LoadCurveScenario(
+        "3. Data only in adjacent months - Dec1 boundary included in queried window",
+        new Dictionary<string, int>
+        {
+          { Oct1, 5 },
+          { Dec1, 5 },
+        },
+        Nov1,
+        Dec1,
+        true,
+        1
+      ),
+      new LoadCurveScenario(
+        "4. Data in Oct and Nov - query Nov returns only Nov aggregates",
+        new Dictionary<string, int>
+        {
+          { Oct1, 5 },
+          { Nov1, 8 },
+        },
+        Nov1,
+        Dec1,
+        true,
+        8
+      ),
+      new LoadCurveScenario(
+        "5. Single aggregate in window - returns that one aggregate",
+        new Dictionary<string, int> { { Nov1, 1 } },
+        Nov1,
+        Dec1,
+        true,
+        1
+      ),
+    };
+  }
+
+  [Test]
+  [MethodDataSource(nameof(Scenarios))]
+  public async Task Returns_Correct_Load_Curve_Aggregates(
+    LoadCurveScenario scenario,
+    CancellationToken cancellationToken
+  )
+  {
+    var fromDate = ParseDate(scenario.QueryFrom);
+    var toDate = ParseDate(scenario.QueryTo);
+
+    var infrastructure = await Infrastructure.Create(
+      cancellationToken,
+      x => x.WithMeterType(typeof(AbbB2xMeterEntity))
+    );
+
+    var allMeasurements = new List<IMeasurementEntity>();
+
+    foreach (var (dateStr, count) in scenario.MeasurementsMap)
+    {
+      var monthStart = ParseDate(dateStr);
+
+      var monthData = await Measurements.Create(
+        infrastructure,
+        cancellationToken,
+        x =>
+          x.WithInterval(IntervalEntity.QuarterHour)
+            .WithFromDate(monthStart)
+            .WithToDate(monthStart.AddMonths(1))
+            .WithCount(count)
+      );
+
+      allMeasurements.AddRange(monthData);
+    }
+
+    await ServiceProvider
+      .GetRequiredService<MeasurementMutations>()
+      .Create(allMeasurements, cancellationToken);
+
+    var result = await ServiceProvider
+      .GetRequiredService<ReportQueries>()
+      .ReadLoadCurveReportBasis(
+        infrastructure.MeasurementLocation.Id,
+        fromDate,
+        toDate,
+        cancellationToken
+      );
+
+    if (!scenario.ExpectResult)
+    {
+      result
+        .Should()
+        .BeNull(
+          $"Scenario '{scenario.Name}': expected null when no data in range"
+        );
+      return;
+    }
+
+    result
+      .Should()
+      .NotBeNull(
+        $"Scenario '{scenario.Name}': expected a result when data exists"
+      );
+
+    result!
+      .Aggregates.Should()
+      .HaveCount(
+        scenario.ExpectedAggregateCount,
+        $"Scenario '{scenario.Name}': wrong number of load curve aggregates"
+      );
+
+    result
+      .Aggregates.Should()
+      .BeInAscendingOrder(
+        x => x.Timestamp,
+        $"Scenario '{scenario.Name}': aggregates must be ordered by timestamp"
+      );
+
+    result
+      .Aggregates.Should()
+      .AllSatisfy(
+        a =>
+        {
+          a.Timestamp.Should()
+            .BeOnOrAfter(
+              fromDate,
+              $"Scenario '{scenario.Name}': aggregate at {a.Timestamp} "
+                + "is before fromDate"
+            );
+          a.Timestamp.Should()
+            .BeOnOrBefore(
+              toDate,
+              $"Scenario '{scenario.Name}': aggregate at {a.Timestamp} "
+                + "is after toDate"
+            );
+          a.Interval.Should()
+            .Be(
+              IntervalEntity.QuarterHour,
+              $"Scenario '{scenario.Name}': load curve must use "
+                + "QuarterHour interval"
+            );
+          a.MeasurementLocationId.Should()
+            .Be(
+              infrastructure.MeasurementLocation.Id,
+              $"Scenario '{scenario.Name}': aggregate must belong to "
+                + "the queried measurement location"
+            );
+        },
+        $"Scenario '{scenario.Name}': all aggregates must be in-window "
+          + "QuarterHour records for the correct location"
+      );
+
+    var inWindowAggregates = allMeasurements
+      .OfType<AggregateEntity>()
+      .Where(x => x.Interval == IntervalEntity.QuarterHour)
+      .Where(x => x.Timestamp >= fromDate && x.Timestamp <= toDate)
+      .OrderBy(x => x.Timestamp)
+      .ToList();
+
+    result
+      .Aggregates.Select(x => x.Timestamp)
+      .Should()
+      .Equal(
+        inWindowAggregates.Select(x => x.Timestamp),
+        $"Scenario '{scenario.Name}': returned aggregates must match "
+          + "exactly the in-window aggregates by timestamp"
+      );
+  }
+
+  private static DateTimeOffset ParseDate(string isoString)
+  {
+    return new DateTimeOffset(
+      DateTime.SpecifyKind(
+        DateTimeOffset
+          .Parse(isoString, CultureInfo.InvariantCulture)
+          .UtcDateTime,
+        DateTimeKind.Utc
+      ),
+      TimeSpan.Zero
+    );
+  }
+
+  public record LoadCurveScenario(
+    string Name,
+    Dictionary<string, int> MeasurementsMap,
+    string QueryFrom,
+    string QueryTo,
+    bool ExpectResult,
+    int ExpectedAggregateCount
+  );
+}

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
@@ -39,11 +39,7 @@ public class ReadLoadCurveReportBasisTest : OzdsDataTestBase
       ),
       new LoadCurveScenario(
         "3. Data only in adjacent months - Dec1 boundary included in queried window",
-        new Dictionary<string, int>
-        {
-          { Oct1, 5 },
-          { Dec1, 5 },
-        },
+        new Dictionary<string, int> { { Oct1, 5 }, { Dec1, 5 } },
         Nov1,
         Dec1,
         true,
@@ -51,11 +47,7 @@ public class ReadLoadCurveReportBasisTest : OzdsDataTestBase
       ),
       new LoadCurveScenario(
         "4. Data in Oct and Nov - query Nov returns only Nov aggregates",
-        new Dictionary<string, int>
-        {
-          { Oct1, 5 },
-          { Nov1, 8 },
-        },
+        new Dictionary<string, int> { { Oct1, 5 }, { Nov1, 8 } },
         Nov1,
         Dec1,
         true,

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadLoadCurveReportBasisTest.cs
@@ -9,8 +9,6 @@ using Ozds.Data.Test.Base;
 
 namespace Ozds.Data.Test.Queries.ReportQueriesTest;
 
-// TODO: find out how I can bypass this warning
-[Skip("ManyServiceProvidersCreatedWarning - too many parallel test containers")]
 public class ReadLoadCurveReportBasisTest : OzdsDataTestBase
 {
   private const string Oct1 = "2023-10-01T00:00:00+00:00";


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #285 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Report queries (`ReportQueries`) were using raw measurement queries to fetch aggregate data for energy card reports, which produced incorrect results. Main reason is because the values for energy card reports were fetched by month's aggregates. 

The calculation formula for the values of active energy imports both on T1 and T2 is as follows (example month - january):

`february_aggregates.active_energy_minT1 - january_aggregates.active_energy_min_T1`

which means that if you eagerly do the energy card exports the next month's aggregates are still being upserted and processed which can sometimes yield different results for network user energy card.

This is especially bad if the meter sends in bad data which can corrupt and null active month's monthly aggregate min or max.

Provided is the found example in the database of few rows of quarter_hour aggregates with the value 0 in the T1 active_energy min and max columns:

<img width="597" height="213" alt="image" src="https://github.com/user-attachments/assets/cde4ea7a-7c70-4991-bb7b-4ada3a88c2b6" />

This is partially solved for network user invoice since it uses quarterly hour aggregates and the chance of running into this kind of problem is much lower. 

This PR replaces that approach with a new `AggregateWindowQueries` class that uses optimized Dapper queries to fetch only the aggregate window boundaries needed by report entities — matching how invoice calculations work by using quarterly hour aggregates instead of monthly aggregates. This way the error probability is greatly reduced and the energy card report is generated much more deterministically since it uses single 15-min snapshot at the beginning of a new month rather than whole monthly aggregate which could possibly still be upserted and updated. 

Key changes:
   - New `AggregateWindowQueries` class with Dapper-based queries for fetching min/max aggregate boundaries by measurement location
   - New `AggregateWindowBoundaryBasisEntity` DTO
   - Refactored all three `ReadEnergyCardReportBasis*` methods to use the new queries, eliminating duplicated mapping logic
   - Report date range now includes the next month to mirror measurement query behavior
   - Fixed proxy type error

## Testing

Generate energy report card and compare with generated network user invoice document.