### PR TITLE
249 mudblazor update and dropdown fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- bumped MudBlazor version from 8.1.0 to 8.6.0
+- moved MudBlazor, Tizzani HtmlEditor, Quill and Google Fonts Roboto
+  `<link>`/`<script>` tags from `ThemeStateProvider.razor` into
+  `_AppLayout.cshtml` so they load at the server layout level rather than inside
+  the client theme provider
+
 ## [1.8.2] - 2026-04-03
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,10 +10,7 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion
-      Include="Altibiz.DependencyInjection.Extensions"
-      Version="1.0.10"
-    />
+    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -25,74 +22,26 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Design"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Proxies"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.InMemory"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.NamingConventions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.BulkExtensions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
-      Version="8.0.4"
-    />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion
-      Include="Quartz.Serialization.SystemTextJson"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.DependencyInjection"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.Hosting"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
-      Version="0.5.1"
-    />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion
-      Include="MassTransit.RabbitMQ"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.Azure.ServiceBus.Core"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.EntityFrameworkCore"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
-      Version="8.0.17"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.Cookies"
-      Version="2.3.0"
-    />
-    <PackageVersion
-      Include="Novell.Directory.Ldap.NETStandard"
-      Version="3.6.0"
-    />
-    <PackageVersion Include="MudBlazor" Version="8.1.0" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
+    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+    <PackageVersion Include="MudBlazor" Version="8.6.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
@@ -104,10 +53,7 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Mvc.Testing"
-      Version="8.0.17"
-    />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,10 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
+    <PackageVersion
+      Include="Altibiz.DependencyInjection.Extensions"
+      Version="1.0.10"
+    />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -22,25 +25,73 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Design"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Proxies"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.InMemory"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.NamingConventions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.BulkExtensions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
+      Version="8.0.4"
+    />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
+    <PackageVersion
+      Include="Quartz.Serialization.SystemTextJson"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.DependencyInjection"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.Hosting"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
+      Version="0.5.1"
+    />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
-    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+    <PackageVersion
+      Include="MassTransit.RabbitMQ"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.Azure.ServiceBus.Core"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.EntityFrameworkCore"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
+      Version="8.0.17"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.Cookies"
+      Version="2.3.0"
+    />
+    <PackageVersion
+      Include="Novell.Directory.Ldap.NETStandard"
+      Version="3.6.0"
+    />
     <PackageVersion Include="MudBlazor" Version="8.6.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
@@ -53,7 +104,10 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Mvc.Testing"
+      Version="8.0.17"
+    />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/scripts/flake/ozds/deps.json
+++ b/scripts/flake/ozds/deps.json
@@ -476,8 +476,8 @@
   },
   {
     "pname": "MudBlazor",
-    "version": "8.1.0",
-    "hash": "sha256-y7facnCuqvNfyGAmR47RowFQCJnbHGEENWFZGkdOFoo="
+    "version": "8.6.0",
+    "hash": "sha256-lQohRfV7DR3uwpz7MpuYIenJ+AE4a/DsWb1JrYCa8P8="
   },
   {
     "pname": "MudBlazor.ThemeManager",

--- a/src/Ozds.Client/Components/Providers/ThemeStateProvider.razor
+++ b/src/Ozds.Client/Components/Providers/ThemeStateProvider.razor
@@ -10,13 +10,6 @@
 
 @* FIXME: it doesn't work inside HeadContent *@
 <Fragment>
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet"/>
-
-  <link href="/_content/MudBlazor/MudBlazor.min.css" rel="stylesheet"/>
-  <link href="/_content/MudBlazor.ThemeManager/MudBlazorThemeManager.css" rel="stylesheet"/>
-
-  <link href="/_content/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.css" rel="stylesheet"/>
-
   <!-- NOTE: keep here just in case -->
   <!--
   <link href="/_content/Blazor-ApexCharts/css/apexcharts.css" rel=stylesheet />
@@ -56,11 +49,6 @@
     @ChildContent
   </MudBreakpointProvider>
 </CascadingValue>
-
-<script src="/_content/MudBlazor/MudBlazor.min.js"></script>
-
-<script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js"></script>
-<script src="/_content/Tizzani.MudBlazor.HtmlEditor/quill-blot-formatter.min.js"></script> <!-- optional; for image resize -->
 
 <!-- NOTE: keep here just in case -->
 <!--

--- a/src/Ozds.Server/Views/Shared/_AppLayout.cshtml
+++ b/src/Ozds.Server/Views/Shared/_AppLayout.cshtml
@@ -20,6 +20,10 @@
     <base href="/app/@(AppIndexController.LocalStorageCulture)/"/>
   }
 
+  <link href="/_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+  <link href="/_content/MudBlazor.ThemeManager/MudBlazorThemeManager.css" rel="stylesheet" />
+  <link href="/_content/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
   <link rel="icon" type="image/png" href="/favicon.png">
 
   @(await Html.RenderComponentAsync<HeadOutlet>(RenderMode.Server))
@@ -29,5 +33,8 @@
 @RenderBody()
 
 <script src="/_framework/blazor.server.js"></script>
+<script src="/_content/MudBlazor/MudBlazor.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js"></script>
+<script src="/_content/Tizzani.MudBlazor.HtmlEditor/quill-blot-formatter.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #249

Partial fix on #213 issue, since this issue also states problem with opening MudBlazor's `MudSelect` components.

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

This PR introduces small changes made for bumping up version of MudBlazor to 8.6.0, thus preparing it for further updates leaning towards 9.x.x.

Main focus was resolving issue with `MudSelect` component stated in following links:

https://github.com/MudBlazor/MudBlazor/issues/10733

https://github.com/MudBlazor/MudBlazor/issues/10739

Main pattern being that the stated issue versions of MudBlazor are `8.1.0`.

This problem was of internal nature of the MudBlazor package so the update from version `8.1.0` was mandatory. The `8.6.0` version was chosen because it does not have any new breaking implementations and offer a variety of fixes including this one for dropdown.

Also static links from the `ThemeStateProvider.razor` have been moved to `_AppLayout.cshtml`, css links being situated on their default place in `<head>` element and JS scripts moved to the extreme end of the `<body>` element so it's assured safe from browser's top-down parsing.

## Testing

Local start and frontend testing and trying out things stated both in issue and PR.
