### PR TITLE
310 Smaller billing query optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Optimized `BillingQueries` to group aggregates by measurement location ID
+  upfront using a dictionary instead of filtering per-location in a loop
+
 ## [1.8.2] - 2026-04-03
 
 ### Changed

--- a/src/Ozds.Data/Queries/BillingQueries.cs
+++ b/src/Ozds.Data/Queries/BillingQueries.cs
@@ -406,8 +406,11 @@ public class BillingQueries(
       {
         var locationId = basis.MeasurementLocation.Id;
 
-        var locationAggregates = groupedByMeasurementLocationIds
-        .TryGetValue(locationId, out var v) ? new List<AggregateEntity>(v)
+        var locationAggregates = groupedByMeasurementLocationIds.TryGetValue(
+          locationId,
+          out var v
+        )
+          ? new List<AggregateEntity>(v)
           : new List<AggregateEntity>();
 
         var next = nextBoundaries.FirstOrDefault(x =>
@@ -436,8 +439,8 @@ public class BillingQueries(
 
         if (
           startAggregate != null
-          && !resultAggregates.Exists(
-            x => x.Timestamp == startAggregate.Timestamp
+          && !resultAggregates.Exists(x =>
+            x.Timestamp == startAggregate.Timestamp
           )
         )
         {
@@ -446,8 +449,8 @@ public class BillingQueries(
 
         if (
           endAggregate != null
-          && !resultAggregates.Exists(
-            x => x.Timestamp == endAggregate.Timestamp
+          && !resultAggregates.Exists(x =>
+            x.Timestamp == endAggregate.Timestamp
           )
         )
         {

--- a/src/Ozds.Data/Queries/BillingQueries.cs
+++ b/src/Ozds.Data/Queries/BillingQueries.cs
@@ -397,15 +397,18 @@ public class BillingQueries(
       }
     }
 
+    var groupedByMeasurementLocationIds = inWindowAggregates
+      .GroupBy(x => x.MeasurementLocationId)
+      .ToDictionary(g => g.Key, g => g.OrderBy(x => x.Timestamp).ToList());
+
     return bases
       .Select(basis =>
       {
         var locationId = basis.MeasurementLocation.Id;
 
-        var locationAggregates = inWindowAggregates
-          .Where(x => x.MeasurementLocationId == locationId)
-          .OrderBy(x => x.Timestamp)
-          .ToList();
+        var locationAggregates = groupedByMeasurementLocationIds
+        .TryGetValue(locationId, out var v) ? new List<AggregateEntity>(v)
+          : new List<AggregateEntity>();
 
         var next = nextBoundaries.FirstOrDefault(x =>
           x.MeasurementLocationId == locationId
@@ -433,9 +436,7 @@ public class BillingQueries(
 
         if (
           startAggregate != null
-          && !resultAggregates.Exists(x =>
-            x.Timestamp == startAggregate.Timestamp
-          )
+          && resultAggregates.FirstOrDefault() != startAggregate
         )
         {
           resultAggregates.Insert(0, startAggregate);
@@ -443,9 +444,7 @@ public class BillingQueries(
 
         if (
           endAggregate != null
-          && !resultAggregates.Exists(x =>
-            x.Timestamp == endAggregate.Timestamp
-          )
+          && (resultAggregates.Count > 0 ? resultAggregates[^1] : null) != endAggregate
         )
         {
           resultAggregates.Add(endAggregate);

--- a/src/Ozds.Data/Queries/BillingQueries.cs
+++ b/src/Ozds.Data/Queries/BillingQueries.cs
@@ -436,7 +436,9 @@ public class BillingQueries(
 
         if (
           startAggregate != null
-          && resultAggregates.FirstOrDefault() != startAggregate
+          && !resultAggregates.Exists(
+            x => x.Timestamp == startAggregate.Timestamp
+          )
         )
         {
           resultAggregates.Insert(0, startAggregate);
@@ -444,7 +446,9 @@ public class BillingQueries(
 
         if (
           endAggregate != null
-          && (resultAggregates.Count > 0 ? resultAggregates[^1] : null) != endAggregate
+          && !resultAggregates.Exists(
+            x => x.Timestamp == endAggregate.Timestamp
+          )
         )
         {
           resultAggregates.Add(endAggregate);

--- a/src/Ozds.Data/Queries/BillingQueries.cs
+++ b/src/Ozds.Data/Queries/BillingQueries.cs
@@ -410,7 +410,7 @@ public class BillingQueries(
           locationId,
           out var v
         )
-          ? new List<AggregateEntity>(v)
+          ? v
           : new List<AggregateEntity>();
 
         var next = nextBoundaries.FirstOrDefault(x =>


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #310 

More info on optimizations and propositions on them on Issue no. #310.

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

- Optimized `BillingQueries` to group aggregates by measurement location ID
  upfront using a dictionary instead of filtering per-location in a loop

## Testing

`Ozds.Data` unit tests for billing queries.
