### PR TITLE
Validator for enumerable skips first item validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
   AggregateWindowQueries, eliminating duplicated mapping logic across
   ReadEnergyCardReportBasis, ReadEnergyCardReportBasisByNetworkUser, and
   ReadEnergyCardReportBasisByLocation
+- Fix `ModelIValidator` method `Validate` for `IEnumerable` pass skips first
+  element for validation
+- Fix `ModelIValidator` omits default model check with `Validate` method and
+  `ValidationContext`
 
 ### Added
 

--- a/src/Ozds.Business/Validation/ModelValidator.cs
+++ b/src/Ozds.Business/Validation/ModelValidator.cs
@@ -47,7 +47,11 @@ public class ModelValidator(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var validator = GetValidator(current.GetType());
 
-    var validationContext = new ValidationContext(current, serviceProvider, null);
+    var validationContext = new ValidationContext(
+      current,
+      serviceProvider,
+      null
+    );
     validationResults.AddRange(current.Validate(validationContext));
 
     if (validator is not null)

--- a/src/Ozds.Business/Validation/ModelValidator.cs
+++ b/src/Ozds.Business/Validation/ModelValidator.cs
@@ -47,6 +47,16 @@ public class ModelValidator(IServiceProvider serviceProvider)
     var current = enumerator.Current;
     var validator = GetValidator(current.GetType());
 
+    var validationContext = new ValidationContext(current, serviceProvider, null);
+    validationResults.AddRange(current.Validate(validationContext));
+
+    if (validator is not null)
+    {
+      validationResults.AddRange(
+        await validator.ValidateAsync(current, cancellationToken)
+      );
+    }
+
     while (enumerator.MoveNext())
     {
       var next = enumerator.Current;
@@ -55,6 +65,9 @@ public class ModelValidator(IServiceProvider serviceProvider)
         validator = GetValidator(next.GetType());
         current = next;
       }
+
+      validationContext = new ValidationContext(next, serviceProvider, null);
+      validationResults.AddRange(next.Validate(validationContext));
 
       if (validator is not null)
       {


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

- Fix `ModelIValidator` method `Validate` for `IEnumerable` pass skips first
  element for validation
- Fix `ModelIValidator` omits default model check with `Validate` method and
  `ValidationContext`

## Testing

The `Ozds.Business` class omits raw validation testing, but this problem is small in nature, so a new backlog issue should be created to verify by feeding test sentinels trough validators with various edge cases.