### PR TITLE
1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## [1.8.2] - 2026-04-03
+
 ### Changed
 
 - Optimized `ReadReportBasesByLocation` EF query in `ReportQueries` to fetch
@@ -70,7 +72,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
   its raw identifier, with a loading fallback that shows the ID while the title
   loads
 
-## [1.8.1] - 2025-02-26
+## [1.8.1] - 2026-02-26
 
 ### Removed
 
@@ -699,6 +701,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - init
 
+[1.8.2]: https://github.com/altibiz/ozds/compare/1.8.1...1.8.2
 [1.8.1]: https://github.com/altibiz/ozds/compare/1.8.0...1.8.1
 [1.8.0]: https://github.com/altibiz/ozds/compare/1.7.1...1.8.0
 [1.7.1]: https://github.com/altibiz/ozds/compare/1.7.0...1.7.1


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- Optimized `ReadReportBasesByLocation` EF query in `ReportQueries` to fetch
  network users directly by location foreign key
- Fix, `ApiV1Href` property on `OzdsComponentBase` is now just a string that
  points from root of url to the swagger API
- update mailkit
- updated sonar analyzer package
- updated azure identity package
- suppressed specific warnings because either they are new or .razor warning
  package suppression does not work
- added new script `./scripts/database/migrate-generated.nu` for creating
  migration specific to generated SQL code (for procedures and non EF stuff)
- Fix, `rollback.nu` missing db context fix
- `rollback.nu` script uses new where instead of deprecated filter
- Fix, missing mapping field in `EnergyCardModelReportEntityConverter` for field
  `ActiveEnergyTotalImportT0_kWh`
- Ozds.Caching.Test tests now have Repeat attribute which is used to catch more
  flaky non deterministic failures
- Removed polling program parts since Ozds.Caching.Test should now be
  deterministic
- Fix network energy card CSV/report queries to use proper aggregate window
  boundaries instead of raw measurement queries, matching invoice calculation
  behavior
- Refactored ReportQueries to delegate aggregate fetching to
  AggregateWindowQueries, eliminating duplicated mapping logic across
  ReadEnergyCardReportBasis, ReadEnergyCardReportBasisByNetworkUser, and
  ReadEnergyCardReportBasisByLocation
- In `MeasurementChartControls.cs` changed `Fetch` method to use new overloads
  which do not cut measurements with pagination
- Changed Meter details to show the measurement validator by its title/name
  instead of its identifier number
- Fix `ModelIValidator` method `Validate` for `IEnumerable` pass skips first
  element for validation
- Fix `ModelIValidator` omits default model check with `Validate` method and
  `ValidationContext`

### Added

- Added small button onto `MappedTable` which toggles case sensitive search (on
  by default)
- In `Table.cs` added private property and logic to define case sensitivity on
  table search
- add `ShortenedEnergyCardReportEntity` in Ozds.Report and
  `ShortenedEnergyCardReportModel` in Ozds.Entity
- energy report generator now uses shortened models for generating energy card
  reports
- add another button `Shortened energy card report (CSV)` with specific use for
  generating requested shortened version
- New AggregateWindowQueries class with optimized Dapper queries for fetching
  aggregate window boundaries by measurement location - New
  AggregateWindowBoundaryBasisEntity DTO for aggregate window query results
- Tests for ReadEnergyCardReportBasisByNetworkUser and ReadLoadCurveReportBasis
  aggregate window queries
- Add new unpaginated query methods in `MeasurementQueries` which are overloads
  of methods `ReadByMeterIds` and `ReadByMeasurementLocationIds`, they do not
  paginate and return back normal List
- Add `TitleLinkField` method component that displays a model's title instead of
  its raw identifier, with a loading fallback that shows the ID while the title
  loads
