### PR TITLE
251 Split total energy into energy on lower and higher tariff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Split single total active energy column in analysis views into two
+  sub-columns showing higher tariff (T1) and lower tariff (T2) separately
+- `MeterAnalysisColumns` and `MeasurementLocationAnalysisColumns` now use
+  `GroupedColumn` with T1/T2 instead of single `ActiveEnergy_kWh` column
+- `MeterAnalysisDetails` and `MeasurementLocationAnalysisDetails` now use
+  `FieldSection` groups with T1/T2 fields instead of single energy field
+- `FieldSection` title typography is now configurable via `TitleTypo` parameter
+  (defaults to `Typo.h5`), title text wrapped in bold
+- `Analyzer.AnalyzeConsumption` uses named parameters for readability
+
+### Added
+
+- `ActiveEnergy_Tariff1_kWh` and `ActiveEnergy_Tariff2_kWh` fields on
+  `Consumption` record, computed via `.TariffBinary().T1` / `.T2`
+- `GroupedColumn<T>` method on `OzdsColumnsComponentBase` that renders multiple
+  sub-columns under a shared header title using CSS grid layout
+- Translations for grouped column headers and tariff sub-columns in both
+  English and Croatian (`ActiveEnergyLastMonth`, `ActiveEnergyThisMonth`,
+  `ActiveEnergy_Tariff1_kWh`, `ActiveEnergy_Tariff2_kWh`)
+
 ## [1.8.2] - 2026-04-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Split single total active energy column in analysis views into two
-  sub-columns showing higher tariff (T1) and lower tariff (T2) separately
+- Split single total active energy column in analysis views into two sub-columns
+  showing higher tariff (T1) and lower tariff (T2) separately
 - `MeterAnalysisColumns` and `MeasurementLocationAnalysisColumns` now use
   `GroupedColumn` with T1/T2 instead of single `ActiveEnergy_kWh` column
 - `MeterAnalysisDetails` and `MeasurementLocationAnalysisDetails` now use
@@ -27,8 +27,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
   `Consumption` record, computed via `.TariffBinary().T1` / `.T2`
 - `GroupedColumn<T>` method on `OzdsColumnsComponentBase` that renders multiple
   sub-columns under a shared header title using CSS grid layout
