### PR TITLE
254 text for meter validator should be named instead of identifier number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
   AggregateWindowQueries, eliminating duplicated mapping logic across
   ReadEnergyCardReportBasis, ReadEnergyCardReportBasisByNetworkUser, and
   ReadEnergyCardReportBasisByLocation
+- Changed Meter details to show the measurement validator by its title/name
+  instead of its identifier number
 
 ### Added
 
@@ -55,6 +57,9 @@ and adheres to [Semantic Versioning](https://semver.org/).
   AggregateWindowBoundaryBasisEntity DTO for aggregate window query results
 - Tests for ReadEnergyCardReportBasisByNetworkUser and ReadLoadCurveReportBasis
   aggregate window queries
+- Add `TitleLinkField` method component that displays a model's title instead of
+  its raw identifier, with a loading fallback that shows the ID while the title
+  loads
 
 ## [1.8.1] - 2025-02-26
 

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17131,17 +17131,18 @@
         From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 25 column 12
         From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 26 column 12
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 121 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 147 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 182 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 238 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 263 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 289 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 310 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 331 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 350 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 376 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 168 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 183 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 239 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 264 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 290 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 311 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 332 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 351 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 375 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 413 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 169 column 36
       </Metadata>
       <Value>
         None

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17131,17 +17131,18 @@
         From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 25 column 12
         From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 26 column 12
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 121 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 147 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 182 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 238 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 263 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 289 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 310 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 331 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 350 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 376 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 168 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 183 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 239 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 264 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 290 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 311 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 332 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 351 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 375 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 413 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 169 column 36
       </Metadata>
       <Value>
         Nema

--- a/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
@@ -7,6 +7,7 @@
 @using MudBlazor
 @using Ozds.Business.Models.Abstractions
 @using Ozds.Client.Components.Fields
+@using Ozds.Client.Components.Streaming
 @inherits OzdsManagedModelComponentBase<TModel>
 
 @Base()
@@ -356,6 +357,34 @@
                </MudLink>
              }
            </DetailsField>;
+  }
+
+  protected RenderFragment TitleLinkField<T>(
+    Expression<Func<TModel, string?>> next
+  )
+    where T : IIdentifiable
+  {
+      var nextFunc = next.Compile();
+      var id = nextFunc(Model);
+      var href = id is null
+        ? null
+        : PageHref(Provider.GetPageComponentType(typeof(T)), new { id });
+      return @<DetailsField Title="@(Translate(Label(next)))">
+          @if (id is null || href is null)
+          {
+              @Translate("None")
+          }
+          else
+          {
+            <Loading T="T" Id="@id">
+              <Found Context="model">
+                <MudLink Href="@href">
+                  @model.Title
+                </MudLink>
+              </Found>
+            </Loading>
+          }
+      </DetailsField>;
   }
 
   protected RenderFragment PolymorphicLinkField(

--- a/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
@@ -377,11 +377,19 @@
           else
           {
             <Loading T="T" Id="@id">
+
               <Found Context="model">
                 <MudLink Href="@href">
                   @model.Title
                 </MudLink>
               </Found>
+
+              <Progress>
+                <MudLink Href="@href">
+                  @id
+                </MudLink>
+              </Progress>
+
             </Loading>
           }
       </DetailsField>;

--- a/src/Ozds.Client/Components/Models/Implementations/Measurements/Meters/MeterDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Measurements/Meters/MeterDetails.razor
@@ -8,7 +8,7 @@
 
 @(LinkField<IMessenger>(x => x.MessengerId))
 
-@(LinkField<IMeasurementValidator>(x => x.MeasurementValidatorId))
+@(TitleLinkField<IMeasurementValidator>(x => x.MeasurementValidatorId))
 
 @Field(x => x.ConnectionPower_W)
 


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

- Added `TitleLinkField` method that returns Blazor component which displays a model's title instead of
  its raw identifier, with a loading fallback that shows the ID while the title of `IIdentifiable` entity loads
- Changed Meter details to show the measurement validator by its title/name
  instead of its identifier number

## Testing

Open any meter details page, on the place of  attribute `Measurement validator` there should now be an async-streaming component which loads in title for the measurement validator of selected meter.

