### PR TITLE
306 energy card to have same fetch operations such as network user invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Refactored `AggregateWindowQueries` report fetching to be more like
+  `BillingQueries` by fetching next-boundary and blackout-location aggregates
+  separately for more accurate energy card report calculations
+- Fix Playwright `.local-browsers` folder missing from GitHub Actions artifact
+  by creating it without the dot prefix during publish and renaming on startup
+
 ## [1.8.2] - 2026-04-03
 
 ### Changed

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -358,13 +358,13 @@ public class AggregateWindowQueries(
         measurementLocationIds.Select(locationId =>
         {
           var orderedLocationAggregates =
-          inWindowAggregatesByLocation
-           .TryGetValue(locationId, out var v)
-           ? v : new List<AggregateEntity>();
+            inWindowAggregatesByLocation.TryGetValue(locationId, out var v)
+              ? v
+              : new List<AggregateEntity>();
 
           var next = nextBoundaries.FirstOrDefault(x =>
-             x.MeasurementLocationId == locationId
-           );
+            x.MeasurementLocationId == locationId
+          );
 
           var previous = actualStartBoundaries.FirstOrDefault(x =>
             x.MeasurementLocationId == locationId

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -6,6 +6,7 @@ using Ozds.Data.Entities.Enums;
 using Ozds.Data.Extensions;
 using Ozds.Data.Queries.Abstractions;
 using Ozds.Data.Reflection;
+using ITimeQueries = Ozds.Time.Queries.Abstractions.ITimeQueries;
 
 namespace Ozds.Data.Queries;
 
@@ -14,7 +15,8 @@ namespace Ozds.Data.Queries;
 
 public class AggregateWindowQueries(
   IDbContextFactory<DataDbContext> factory,
-  EntityReflector reflector
+  EntityReflector reflector,
+  ITimeQueries timeQueries
 ) : IQueries
 {
   public async Task<
@@ -181,7 +183,7 @@ public class AggregateWindowQueries(
             AND aggregates.interval
                 = '{quarterHourIntervalValue}'::{intervalTypeName}
             AND aggregates.timestamp >= @from
-            AND aggregates.timestamp <= @to
+            AND aggregates.timestamp < @to
           ORDER BY aggregates.timestamp ASC
           LIMIT 1
         ) agg
@@ -195,13 +197,13 @@ public class AggregateWindowQueries(
             AND aggregates.interval
                 = '{quarterHourIntervalValue}'::{intervalTypeName}
             AND aggregates.timestamp >= @from
-            AND aggregates.timestamp <= @to
+            AND aggregates.timestamp < @to
           ORDER BY aggregates.timestamp DESC
           LIMIT 1
         ) agg
       ";
 
-      var returnedAggregates = await context.DapperCommand<AggregateEntity>(
+      var inWindowAggregates = await context.DapperCommand<AggregateEntity>(
         aggregateType,
         sql,
         cancellationToken,
@@ -209,17 +211,178 @@ public class AggregateWindowQueries(
         300
       );
 
+      var nextBoundariesSql =
+      $@"
+        SELECT picked.*
+        FROM (
+          VALUES {string.Join(", ", locationValueRows)}
+        ) AS selected_locations(location_id)
+        CROSS JOIN LATERAL (
+          SELECT aggregates.*
+          FROM {table} aggregates
+          WHERE aggregates.measurement_location_id
+              = selected_locations.location_id
+            AND aggregates.interval
+              = '{quarterHourIntervalValue}'::{intervalTypeName}
+            AND aggregates.timestamp >= @to
+          ORDER BY aggregates.timestamp ASC
+          LIMIT 1
+        ) AS picked
+      ";
+
+      var nextBoundaries = await context.DapperCommand<AggregateEntity>(
+        aggregateType,
+        nextBoundariesSql,
+        cancellationToken,
+        parameters,
+        300
+      );
+
+      var locationsWithData = inWindowAggregates
+      .Select(x => x.MeasurementLocationId)
+      .Distinct()
+      .ToHashSet();
+
+      var blackoutLocationIds = measurementLocationIds
+        .Where(id => !locationsWithData.Contains(id))
+        .ToList();
+
+      var actualStartBoundaries = new List<AggregateEntity>();
+
+      if (blackoutLocationIds.Count != 0)
+      {
+        var blackoutParameters = new Dictionary<string, object?>(parameters);
+        var blackoutRows = new List<string>();
+        var blackoutIndex = 0;
+        foreach (var id in blackoutLocationIds)
+        {
+          var parameterName = $"blackout_location{blackoutIndex++}";
+          blackoutParameters[parameterName] = long.Parse(id);
+          blackoutRows.Add($"(@{parameterName})");
+        }
+
+        var lastReadingsBeforeBlackoutSql =
+          $@"
+            SELECT picked.*
+            FROM (
+              VALUES {string.Join(", ", blackoutRows)}
+            ) AS selected_locations(location_id)
+            CROSS JOIN LATERAL (
+              SELECT aggregates.*
+              FROM {table} aggregates
+              WHERE aggregates.measurement_location_id
+                  = selected_locations.location_id
+                AND aggregates.interval
+                  = '{quarterHourIntervalValue}'::{intervalTypeName}
+                AND aggregates.timestamp < @from
+              ORDER BY aggregates.timestamp DESC
+              LIMIT 1
+            ) AS picked
+          ";
+
+        var lastReadingsBeforeBlackout =
+          await context.DapperCommand<AggregateEntity>(
+            aggregateType,
+            lastReadingsBeforeBlackoutSql,
+            cancellationToken,
+            blackoutParameters,
+            300
+          );
+
+        if (lastReadingsBeforeBlackout.Count != 0)
+        {
+          var targetParameters = new Dictionary<string, object?>
+        {
+          {
+            "interval",
+            StringExtensions.ToSnakeCase(nameof(IntervalEntity.QuarterHour))
+          },
+        };
+
+          var targetRows = new List<string>();
+          var targetIndex = 0;
+
+          foreach (var reading in lastReadingsBeforeBlackout)
+          {
+            var monthStart = timeQueries.GetStartOfMonth(reading.Timestamp);
+
+            var locationParameter = $"target_location{targetIndex}";
+            var dateParameter = $"target_date{targetIndex}";
+
+            targetParameters[locationParameter] = long.Parse(
+              reading.MeasurementLocationId
+            );
+            targetParameters[dateParameter] = monthStart;
+
+            targetRows.Add($"(@{locationParameter}, @{dateParameter})");
+
+            targetIndex++;
+          }
+
+          if (targetRows.Count != 0)
+          {
+            var actualStartBoundariesSql =
+              $@"
+                SELECT picked.*
+                FROM (
+                  VALUES {string.Join(", ", targetRows)}
+                ) AS targets(location_id, target_start)
+                CROSS JOIN LATERAL (
+                  SELECT aggregates.*
+                  FROM {table} aggregates
+                  WHERE aggregates.measurement_location_id = targets.location_id
+                    AND aggregates.interval = '{quarterHourIntervalValue}'::{intervalTypeName}
+                    AND aggregates.timestamp >= targets.target_start
+                  ORDER BY aggregates.timestamp ASC
+                  LIMIT 1
+                ) AS picked
+              ";
+
+            actualStartBoundaries = await context.DapperCommand<AggregateEntity>(
+              aggregateType,
+              actualStartBoundariesSql,
+              cancellationToken,
+              targetParameters,
+              300
+            );
+          }
+        }
+      }
+
       totalWindowAggregates.AddRange(
-        returnedAggregates
+        inWindowAggregates
           .GroupBy(a => a.MeasurementLocationId)
           .Select(group =>
           {
-            var ordered = group.OrderBy(a => a.Timestamp).ToList();
+            var orderedLocationAggregates = group.OrderBy(a => a.Timestamp).ToList();
+
+            var next = nextBoundaries.FirstOrDefault(x =>
+              x.MeasurementLocationId == group.Key
+            );
+
+            var previous = actualStartBoundaries.FirstOrDefault(x =>
+              x.MeasurementLocationId == group.Key
+            );
+
+            AggregateEntity? startAggregate = null;
+            AggregateEntity? endAggregate = null;
+
+            if (orderedLocationAggregates.Count != 0)
+            {
+              startAggregate = orderedLocationAggregates.First();
+              endAggregate = next;
+            }
+            else
+            {
+              startAggregate = previous;
+              endAggregate = next;
+            }
+
             return new AggregateWindowBoundaryBasisEntity
             {
               MeasurementLocationId = group.Key,
-              StartAggregate = ordered.FirstOrDefault(),
-              EndAggregate = ordered.LastOrDefault(),
+              StartAggregate = startAggregate,
+              EndAggregate = endAggregate,
             };
           })
       );

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -350,44 +350,47 @@ public class AggregateWindowQueries(
         }
       }
 
+      var inWindowAggregatesByLocation = inWindowAggregates
+        .GroupBy(a => a.MeasurementLocationId)
+        .ToDictionary(g => g.Key, g => g.OrderBy(x => x.Timestamp).ToList());
+
       totalWindowAggregates.AddRange(
-        inWindowAggregates
-          .GroupBy(a => a.MeasurementLocationId)
-          .Select(group =>
+        measurementLocationIds.Select(locationId =>
+        {
+          var orderedLocationAggregates =
+          inWindowAggregatesByLocation
+           .TryGetValue(locationId, out var v)
+           ? new List<AggregateEntity>(v) : new List<AggregateEntity>();
+
+          var next = nextBoundaries.FirstOrDefault(x =>
+             x.MeasurementLocationId == locationId
+           );
+
+          var previous = actualStartBoundaries.FirstOrDefault(x =>
+            x.MeasurementLocationId == locationId
+          );
+
+          AggregateEntity? startAggregate = null;
+          AggregateEntity? endAggregate = null;
+
+          if (orderedLocationAggregates.Count != 0)
           {
-            var orderedLocationAggregates = group
-              .OrderBy(a => a.Timestamp)
-              .ToList();
+            startAggregate = orderedLocationAggregates.First();
+            endAggregate = next;
+          }
+          else
+          {
+            startAggregate = previous;
+            endAggregate = next;
+          }
 
-            var next = nextBoundaries.FirstOrDefault(x =>
-              x.MeasurementLocationId == group.Key
-            );
-
-            var previous = actualStartBoundaries.FirstOrDefault(x =>
-              x.MeasurementLocationId == group.Key
-            );
-
-            AggregateEntity? startAggregate = null;
-            AggregateEntity? endAggregate = null;
-
-            if (orderedLocationAggregates.Count != 0)
-            {
-              startAggregate = orderedLocationAggregates.First();
-              endAggregate = next;
-            }
-            else
-            {
-              startAggregate = previous;
-              endAggregate = next;
-            }
-
-            return new AggregateWindowBoundaryBasisEntity
-            {
-              MeasurementLocationId = group.Key,
-              StartAggregate = startAggregate,
-              EndAggregate = endAggregate,
-            };
-          })
+          return new AggregateWindowBoundaryBasisEntity
+          {
+            MeasurementLocationId = locationId,
+            StartAggregate = startAggregate,
+            EndAggregate = endAggregate,
+          };
+        })
       );
     }
 

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -360,7 +360,7 @@ public class AggregateWindowQueries(
           var orderedLocationAggregates =
           inWindowAggregatesByLocation
            .TryGetValue(locationId, out var v)
-           ? new List<AggregateEntity>(v) : new List<AggregateEntity>();
+           ? v : new List<AggregateEntity>();
 
           var next = nextBoundaries.FirstOrDefault(x =>
              x.MeasurementLocationId == locationId

--- a/src/Ozds.Data/Queries/AggregateWindowQueries.cs
+++ b/src/Ozds.Data/Queries/AggregateWindowQueries.cs
@@ -212,7 +212,7 @@ public class AggregateWindowQueries(
       );
 
       var nextBoundariesSql =
-      $@"
+        $@"
         SELECT picked.*
         FROM (
           VALUES {string.Join(", ", locationValueRows)}
@@ -239,9 +239,9 @@ public class AggregateWindowQueries(
       );
 
       var locationsWithData = inWindowAggregates
-      .Select(x => x.MeasurementLocationId)
-      .Distinct()
-      .ToHashSet();
+        .Select(x => x.MeasurementLocationId)
+        .Distinct()
+        .ToHashSet();
 
       var blackoutLocationIds = measurementLocationIds
         .Where(id => !locationsWithData.Contains(id))
@@ -292,12 +292,12 @@ public class AggregateWindowQueries(
         if (lastReadingsBeforeBlackout.Count != 0)
         {
           var targetParameters = new Dictionary<string, object?>
-        {
           {
-            "interval",
-            StringExtensions.ToSnakeCase(nameof(IntervalEntity.QuarterHour))
-          },
-        };
+            {
+              "interval",
+              StringExtensions.ToSnakeCase(nameof(IntervalEntity.QuarterHour))
+            },
+          };
 
           var targetRows = new List<string>();
           var targetIndex = 0;
@@ -338,13 +338,14 @@ public class AggregateWindowQueries(
                 ) AS picked
               ";
 
-            actualStartBoundaries = await context.DapperCommand<AggregateEntity>(
-              aggregateType,
-              actualStartBoundariesSql,
-              cancellationToken,
-              targetParameters,
-              300
-            );
+            actualStartBoundaries =
+              await context.DapperCommand<AggregateEntity>(
+                aggregateType,
+                actualStartBoundariesSql,
+                cancellationToken,
+                targetParameters,
+                300
+              );
           }
         }
       }
@@ -354,7 +355,9 @@ public class AggregateWindowQueries(
           .GroupBy(a => a.MeasurementLocationId)
           .Select(group =>
           {
-            var orderedLocationAggregates = group.OrderBy(a => a.Timestamp).ToList();
+            var orderedLocationAggregates = group
+              .OrderBy(a => a.Timestamp)
+              .ToList();
 
             var next = nextBoundaries.FirstOrDefault(x =>
               x.MeasurementLocationId == group.Key

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -22,7 +22,7 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
     {
       new EnergyCardScenario(
         "1. Normal month - data in queried window returns result",
-        new Dictionary<string, bool> { { Nov1, true } },
+        new Dictionary<string, bool> { { Nov1, true }, { Dec1, true} },
         Nov1,
         Dec1,
         true
@@ -74,6 +74,13 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
         Dec1,
         true
       ),
+      new EnergyCardScenario(
+        "8. Data in Nov only - pending month query, does not have right anchor - empty result as it falls under blackout",
+        new Dictionary<string, bool> { { Nov1, true } },
+        Nov1,
+        Dec1,
+        false
+      )
     };
   }
 

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -21,11 +21,13 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
     return new[]
     {
       new EnergyCardScenario(
-        "1. Normal month - data in queried window returns result",
+        "1. Normal month - data in queried window and next month returns result",
         new Dictionary<string, bool> { { Nov1, true }, { Dec1, true } },
         Nov1,
         Dec1,
-        true
+        true,
+        Nov1,
+        Dec1
       ),
       new EnergyCardScenario(
         "2. No data anywhere - empty result",
@@ -35,21 +37,21 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
         false
       ),
       new EnergyCardScenario(
-        "3. Data only in previous month - empty result for queried window",
+        "3. Data only in previous month - no next boundary, empty result",
         new Dictionary<string, bool> { { Oct1, true } },
         Nov1,
         Dec1,
         false
       ),
       new EnergyCardScenario(
-        "4. Data not in selected range - empty result for queried window",
+        "4. Data not in selected range - no start boundary, empty result",
         new Dictionary<string, bool> { { Jan1, true } },
         Nov1,
         Dec1,
         false
       ),
       new EnergyCardScenario(
-        "5. Data in Oct, Nov, Dec - query Nov returns result bounded to Nov",
+        "5. Data in Oct, Nov, Dec - query Nov returns result bounded to Nov-Dec",
         new Dictionary<string, bool>
         {
           { Oct1, true },
@@ -58,24 +60,30 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
         },
         Nov1,
         Dec1,
-        true
+        true,
+        Nov1,
+        Dec1
       ),
       new EnergyCardScenario(
-        "6. Data in Oct and Jan but not in Nov and Dec - empty result for Nov",
+        "6. Data in Oct and Jan - blackout bridged with previous start and next boundary",
         new Dictionary<string, bool> { { Oct1, true }, { Jan1, true } },
         Nov1,
         Dec1,
-        false
+        true,
+        Oct1,
+        Jan1
       ),
       new EnergyCardScenario(
-        "7. Data in Nov and Dec - query Nov only returns for Nov boundaries",
+        "7. Data in Nov and Dec - query Nov only returns for Nov-Dec boundaries",
         new Dictionary<string, bool> { { Nov1, true }, { Dec1, true } },
         Nov1,
         Dec1,
-        true
+        true,
+        Nov1,
+        Dec1
       ),
       new EnergyCardScenario(
-        "8. Data in Nov only - pending month query, does not have right anchor - empty result as it falls under blackout",
+        "8. Data in Nov only - no next boundary, empty result",
         new Dictionary<string, bool> { { Nov1, true } },
         Nov1,
         Dec1,
@@ -159,36 +167,23 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
 
     var basis = result!.First();
 
-    var inWindowAggregates = allMeasurements
-      .OfType<AggregateEntity>()
-      .Where(x => x.Interval == IntervalEntity.QuarterHour)
-      .Where(x => x.Timestamp >= fromDate && x.Timestamp <= toDate)
-      .OrderBy(x => x.Timestamp)
-      .ToList();
-
-    inWindowAggregates
-      .Should()
-      .NotBeEmpty(
-        $"Scenario '{scenario.Name}': test data must have in-window aggregates"
-      );
-
-    var expectedMinTimestamp = inWindowAggregates.First().Timestamp;
-    var expectedMaxTimestamp = inWindowAggregates.Last().Timestamp;
+    var expectedMinTimestamp = ParseDate(scenario.ExpectedMin!);
+    var expectedMaxTimestamp = ParseDate(scenario.ExpectedMax!);
 
     basis
       .MinAggregate.Timestamp.Should()
       .Be(
         expectedMinTimestamp,
-        $"Scenario '{scenario.Name}': MinAggregate should be the first "
-          + "aggregate in the queried window"
+        $"Scenario '{scenario.Name}': MinAggregate should match "
+          + "expected start boundary"
       );
 
     basis
       .MaxAggregate.Timestamp.Should()
       .Be(
         expectedMaxTimestamp,
-        $"Scenario '{scenario.Name}': MaxAggregate should be the last "
-          + "aggregate in the queried window"
+        $"Scenario '{scenario.Name}': MaxAggregate should match "
+          + "expected next boundary"
       );
 
     basis
@@ -216,17 +211,11 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
       );
 
     basis
-      .MinAggregate.Timestamp.Should()
-      .BeOnOrAfter(
-        fromDate,
-        $"Scenario '{scenario.Name}': MinAggregate must not precede fromDate"
-      );
-
-    basis
       .MaxAggregate.Timestamp.Should()
-      .BeOnOrBefore(
+      .BeOnOrAfter(
         toDate,
-        $"Scenario '{scenario.Name}': MaxAggregate must be on or before toDate"
+        $"Scenario '{scenario.Name}': MaxAggregate must be at or after "
+          + "toDate as it is a next boundary"
       );
   }
 
@@ -248,6 +237,8 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
     Dictionary<string, bool> MeasurementsMap,
     string QueryFrom,
     string QueryTo,
-    bool ExpectResult
+    bool ExpectResult,
+    string? ExpectedMin = null,
+    string? ExpectedMax = null
   );
 }

--- a/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
+++ b/test/Ozds.Data.Test/Queries/ReportQueriesTest/ReadEnergyCardReportBasisByNetworkUserTest.cs
@@ -22,7 +22,7 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
     {
       new EnergyCardScenario(
         "1. Normal month - data in queried window returns result",
-        new Dictionary<string, bool> { { Nov1, true }, { Dec1, true} },
+        new Dictionary<string, bool> { { Nov1, true }, { Dec1, true } },
         Nov1,
         Dec1,
         true
@@ -80,7 +80,7 @@ public class ReadEnergyCardReportBasisByNetworkUserTest : OzdsDataTestBase
         Nov1,
         Dec1,
         false
-      )
+      ),
     };
   }
 


### PR DESCRIPTION
# Task

@HrvojeJuric
Fixes #306

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Per request of Marko, this fetching method has been reworked to now completely resemble the one on network user invoice. Older model was correct but fetched aggregated boundary windows only in specific month, leading to potentional mismatches with the generated network user invoice report that Marko has highlighted. And all of them follow the same pattern - months whose aggregates end earlier than the factual end of month (missing aggregates or measurements towards end) yield different results on shortened energy card report and energy card.

- Refactored `AggregateWindowQueries` report fetching to be more like
  `BillingQueries` by fetching next-boundary and blackout-location aggregates
  separately for more accurate energy card report calculations
- Fix Playwright `.local-browsers` folder missing from GitHub Actions artifact
  by creating it without the dot prefix during publish and renaming on startup

## Testing

One unit test has been rewritten to now adjust for the new changes based on request and also another one has been added which tries to simulate fetching during pending month (mirrors blackout test from calculators in `Ozds.Business`).
