### PR TITLE
298 measurement chart gaps problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
   AggregateWindowQueries, eliminating duplicated mapping logic across
   ReadEnergyCardReportBasis, ReadEnergyCardReportBasisByNetworkUser, and
   ReadEnergyCardReportBasisByLocation
+- In `MeasurementChartControls.cs` changed `Fetch` method to use new overloads
+  which do not cut measurements with pagination
 
 ### Added
 
@@ -55,6 +57,9 @@ and adheres to [Semantic Versioning](https://semver.org/).
   AggregateWindowBoundaryBasisEntity DTO for aggregate window query results
 - Tests for ReadEnergyCardReportBasisByNetworkUser and ReadLoadCurveReportBasis
   aggregate window queries
+- Add new unpaginated query methods in `MeasurementQueries` which are overloads
+  of methods `ReadByMeterIds` and `ReadByMeasurementLocationIds`, they do not
+  paginate and return back normal List
 
 ## [1.8.1] - 2025-02-26
 

--- a/src/Ozds.Business/Queries/MeasurementQueries.cs
+++ b/src/Ozds.Business/Queries/MeasurementQueries.cs
@@ -17,16 +17,14 @@ public class MeasurementQueries(
   TimeQueries time
 ) : IQueries
 {
-  public async Task<PaginatedList<IMeasurement>> ReadByMeterIds(
+  public async Task<List<IMeasurement>> ReadByMeterIds(
     IEnumerable<string> meterIds,
     ResolutionModel resolution,
     int multiplier,
-    int pageNumber,
     CancellationToken cancellationToken,
     IntervalModel? interval = default,
     DateTimeOffset fromDate = default,
-    DateTimeOffset toDate = default,
-    int pageCount = QueryConstants.DefaultMeasurementPageCount
+    DateTimeOffset toDate = default
   )
   {
     var now = clock.Timestamp();
@@ -39,11 +37,9 @@ public class MeasurementQueries(
     return await ReadByMeterIds(
       meterIds,
       appropriateIntervalModel,
-      fromDate,
-      toDate,
-      pageNumber,
       cancellationToken,
-      pageCount
+      fromDate,
+      toDate
     );
   }
 
@@ -161,15 +157,13 @@ public class MeasurementQueries(
     return last;
   }
 
-  public async Task<PaginatedList<IMeasurement>> ReadByMeasurementLocationIds(
+  public async Task<List<IMeasurement>> ReadByMeasurementLocationIds(
     IEnumerable<string> measurementLocationIds,
     ResolutionModel resolution,
     int multiplier,
-    int pageNumber,
     CancellationToken cancellationToken,
     DateTimeOffset fromDate = default,
-    DateTimeOffset toDate = default,
-    int pageCount = QueryConstants.DefaultMeasurementPageCount
+    DateTimeOffset toDate = default
   )
   {
     var now = clock.Timestamp();
@@ -182,11 +176,9 @@ public class MeasurementQueries(
     return await ReadByMeasurementLocationIds(
       measurementLocationIds,
       appropriateIntervalModel,
-      fromDate,
-      toDate,
-      pageNumber,
       cancellationToken,
-      pageCount
+      fromDate,
+      toDate
     );
   }
 
@@ -271,5 +263,98 @@ public class MeasurementQueries(
       .ToList();
 
     return last;
+  }
+
+  public async Task<List<IMeasurement>> ReadByMeterIds(
+    IEnumerable<string> meterIds,
+    IntervalModel? appropriateIntervalModel,
+    CancellationToken cancellationToken,
+    DateTimeOffset fromDate = default,
+    DateTimeOffset toDate = default
+  )
+  {
+    var appropriateInterval = appropriateIntervalModel?.ToDataEntity();
+    var isAggregate = appropriateInterval is not null;
+
+    var modelIdsByEntityType = meterIds
+      .GroupBy(id =>
+        isAggregate
+          ? modelEntityConverter.EntityType(
+            meterNamingConvention.AggregateTypeForMeterId(id)
+          )
+          : modelEntityConverter.EntityType(
+            meterNamingConvention.MeasurementTypeForMeterId(id)
+          )
+      )
+      .Select(group => new KeyValuePair<Type, IEnumerable<string>>(
+        group.Key,
+        group
+      ))
+      .ToList();
+
+    var entities = await queries.ReadByMeterIds(
+      modelIdsByEntityType,
+      appropriateInterval,
+      fromDate,
+      toDate,
+      cancellationToken
+    );
+
+    var buffered = measurementBuffer
+      .Peek()
+      .Where(x =>
+        (
+          appropriateIntervalModel is not null
+            ? x is IAggregate aggregate
+              && aggregate.Interval == appropriateIntervalModel
+            : x is not IAggregate
+        )
+        && meterIds.Any(y => y == x.MeterId)
+        && x.Timestamp >= fromDate
+        && x.Timestamp < toDate
+      )
+      .ToList();
+
+    return entities
+      .Select(modelEntityConverter.ToModel<IMeasurement>)
+      .Concat(buffered)
+      .ToList();
+  }
+
+  public async Task<List<IMeasurement>> ReadByMeasurementLocationIds(
+    IEnumerable<string> measurementLocationIds,
+    IntervalModel? appropriateIntervalModel,
+    CancellationToken cancellationToken,
+    DateTimeOffset fromDate = default,
+    DateTimeOffset toDate = default
+  )
+  {
+    var entities = await queries.ReadByMeasurementLocationIds(
+      measurementLocationIds,
+      appropriateIntervalModel?.ToDataEntity(),
+      fromDate,
+      toDate,
+      cancellationToken
+    );
+
+    var buffered = measurementBuffer
+      .Peek()
+      .Where(x =>
+        (
+          appropriateIntervalModel is not null
+            ? x is IAggregate aggregate
+              && aggregate.Interval == appropriateIntervalModel
+            : x is not IAggregate
+        )
+        && measurementLocationIds.Any(y => y == x.MeasurementLocationId)
+        && x.Timestamp >= fromDate
+        && x.Timestamp < toDate
+      )
+      .ToList();
+
+    return entities
+      .Select(modelEntityConverter.ToModel<IMeasurement>)
+      .Concat(buffered)
+      .ToList();
   }
 }

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -289,7 +289,6 @@ public partial class MeasurementChartControls : OzdsComponentBase
       _parameters.Meters.Select(x => x.Id).ToList(),
       _parameters.Resolution,
       _parameters.Multiplier,
-      0,
       CancellationToken,
       fromDate: fromDate,
       toDate: toDate
@@ -298,20 +297,19 @@ public partial class MeasurementChartControls : OzdsComponentBase
       _parameters.MeasurementLocations.Select(x => x.Id).ToList(),
       _parameters.Resolution,
       _parameters.Multiplier,
-      0,
       CancellationToken,
       fromDate,
       toDate
     );
     _parameters.Measurements = new PaginatedList<IMeasurement>(
       fromMeters
-        .Items.Concat(fromMeasurementLocations.Items)
+        .Concat(fromMeasurementLocations)
         .DistinctBy(x =>
           (x.MeterId, x.MeasurementLocationId, x.Timestamp, x.GetType())
         )
         .OrderBy(x => x.Timestamp)
         .ToList(),
-      fromMeters.TotalCount + fromMeasurementLocations.TotalCount
+      fromMeters.Count + fromMeasurementLocations.Count
     );
   }
 

--- a/src/Ozds.Data/Queries/MeasurementQueries.cs
+++ b/src/Ozds.Data/Queries/MeasurementQueries.cs
@@ -400,4 +400,170 @@ public class MeasurementQueries(
 
     return items;
   }
+
+  public async Task<List<IMeasurementEntity>> ReadByMeterIds(
+    IEnumerable<KeyValuePair<Type, IEnumerable<string>>> meterIdsByEntityType,
+    IntervalEntity? interval,
+    DateTimeOffset fromDate,
+    DateTimeOffset toDate,
+    CancellationToken cancellationToken
+  )
+  {
+    await using var context = await factory.CreateDbContextAsync(
+      cancellationToken
+    );
+
+    List<IMeasurementEntity> items = new();
+    var futureItems = new List<QueryFutureEnumerable<IMeasurementEntity>>();
+
+    foreach (var group in meterIdsByEntityType)
+    {
+      var entityType = group.Key;
+      var meterIds = group.Value;
+      var queryable = context.GetQueryable<IMeasurementEntity>(entityType);
+
+      var filtered = queryable
+        .Where(measurement => measurement.Timestamp >= fromDate)
+        .Where(measurement => measurement.Timestamp <= toDate);
+
+      if (entityType.IsAssignableTo(typeof(IAggregateEntity)))
+      {
+        var intervalParameter = Expression.Parameter(
+          typeof(IMeasurementEntity),
+          "entity"
+        );
+        var intervalExpression = Expression.Lambda<
+          Func<IMeasurementEntity, bool>
+        >(
+          Expression.Equal(
+            Expression.Property(
+              Expression.Convert(intervalParameter, typeof(IAggregateEntity)),
+              nameof(AggregateEntity<MeterEntity>.Interval)
+            ),
+            Expression.Constant(
+              interval
+                ?? throw new InvalidOperationException("Interval is null"),
+              typeof(IntervalEntity)
+            )
+          ),
+          intervalParameter
+        );
+
+        filtered = filtered.Where(intervalExpression);
+      }
+
+      var foreignKeyParameter = Expression.Parameter(
+        typeof(IMeasurementEntity),
+        "entity"
+      );
+      var foreignKeyExpression = Expression.Lambda<
+        Func<IMeasurementEntity, bool>
+      >(
+        Expression.Invoke(
+          context.ForeignKeyIn(
+            entityType,
+            nameof(MeasurementEntity<MeterEntity>.Meter),
+            meterIds
+          ),
+          Expression.Convert(foreignKeyParameter, typeof(object))
+        ),
+        foreignKeyParameter
+      );
+      filtered = filtered.Where(foreignKeyExpression);
+
+      var ordered = filtered.OrderBy(measurement => measurement.Timestamp);
+      futureItems.Add(ordered.Future());
+    }
+
+    foreach (var futureItem in futureItems)
+    {
+      items.AddRange(await futureItem.ToListAsync(cancellationToken));
+    }
+
+    return items;
+  }
+
+  public async Task<List<IMeasurementEntity>> ReadByMeasurementLocationIds(
+    IEnumerable<string> measurementLocationIds,
+    IntervalEntity? interval,
+    DateTimeOffset fromDate,
+    DateTimeOffset toDate,
+    CancellationToken cancellationToken
+  )
+  {
+    await using var context = await factory.CreateDbContextAsync(
+      cancellationToken
+    );
+
+    List<IMeasurementEntity> items = new();
+    var futureItems = new List<QueryFutureEnumerable<IMeasurementEntity>>();
+
+    var types = interval is not null
+      ? reflector.AggregateTypes
+      : reflector.MeasurementTypes;
+
+    foreach (var entityType in types)
+    {
+      var queryable = context.GetQueryable<IMeasurementEntity>(entityType);
+
+      var filtered = queryable
+        .Where(measurement => measurement.Timestamp >= fromDate)
+        .Where(measurement => measurement.Timestamp <= toDate);
+
+      if (entityType.IsAssignableTo(typeof(IAggregateEntity)))
+      {
+        var intervalParameter = Expression.Parameter(
+          typeof(IMeasurementEntity),
+          "entity"
+        );
+        var intervalExpression = Expression.Lambda<
+          Func<IMeasurementEntity, bool>
+        >(
+          Expression.Equal(
+            Expression.Property(
+              Expression.Convert(intervalParameter, typeof(IAggregateEntity)),
+              nameof(AggregateEntity<MeterEntity>.Interval)
+            ),
+            Expression.Constant(
+              interval
+                ?? throw new InvalidOperationException("Interval is null"),
+              typeof(IntervalEntity)
+            )
+          ),
+          intervalParameter
+        );
+
+        filtered = filtered.Where(intervalExpression);
+      }
+
+      var foreignKeyParameter = Expression.Parameter(
+        typeof(IMeasurementEntity),
+        "entity"
+      );
+      var foreignKeyExpression = Expression.Lambda<
+        Func<IMeasurementEntity, bool>
+      >(
+        Expression.Invoke(
+          context.ForeignKeyIn(
+            entityType,
+            nameof(MeasurementEntity<MeterEntity>.MeasurementLocation),
+            measurementLocationIds
+          ),
+          Expression.Convert(foreignKeyParameter, typeof(object))
+        ),
+        foreignKeyParameter
+      );
+      filtered = filtered.Where(foreignKeyExpression);
+
+      var ordered = filtered.OrderBy(measurement => measurement.Timestamp);
+      futureItems.Add(ordered.Future());
+    }
+
+    foreach (var futureItem in futureItems)
+    {
+      items.AddRange(await futureItem.ToListAsync(cancellationToken));
+    }
+
+    return items;
+  }
 }


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #298 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Full root cause explanation on issue no. #298.

- In `MeasurementChartControls.cs` changed `Fetch` method to use new overloads
  which do not cut measurements with pagination

- Add new unpaginated query methods in `MeasurementQueries` which are overloads
  of methods `ReadByMeterIds` and `ReadByMeasurementLocationIds`, they do not
  paginate and return back normal List

## Testing

`just fake insert` with `--interval` set to pas hour and set the resolution to 60 minutes on measurement chart, after that start adding multiple measurement locations which roughly could match >5000 measurements that should create a gap on dev branch but should do nothing on this branch. 