-- Translations for grouped column headers and tariff sub-columns in both
-  English and Croatian (`ActiveEnergyLastMonth`, `ActiveEnergyThisMonth`,
+- Translations for grouped column headers and tariff sub-columns in both English
+  and Croatian (`ActiveEnergyLastMonth`, `ActiveEnergyThisMonth`,
   `ActiveEnergy_Tariff1_kWh`, `ActiveEnergy_Tariff2_kWh`)
 
 ## [1.8.2] - 2026-04-03

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -2210,7 +2210,40 @@
         ActiveEnergy_Tariff1_kWh
       </Key>
       <Metadata>
-        Property 'ActiveEnergy_Tariff1_kWh' of type 'Ozds.Business.Analysis.Consumption'
+        Property 'ActiveEnergy_Tariff1_kWh' of type 'Ozds.Business.Analysis.Consumption' with overrides:
+        MonthlyAnalysis.Consumption.ActiveEnergy_Tariff1_kWh
+        ~MonthlyAnalysis.Consumption.ActiveEnergy_Tariff1_kWh
+        Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~Consumption.ActiveEnergy_Tariff1_kWh
       </Metadata>
       <Value>
         Higher tariff (kWh)
@@ -2221,7 +2254,40 @@
         ActiveEnergy_Tariff2_kWh
       </Key>
       <Metadata>
-        Property 'ActiveEnergy_Tariff2_kWh' of type 'Ozds.Business.Analysis.Consumption'
+        Property 'ActiveEnergy_Tariff2_kWh' of type 'Ozds.Business.Analysis.Consumption' with overrides:
+        MonthlyAnalysis.Consumption.ActiveEnergy_Tariff2_kWh
+        ~MonthlyAnalysis.Consumption.ActiveEnergy_Tariff2_kWh
+        Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~Consumption.ActiveEnergy_Tariff2_kWh
       </Metadata>
       <Value>
         Lower tariff (kWh)
@@ -2456,7 +2522,8 @@
         ActiveEnergyLastMonth
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 14 column 3
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisDetails.razor' line 8 column 23
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisDetails.razor' line 8 column 23
       </Metadata>
       <Value>
         Active energy for the previous month
@@ -2491,7 +2558,8 @@
         ActiveEnergyThisMonth
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 20 column 3
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisDetails.razor' line 13 column 23
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisDetails.razor' line 13 column 23
       </Metadata>
       <Value>
         Active energy for the current month

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -2207,6 +2207,28 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        ActiveEnergy_Tariff1_kWh
+      </Key>
+      <Metadata>
+        Property 'ActiveEnergy_Tariff1_kWh' of type 'Ozds.Business.Analysis.Consumption'
+      </Metadata>
+      <Value>
+        Higher tariff (kWh)
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        ActiveEnergy_Tariff2_kWh
+      </Key>
+      <Metadata>
+        Property 'ActiveEnergy_Tariff2_kWh' of type 'Ozds.Business.Analysis.Consumption'
+      </Metadata>
+      <Value>
+        Lower tariff (kWh)
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         ActiveEnergy_Wh
       </Key>
       <Metadata>
@@ -2431,6 +2453,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        ActiveEnergyLastMonth
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 14 column 3
+      </Metadata>
+      <Value>
+        Active energy for the previous month
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         ActiveEnergyPrice_EUR
       </Key>
       <Metadata>
@@ -2451,6 +2484,17 @@
       </Metadata>
       <Value>
         Active energy price (EUR)
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        ActiveEnergyThisMonth
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 20 column 3
+      </Metadata>
+      <Value>
+        Active energy for the current month
       </Value>
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -2211,7 +2211,40 @@
         ActiveEnergy_Tariff1_kWh
       </Key>
       <Metadata>
-        Property 'ActiveEnergy_Tariff1_kWh' of type 'Ozds.Business.Analysis.Consumption'
+        Property 'ActiveEnergy_Tariff1_kWh' of type 'Ozds.Business.Analysis.Consumption' with overrides:
+        MonthlyAnalysis.Consumption.ActiveEnergy_Tariff1_kWh
+        ~MonthlyAnalysis.Consumption.ActiveEnergy_Tariff1_kWh
+        Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+        ~MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff1_kWh
+        ~Consumption.ActiveEnergy_Tariff1_kWh
       </Metadata>
       <Value>
         Viša tarifa (kWh)
@@ -2222,7 +2255,40 @@
         ActiveEnergy_Tariff2_kWh
       </Key>
       <Metadata>
-        Property 'ActiveEnergy_Tariff2_kWh' of type 'Ozds.Business.Analysis.Consumption'
+        Property 'ActiveEnergy_Tariff2_kWh' of type 'Ozds.Business.Analysis.Consumption' with overrides:
+        MonthlyAnalysis.Consumption.ActiveEnergy_Tariff2_kWh
+        ~MonthlyAnalysis.Consumption.ActiveEnergy_Tariff2_kWh
+        Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~LocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~LocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~LocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~NetworkUserAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~NetworkUserAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~NetworkUserAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~MeasurementLocationAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeasurementLocationAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeasurementLocationAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~MeterAnalysis.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeterAnalysis.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+        ~MeterAnalysis.Analysis.Monthly.Consumption.ActiveEnergy_Tariff2_kWh
+        ~Consumption.ActiveEnergy_Tariff2_kWh
       </Metadata>
       <Value>
         Niža tarifa (kWh)
@@ -2457,7 +2523,8 @@
         ActiveEnergyLastMonth
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 14 column 3
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisDetails.razor' line 8 column 23
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisDetails.razor' line 8 column 23
       </Metadata>
       <Value>
         Radna energija za prethodni mjesec
@@ -2492,7 +2559,8 @@
         ActiveEnergyThisMonth
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 20 column 3
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisDetails.razor' line 13 column 23
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisDetails.razor' line 13 column 23
       </Metadata>
       <Value>
         Radna energija za tekući mjesec

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -2208,6 +2208,28 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        ActiveEnergy_Tariff1_kWh
+      </Key>
+      <Metadata>
+        Property 'ActiveEnergy_Tariff1_kWh' of type 'Ozds.Business.Analysis.Consumption'
+      </Metadata>
+      <Value>
+        Viša tarifa (kWh)
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        ActiveEnergy_Tariff2_kWh
+      </Key>
+      <Metadata>
+        Property 'ActiveEnergy_Tariff2_kWh' of type 'Ozds.Business.Analysis.Consumption'
+      </Metadata>
+      <Value>
+        Niža tarifa (kWh)
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         ActiveEnergy_Wh
       </Key>
       <Metadata>
@@ -2432,6 +2454,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        ActiveEnergyLastMonth
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 14 column 3
+      </Metadata>
+      <Value>
+        Radna energija za prethodni mjesec
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         ActiveEnergyPrice_EUR
       </Key>
       <Metadata>
@@ -2452,6 +2485,17 @@
       </Metadata>
       <Value>
         Cijena radne energije (EUR)
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        ActiveEnergyThisMonth
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor' line 20 column 3
+      </Metadata>
+      <Value>
+        Radna energija za tekući mjesec
       </Value>
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>

--- a/src/Ozds.Business/Analysis/Analysis.cs
+++ b/src/Ozds.Business/Analysis/Analysis.cs
@@ -61,18 +61,18 @@ public record Consumption(
 )
 {
   public static readonly Consumption Null = new(
-    DateTimeOffset.MinValue,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0
+    Timestamp: DateTimeOffset.MinValue,
+    MinActiveEnergy_kWh: 0,
+    MaxActiveEnergy_kWh: 0,
+    ActiveEnergy_kWh: 0,
+    ActiveEnergy_Tariff1_kWh: 0,
+    ActiveEnergy_Tariff2_kWh: 0,
+    MinReactiveEnergy_kVARh: 0,
+    MaxReactiveEnergy_kVARh: 0,
+    ReactiveEnergy_kVARh: 0,
+    MinApparentEnergy_kVAh: 0,
+    MaxApparentEnergy_kVAh: 0,
+    ApparentEnergy_kVAh: 0
   );
 }
 

--- a/src/Ozds.Business/Analysis/Analysis.cs
+++ b/src/Ozds.Business/Analysis/Analysis.cs
@@ -50,6 +50,8 @@ public record Consumption(
   decimal MinActiveEnergy_kWh,
   decimal MaxActiveEnergy_kWh,
   decimal ActiveEnergy_kWh,
+  decimal ActiveEnergy_Tariff1_kWh,
+  decimal ActiveEnergy_Tariff2_kWh,
   decimal MinReactiveEnergy_kVARh,
   decimal MaxReactiveEnergy_kVARh,
   decimal ReactiveEnergy_kVARh,
@@ -60,6 +62,8 @@ public record Consumption(
 {
   public static readonly Consumption Null = new(
     DateTimeOffset.MinValue,
+    0,
+    0,
     0,
     0,
     0,

--- a/src/Ozds.Business/Analysis/Analyzer.cs
+++ b/src/Ozds.Business/Analysis/Analyzer.cs
@@ -174,102 +174,79 @@ public class Analyzer(ClockQueries clockQueries, TimeQueries timeQueries)
       .GroupBy(x => x.Timestamp)
       .Select(x => new Consumption(
         Timestamp: x.Key,
-        MinActiveEnergy_kWh:
-          x.Select(x =>
-              x.ActiveEnergy_Wh.TariffUnary()
-                .DuplexImport()
-                .AggregateMin()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Min() / 1000M,
-        MaxActiveEnergy_kWh:
-          x.Select(x =>
-              x.ActiveEnergy_Wh.TariffUnary()
-                .DuplexImport()
-                .AggregateMax()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Max() / 1000M,
-        ActiveEnergy_kWh:
-          x.Select(x =>
-              x.ActiveEnergy_Wh
-                .TariffUnary()
-                .DuplexImport()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Sum() / 1000M,
-        ActiveEnergy_Tariff1_kWh:
-          x.Select(x =>
-              x.ActiveEnergy_Wh
-                .TariffBinary().T1
-                .DuplexImport()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Sum() / 1000M,
-        ActiveEnergy_Tariff2_kWh:
-          x.Select(x =>
-              x.ActiveEnergy_Wh
-                .TariffBinary().T2
-                .DuplexImport()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Sum() / 1000M,
-        MinReactiveEnergy_kVARh:
-          x.Select(x =>
-              x.ReactiveEnergy_VARh.TariffUnary()
-                .DuplexImport()
-                .AggregateMin()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Min() / 1000M,
-        MaxReactiveEnergy_kVARh:
-          x.Select(x =>
-              x.ReactiveEnergy_VARh.TariffUnary()
-                .DuplexImport()
-                .AggregateMax()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Max() / 1000M,
-        ReactiveEnergy_kVARh:
-          x.Select(x =>
-              x.ReactiveEnergy_VARh
-                .TariffUnary()
-                .DuplexImport()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Sum() / 1000M,
-        MinApparentEnergy_kVAh:
-          x.Select(x =>
-              x.ApparentEnergy_VAh.TariffUnary()
-                .DuplexImport()
-                .AggregateMin()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Min() / 1000M,
-        MaxApparentEnergy_kVAh:
-          x.Select(x =>
-              x.ApparentEnergy_VAh.TariffUnary()
-                .DuplexImport()
-                .AggregateMax()
-                .PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Max() / 1000M,
-        ApparentEnergy_kVAh:
-          x.Select(x =>
-              x.ApparentEnergy_VAh.TariffUnary().DuplexImport().PhaseSum()
-            )
-            .DefaultIfEmpty(0M)
-            .Sum() / 1000M
+        MinActiveEnergy_kWh: x.Select(x =>
+            x.ActiveEnergy_Wh.TariffUnary()
+              .DuplexImport()
+              .AggregateMin()
+              .PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Min() / 1000M,
+        MaxActiveEnergy_kWh: x.Select(x =>
+            x.ActiveEnergy_Wh.TariffUnary()
+              .DuplexImport()
+              .AggregateMax()
+              .PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Max() / 1000M,
+        ActiveEnergy_kWh: x.Select(x =>
+            x.ActiveEnergy_Wh.TariffUnary().DuplexImport().PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Sum() / 1000M,
+        ActiveEnergy_Tariff1_kWh: x.Select(x =>
+            x.ActiveEnergy_Wh.TariffBinary().T1.DuplexImport().PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Sum() / 1000M,
+        ActiveEnergy_Tariff2_kWh: x.Select(x =>
+            x.ActiveEnergy_Wh.TariffBinary().T2.DuplexImport().PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Sum() / 1000M,
+        MinReactiveEnergy_kVARh: x.Select(x =>
+            x.ReactiveEnergy_VARh.TariffUnary()
+              .DuplexImport()
+              .AggregateMin()
+              .PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Min() / 1000M,
+        MaxReactiveEnergy_kVARh: x.Select(x =>
+            x.ReactiveEnergy_VARh.TariffUnary()
+              .DuplexImport()
+              .AggregateMax()
+              .PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Max() / 1000M,
+        ReactiveEnergy_kVARh: x.Select(x =>
+            x.ReactiveEnergy_VARh.TariffUnary().DuplexImport().PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Sum() / 1000M,
+        MinApparentEnergy_kVAh: x.Select(x =>
+            x.ApparentEnergy_VAh.TariffUnary()
+              .DuplexImport()
+              .AggregateMin()
+              .PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Min() / 1000M,
+        MaxApparentEnergy_kVAh: x.Select(x =>
+            x.ApparentEnergy_VAh.TariffUnary()
+              .DuplexImport()
+              .AggregateMax()
+              .PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Max() / 1000M,
+        ApparentEnergy_kVAh: x.Select(x =>
+            x.ApparentEnergy_VAh.TariffUnary().DuplexImport().PhaseSum()
+          )
+          .DefaultIfEmpty(0M)
+          .Sum() / 1000M
       ))
       .OrderByDescending(x => x.Timestamp)
       .ToList();

--- a/src/Ozds.Business/Analysis/Analyzer.cs
+++ b/src/Ozds.Business/Analysis/Analyzer.cs
@@ -173,68 +173,103 @@ public class Analyzer(ClockQueries clockQueries, TimeQueries timeQueries)
     return models
       .GroupBy(x => x.Timestamp)
       .Select(x => new Consumption(
-        x.Key,
-        x.Select(x =>
-            x.ActiveEnergy_Wh.TariffUnary()
-              .DuplexImport()
-              .AggregateMin()
-              .PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Min() / 1000M,
-        x.Select(x =>
-            x.ActiveEnergy_Wh.TariffUnary()
-              .DuplexImport()
-              .AggregateMax()
-              .PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Max() / 1000M,
-        x.Select(x => x.ActiveEnergy_Wh.TariffUnary().DuplexImport().PhaseSum())
-          .DefaultIfEmpty(0M)
-          .Sum() / 1000M,
-        x.Select(x =>
-            x.ReactiveEnergy_VARh.TariffUnary()
-              .DuplexImport()
-              .AggregateMin()
-              .PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Min() / 1000M,
-        x.Select(x =>
-            x.ReactiveEnergy_VARh.TariffUnary()
-              .DuplexImport()
-              .AggregateMax()
-              .PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Max() / 1000M,
-        x.Select(x =>
-            x.ReactiveEnergy_VARh.TariffUnary().DuplexImport().PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Sum() / 1000M,
-        x.Select(x =>
-            x.ApparentEnergy_VAh.TariffUnary()
-              .DuplexImport()
-              .AggregateMin()
-              .PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Min() / 1000M,
-        x.Select(x =>
-            x.ApparentEnergy_VAh.TariffUnary()
-              .DuplexImport()
-              .AggregateMax()
-              .PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Max() / 1000M,
-        x.Select(x =>
-            x.ApparentEnergy_VAh.TariffUnary().DuplexImport().PhaseSum()
-          )
-          .DefaultIfEmpty(0M)
-          .Sum() / 1000M
+        Timestamp: x.Key,
+        MinActiveEnergy_kWh:
+          x.Select(x =>
+              x.ActiveEnergy_Wh.TariffUnary()
+                .DuplexImport()
+                .AggregateMin()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Min() / 1000M,
+        MaxActiveEnergy_kWh:
+          x.Select(x =>
+              x.ActiveEnergy_Wh.TariffUnary()
+                .DuplexImport()
+                .AggregateMax()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Max() / 1000M,
+        ActiveEnergy_kWh:
+          x.Select(x =>
+              x.ActiveEnergy_Wh
+                .TariffUnary()
+                .DuplexImport()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Sum() / 1000M,
+        ActiveEnergy_Tariff1_kWh:
+          x.Select(x =>
+              x.ActiveEnergy_Wh
+                .TariffBinary().T1
+                .DuplexImport()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Sum() / 1000M,
+        ActiveEnergy_Tariff2_kWh:
+          x.Select(x =>
+              x.ActiveEnergy_Wh
+                .TariffBinary().T2
+                .DuplexImport()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Sum() / 1000M,
+        MinReactiveEnergy_kVARh:
+          x.Select(x =>
+              x.ReactiveEnergy_VARh.TariffUnary()
+                .DuplexImport()
+                .AggregateMin()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Min() / 1000M,
+        MaxReactiveEnergy_kVARh:
+          x.Select(x =>
+              x.ReactiveEnergy_VARh.TariffUnary()
+                .DuplexImport()
+                .AggregateMax()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Max() / 1000M,
+        ReactiveEnergy_kVARh:
+          x.Select(x =>
+              x.ReactiveEnergy_VARh
+                .TariffUnary()
+                .DuplexImport()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Sum() / 1000M,
+        MinApparentEnergy_kVAh:
+          x.Select(x =>
+              x.ApparentEnergy_VAh.TariffUnary()
+                .DuplexImport()
+                .AggregateMin()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Min() / 1000M,
+        MaxApparentEnergy_kVAh:
+          x.Select(x =>
+              x.ApparentEnergy_VAh.TariffUnary()
+                .DuplexImport()
+                .AggregateMax()
+                .PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Max() / 1000M,
+        ApparentEnergy_kVAh:
+          x.Select(x =>
+              x.ApparentEnergy_VAh.TariffUnary().DuplexImport().PhaseSum()
+            )
+            .DefaultIfEmpty(0M)
+            .Sum() / 1000M
       ))
       .OrderByDescending(x => x.Timestamp)
       .ToList();

--- a/src/Ozds.Client/Components/Fields/FieldSection.razor
+++ b/src/Ozds.Client/Components/Fields/FieldSection.razor
@@ -5,8 +5,10 @@
   class="@("mt-4 " + Class)"
   style="@("max-width: 36rem; " + Style)">
   <div class="d-flex flex-row justify-space-between">
-    <MudText Typo="Typo.h5">
-      @Title
+    <MudText Typo="@TitleTypo">
+      <b>
+        @Title
+      </b>
     </MudText>
     <MudText Typo="Typo.subtitle1">
       @Unit
@@ -18,6 +20,9 @@
 </div>
 
 @code {
+
+  [Parameter]
+  public Typo TitleTypo {get; set;} = Typo.h5;
 
   [Parameter]
   public string? Title { get; set; } = string.Empty;

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -523,17 +523,18 @@
     params Expression<Func<TModel, T?>>[] nextExpressions
   )
   {
-    var compiledFuncs = nextExpressions.Select(e => e.Compile()).ToArray();
-
+    var compiledFunctions
+        = nextExpressions.Select(e => e.Compile()).ToArray();
+    
     if (searchable)
     {
-      foreach (var (expr, func) in nextExpressions.Zip(compiledFuncs))
+      foreach (var (expr, func) in nextExpressions.Zip(compiledFunctions))
       {
         RegisterSearchMapper(expr, x => func(x)?.ToString());
       }
     }
 
-    var gridStlye
+    var gridStyle
       = @"display:grid;
           grid-template-columns:1fr 1fr;
           gap:.5rem;
@@ -550,7 +551,7 @@
                 @Translate(groupKey)
               </b>
             </MudText>
-            <div style="@gridStlye">
+            <div style="@gridStyle">
               @foreach (var expr in nextExpressions)
               {
                 <MudText Typo="Typo.caption">
@@ -561,8 +562,8 @@
           </div>
         </HeaderTemplate>
         <CellTemplate>
-          <div style="@gridStlye">
-            @foreach (var func in compiledFuncs)
+          <div style="@gridStyle">
+            @foreach (var func in compiledFunctions)
             {
               <MudText>
                 @Get(func)(context.Item)

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -525,7 +525,7 @@
   {
     var compiledFunctions
         = nextExpressions.Select(e => e.Compile()).ToArray();
-    
+
     if (searchable)
     {
       foreach (var (expr, func) in nextExpressions.Zip(compiledFunctions))
@@ -534,12 +534,8 @@
       }
     }
 
-    var gridStyle
-      = @"display:grid;
-          grid-template-columns:1fr 1fr;
-          gap:.5rem;
-          text-align:left;
-          width:100%";
+    var cols = nextExpressions.Length;
+    var gridStyle = $"display:grid;grid-template-columns:repeat({cols},1fr);gap:.5rem;text-align:left;width:100%";
 
     return Nest(
       @<TemplateColumn

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -513,6 +513,63 @@
             </MudLink>
           }
         </CellTemplate>
+      </TemplateColumn>
+        );
+    }
+
+  protected RenderFragment GroupedColumn<T>(
+    string groupKey,
+    bool searchable = false,
+    params Expression<Func<TModel, T?>>[] nextExpressions
+  )
+  {
+    var compiledFuncs = nextExpressions.Select(e => e.Compile()).ToArray();
+
+    if (searchable)
+    {
+      foreach (var (expr, func) in nextExpressions.Zip(compiledFuncs))
+      {
+        RegisterSearchMapper(expr, x => func(x)?.ToString());
+      }
+    }
+
+    var gridStlye
+      = @"display:grid;
+          grid-template-columns:1fr 1fr;
+          gap:.5rem;
+          text-align:left;
+          width:100%";
+
+    return Nest(
+      @<TemplateColumn
+         T="TPrefix">
+        <HeaderTemplate>
+          <div style="display:flex;flex-direction:column;align-items:start;width:100%;">
+            <MudText Typo="Typo.body1" Align="Align.Center" Style="width:100%;">
+              <b>
+                @Translate(groupKey)
+              </b>
+            </MudText>
+            <div style="@gridStlye">
+              @foreach (var expr in nextExpressions)
+              {
+                <MudText Typo="Typo.caption">
+                  @Translate(Label(expr))
+                </MudText>
+              }
+            </div>
+          </div>
+        </HeaderTemplate>
+        <CellTemplate>
+          <div style="@gridStlye">
+            @foreach (var func in compiledFuncs)
+            {
+              <MudText>
+                @Get(func)(context.Item)
+              </MudText>
+            }
+          </div>
+        </CellTemplate>
       </TemplateColumn>);
   }
 

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
@@ -10,8 +10,18 @@
 
 @LinkColumn(x => x.MeasurementLocation, true)
 
-@Column(x => x.Analysis.LastMonthConsumption.ActiveEnergy_kWh)
+@GroupedColumn(
+  "ActiveEnergyLastMonth",
+  false,
+  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh,
+  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+)
 
-@Column(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_kWh)
+@GroupedColumn(
+  "ActiveEnergyThisMonth",
+  false,
+  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh,
+  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+)
 
 @Column(x => x.Analysis.LastMonthExpenses.Total_EUR)

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisDetails.razor
@@ -1,11 +1,18 @@
 @namespace Ozds.Client.Components.Models.Implementations.Analyses
+@using Ozds.Client.Components.Fields
 
 @inherits Ozds.Client.Components.Models.Base.OzdsDetailsComponentBase<Ozds.Business.Analysis.MeasurementLocationAnalysis>
 
 @Field(x => x.MeasurementLocation.Title)
 
-@Field(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_kWh)
+<FieldSection Title="@Translate("ActiveEnergyLastMonth")" TitleTypo="MudBlazor.Typo.body1">
+    @Field(x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh)
+    @Field(x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh)
+</FieldSection>
 
-@Field(x => x.Analysis.LastMonthConsumption.ActiveEnergy_kWh)
+<FieldSection Title="@Translate("ActiveEnergyThisMonth")" TitleTypo="MudBlazor.Typo.body1">
+    @Field(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh)
+    @Field(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh)
+</FieldSection>
 
 @Field(x => x.Analysis.LastMonthExpenses.Total_EUR)

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
@@ -8,8 +8,18 @@
 
 @LinkColumn(x => x.Meter, true)
 
-@Column(x => x.Analysis.LastMonthConsumption.ActiveEnergy_kWh)
+@GroupedColumn(
+  "ActiveEnergyLastMonth",
+  false,
+  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh,
+  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+)
 
-@Column(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_kWh)
+@GroupedColumn(
+  "ActiveEnergyThisMonth",
+  false,
+  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh,
+  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+)
 
 @Column(x => x.Analysis.LastMonthExpenses.Total_EUR)

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisDetails.razor
@@ -1,11 +1,18 @@
 @namespace Ozds.Client.Components.Models.Implementations.Analyses
+@using Ozds.Client.Components.Fields
 
 @inherits Ozds.Client.Components.Models.Base.OzdsDetailsComponentBase<Ozds.Business.Analysis.MeterAnalysis>
 
 @Field(x => x.Meter.Title)
 
-@Field(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_kWh)
+<FieldSection Title="@Translate("ActiveEnergyLastMonth")" TitleTypo="MudBlazor.Typo.body1">
+    @Field(x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh)
+    @Field(x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh)
+</FieldSection>
 
-@Field(x => x.Analysis.LastMonthConsumption.ActiveEnergy_kWh)
+<FieldSection Title="@Translate("ActiveEnergyThisMonth")" TitleTypo="MudBlazor.Typo.body1">
+    @Field(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh)
+    @Field(x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh)
+</FieldSection>
 
 @Field(x => x.Analysis.LastMonthExpenses.Total_EUR)


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #312
Fixes #251 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- Split single total active energy column in analysis views into two
  sub-columns showing higher tariff (T1) and lower tariff (T2) separately
- `MeterAnalysisColumns` and `MeasurementLocationAnalysisColumns` now use
  `GroupedColumn` with T1/T2 instead of single `ActiveEnergy_kWh` column
- `MeterAnalysisDetails` and `MeasurementLocationAnalysisDetails` now use
  `FieldSection` groups with T1/T2 fields instead of single energy field
- `FieldSection` title typography is now configurable via `TitleTypo` parameter
  (defaults to `Typo.h5`), title text wrapped in bold
- `Analyzer.AnalyzeConsumption` uses named parameters for readability

### Added

- `ActiveEnergy_Tariff1_kWh` and `ActiveEnergy_Tariff2_kWh` fields on
  `Consumption` record, computed via `.TariffBinary().T1` / `.T2`
- `GroupedColumn<T>` method on `OzdsColumnsComponentBase` that renders multiple
  sub-columns under a shared header title using CSS grid layout
- Translations for grouped column headers and tariff sub-columns in both
  English and Croatian (`ActiveEnergyLastMonth`, `ActiveEnergyThisMonth`,
  `ActiveEnergy_Tariff1_kWh`, `ActiveEnergy_Tariff2_kWh`)

### Visual of the newly implemented columns:

<img width="1229" height="300" alt="image" src="https://github.com/user-attachments/assets/72127a89-6f3b-4f8d-84a9-d0ed3128fea5" />

<img width="1230" height="236" alt="image" src="https://github.com/user-attachments/assets/3aeccc94-cd25-42d3-98fb-49b5e53211b1" />

Also the column sub part has been implemented as a gird structure since even if the structure starts to fold the logical ordering is preserved in both titles and actual column values, as can be seen in the following image. This function being mostly a last resort measure until frontend fix has been applied.

<img width="355" height="171" alt="image" src="https://github.com/user-attachments/assets/67a4c165-3dbc-429d-9018-d30cabb46d28" />

### Following are the depictions of grid in action on both translations:

<img width="738" height="387" alt="image" src="https://github.com/user-attachments/assets/e27bc80e-78b2-419e-a8c7-f829a9d08ef8" />

<img width="726" height="370" alt="image" src="https://github.com/user-attachments/assets/68b2ff65-3912-49a0-9f6a-0b62777670a4" />

## Appendix 

Current implemenation on `Consumption` analysis is implemented with shortness in mind and determination on keeping the other logic of the application unchanged, therefore `ActiveEnergy_kWh` is unchanged and remains, but it is used to display contents of T0. 

For future reference or if need be, it would be good to write enhancement issue to add private static method helpers which will reduce the size of the `Consumption` constructor since a lot of operations are repeated and this makes it much less readable and harder to manage. (I.E private static method helper in which you can define if you want min or max and then define tariff ).

## Testing

Boot up local .NET server and see analysis tables in meters/measurement locations or just on measurement site where all of the tables lay.
