### PR TITLE
304 Measurement chart gaps created by OnParametersSetAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Fix, centralized `fromDate` recalculation into `Fetch` method with a
+  `forcedRefresh` parameter, removing duplicated date calculation logic from
+  `OnMeasurementLocationsChanged`,
+  `OnMetersChanged`,`OnRefreshChanged`,`OnResolutionChanged`, and
+  `OnMultiplierChanged`
+
+### Added
+
 ## [1.8.2] - 2026-04-03
 
 ### Changed

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -162,16 +162,7 @@ public partial class MeasurementChartControls : OzdsComponentBase
         measurementLocationIds.Contains(measurementLocation.Id)
       )
       .ToHashSet();
-    var now = ClockQueries.Now();
-    var fromDate = now.Subtract(
-      TimeQueries.ResolutionTimeSpan(
-        _parameters.Resolution,
-        now,
-        _parameters.Multiplier
-      )
-    );
-    _parameters.FromDate = fromDate;
-    await Fetch();
+    await Fetch(forcedRefresh: true);
   }
 
   private async Task OnMetersChanged(IEnumerable<string> meterIds)
@@ -179,15 +170,7 @@ public partial class MeasurementChartControls : OzdsComponentBase
     _parameters.Meters = Meters
       .Where(meter => meterIds.Contains(meter.Id))
       .ToHashSet();
-    var now = ClockQueries.Now();
-    _parameters.FromDate = now.Subtract(
-      TimeQueries.ResolutionTimeSpan(
-        _parameters.Resolution,
-        now,
-        _parameters.Multiplier
-      )
-    );
-    await Fetch();
+    await Fetch(forcedRefresh: true);
   }
 
   private async Task OnRefreshChanged(bool refresh)
@@ -195,15 +178,6 @@ public partial class MeasurementChartControls : OzdsComponentBase
     _parameters.Refresh = refresh;
     if (_parameters.Refresh)
     {
-      var now = ClockQueries.Now();
-      var fromDate = now.Subtract(
-        TimeQueries.ResolutionTimeSpan(
-          _parameters.Resolution,
-          now,
-          _parameters.Multiplier
-        )
-      );
-      _parameters.FromDate = fromDate;
       await Fetch();
     }
   }
@@ -211,38 +185,12 @@ public partial class MeasurementChartControls : OzdsComponentBase
   private async Task OnResolutionChanged(ResolutionModel resolution)
   {
     _parameters.Resolution = resolution;
-    if (_parameters.Refresh)
-    {
-      var now = ClockQueries.Now();
-      var fromDate = now.Subtract(
-        TimeQueries.ResolutionTimeSpan(
-          _parameters.Resolution,
-          now,
-          _parameters.Multiplier
-        )
-      );
-      _parameters.FromDate = fromDate;
-    }
-
     await Fetch();
   }
 
   private async Task OnMultiplierChanged(int multiplier)
   {
     _parameters.Multiplier = multiplier;
-    if (_parameters.Refresh)
-    {
-      var now = ClockQueries.Now();
-      var fromDate = now.Subtract(
-        TimeQueries.ResolutionTimeSpan(
-          _parameters.Resolution,
-          now,
-          _parameters.Multiplier
-        )
-      );
-      _parameters.FromDate = fromDate;
-    }
-
     await Fetch();
   }
 
@@ -274,17 +222,36 @@ public partial class MeasurementChartControls : OzdsComponentBase
     Refresh(args.Measurements.ToList(), new List<IAggregate>());
   }
 
-  private async Task Fetch()
+  private async Task Fetch(bool forcedRefresh = false)
   {
     var queries = ScopedServices.GetRequiredService<MeasurementQueries>();
-    var fromDate = _parameters.FromDate;
-    var toDate = fromDate.Add(
+    DateTimeOffset fromDate;
+    DateTimeOffset toDate;
+
+    if (forcedRefresh || _parameters.Refresh)
+    {
+      toDate = ClockQueries.Now();
+      fromDate = toDate.Subtract(
+        TimeQueries.ResolutionTimeSpan(
+          _parameters.Resolution,
+          toDate,
+          _parameters.Multiplier
+        )
+      );
+      _parameters.FromDate = fromDate;
+    }
+    else
+    {
+      fromDate = _parameters.FromDate;
+      toDate = fromDate.Add(
       TimeQueries.ResolutionTimeSpan(
         _parameters.Resolution,
         fromDate,
         _parameters.Multiplier
-      )
-    );
+        )
+      );
+    }
+
     var fromMeters = await queries.ReadByMeterIds(
       _parameters.Meters.Select(x => x.Id).ToList(),
       _parameters.Resolution,

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -244,10 +244,10 @@ public partial class MeasurementChartControls : OzdsComponentBase
     {
       fromDate = _parameters.FromDate;
       toDate = fromDate.Add(
-      TimeQueries.ResolutionTimeSpan(
-        _parameters.Resolution,
-        fromDate,
-        _parameters.Multiplier
+        TimeQueries.ResolutionTimeSpan(
+          _parameters.Resolution,
+          fromDate,
+          _parameters.Multiplier
         )
       );
     }


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #304

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

- Fix, centralized `fromDate` recalculation into `Fetch` method with a
  `forcedRefresh` parameter, removing duplicated date calculation logic from
  `OnMeasurementLocationsChanged`,
  `OnMetersChanged`,`OnRefreshChanged`,`OnResolutionChanged`, and
  `OnMultiplierChanged`

This issue will again be addressed in the further parameter guard implementation since the root cause of this issue was unwanted fetch calls caused by random cascading or non-cascading parameter sets, but I would like to keep this implemented just in cause.

## Testing

(for local project)
- Initiate IoT fake push reactor
- Load up dashboard for ozds
- Wait a few mins without pressing any GUI buttons which trigger updating `FromDate`
- Initiate Dark mode / Light mode change (it's the easiest one to pull off)
- Wait a second or more before the chart refreshes
- See that the problem described in issue does not materialize


