### PR TITLE
295 Read report bases by location optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Optimized `ReadReportBasesByLocation` EF query in `ReportQueries` to fetch
+  network users directly by location foreign key
 - Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
   points from root of url to the swagger API
 - update mailkit

--- a/src/Ozds.Data/Queries/ReportQueries.cs
+++ b/src/Ozds.Data/Queries/ReportQueries.cs
@@ -415,46 +415,34 @@ public class ReportQueries(
       cancellationToken
     );
 
-    // TODO: optimize
+    // TODO: optimize - ??
 
-    var networkUserMeasurementLocations = (
-      await context
-        .Locations.Where(context.PrimaryKeyEquals<LocationEntity>(locationId))
-        .Include(x => x.NetworkUsers)
-          .ThenInclude(x => x.NetworkUserMeasurementLocations)
-        .AsSplitQuery()
-        .ToListAsync(cancellationToken)
-    ).SelectMany(x =>
-      x.NetworkUsers.SelectMany(x => x.NetworkUserMeasurementLocations)
-    );
+    // NOTE: for now viable without split queries
+    var networkUsers =
+        await context.NetworkUsers.Where(
+          context.ForeignKeyEquals<NetworkUserEntity>(
+          nameof(NetworkUserEntity.Location),
+          locationId
+        ))
+        .Include(x => x.Location)
+        .Include(x => x.NetworkUserMeasurementLocations)
+          .ThenInclude(x => x.NetworkUserCatalogue)
+        .Include(x => x.NetworkUserMeasurementLocations)
+            .ThenInclude(x => x.Meter)
+        .ToListAsync(cancellationToken);
 
-    var entities = await context
-      .MeasurementLocations.OfType<NetworkUserMeasurementLocationEntity>()
-      .Where(
-        context.PrimaryKeyIn<NetworkUserMeasurementLocationEntity>(
-          networkUserMeasurementLocations.Select(x => x.Id)
+    return networkUsers.SelectMany(
+      nu => nu.NetworkUserMeasurementLocations.Select(
+        ml => new ReportBasisEntity
+          {
+            Location = nu.Location,
+            NetworkUser = nu,
+            Catalogue = ml.NetworkUserCatalogue,
+            MeasurementLocation = ml,
+            Meter = ml.Meter,
+          }
         )
-      )
-      .Include(x => x.Meter)
-      .Include(x => x.NetworkUserCatalogue)
-      .Include(x => x.NetworkUser)
-        .ThenInclude(x => x.Location)
-      .ToListAsync(cancellationToken);
-    if (entities is null)
-    {
-      return null;
-    }
-
-    return entities
-      .Select(entity => new ReportBasisEntity
-      {
-        Location = entity.NetworkUser.Location,
-        NetworkUser = entity.NetworkUser,
-        Catalogue = entity.NetworkUserCatalogue,
-        MeasurementLocation = entity,
-        Meter = entity.Meter,
-      })
-      .ToList();
+    ).ToList();
   }
 
   private async Task<List<ReportBasisEntity>?> ReadReportBasesByNetworkUser(

--- a/src/Ozds.Data/Queries/ReportQueries.cs
+++ b/src/Ozds.Data/Queries/ReportQueries.cs
@@ -418,31 +418,32 @@ public class ReportQueries(
     // TODO: optimize - ??
 
     // NOTE: for now viable without split queries
-    var networkUsers =
-        await context.NetworkUsers.Where(
-          context.ForeignKeyEquals<NetworkUserEntity>(
+    var networkUsers = await context
+      .NetworkUsers.Where(
+        context.ForeignKeyEquals<NetworkUserEntity>(
           nameof(NetworkUserEntity.Location),
           locationId
-        ))
-        .Include(x => x.Location)
-        .Include(x => x.NetworkUserMeasurementLocations)
-          .ThenInclude(x => x.NetworkUserCatalogue)
-        .Include(x => x.NetworkUserMeasurementLocations)
-            .ThenInclude(x => x.Meter)
-        .ToListAsync(cancellationToken);
-
-    return networkUsers.SelectMany(
-      nu => nu.NetworkUserMeasurementLocations.Select(
-        ml => new ReportBasisEntity
-          {
-            Location = nu.Location,
-            NetworkUser = nu,
-            Catalogue = ml.NetworkUserCatalogue,
-            MeasurementLocation = ml,
-            Meter = ml.Meter,
-          }
         )
-    ).ToList();
+      )
+      .Include(x => x.Location)
+      .Include(x => x.NetworkUserMeasurementLocations)
+        .ThenInclude(x => x.NetworkUserCatalogue)
+      .Include(x => x.NetworkUserMeasurementLocations)
+        .ThenInclude(x => x.Meter)
+      .ToListAsync(cancellationToken);
+
+    return networkUsers
+      .SelectMany(nu =>
+        nu.NetworkUserMeasurementLocations.Select(ml => new ReportBasisEntity
+        {
+          Location = nu.Location,
+          NetworkUser = nu,
+          Catalogue = ml.NetworkUserCatalogue,
+          MeasurementLocation = ml,
+          Meter = ml.Meter,
+        })
+      )
+      .ToList();
   }
 
   private async Task<List<ReportBasisEntity>?> ReadReportBasesByNetworkUser(


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #295 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Optimized `ReadReportBasesByLocation` in `ReportQueries` to query network users directly by location foreign key.

Now the complete query looks like this:

```cs
var networkUsers =
    await context.NetworkUsers.Where(
      context.ForeignKeyEquals<NetworkUserEntity>(
      nameof(NetworkUserEntity.Location),
      locationId
    ))
    .Include(x => x.Location)
    .Include(x => x.NetworkUserMeasurementLocations)
      .ThenInclude(x => x.NetworkUserCatalogue)
    .Include(x => x.NetworkUserMeasurementLocations)
        .ThenInclude(x => x.Meter)
    .ToListAsync(cancellationToken);
```

## Testing

I've checked it internally using vs debugger by invoking the method and looking at the results from the previous two queries combined and current query. 