### PR TITLE
Playwright problems on production - installation on server implementation

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -205,3 +205,4 @@ words:
   - zoomout
   - isexec
   - sbyte
+  - compgen

--- a/justfile
+++ b/justfile
@@ -297,14 +297,14 @@ publish *args:
     cp '{{ ozdsserver }}' '{{ artifacts }}/ozds-server'
     cp '{{ ozdsserverdev }}' '{{ artifacts }}/ozds-server-dev'
 
-    mkdir ("{{ artifacts }}/playwright/package/local-browsers" \
-      + "/chromium_headless_shell-1155/chrome-linux")
+    #mkdir ("{{ artifacts }}/playwright/package/local-browsers" \
+    #  + "/chromium_headless_shell-1155/chrome-linux")
 
-    cd ("{{ artifacts }}/playwright/package/local-browsers" \
-      + "/chromium_headless_shell-1155/chrome-linux"); \
-      nix-bundle \
-        '(builtins.getFlake "git+file:{{ root }}").packages.${builtins.currentSystem}.playwrightBrowsers' \
-        "/chromium_headless_shell-1155/chrome-linux/headless_shell"
+    #cd ("{{ artifacts }}/playwright/package/local-browsers" \
+    #  + "/chromium_headless_shell-1155/chrome-linux"); \
+    #  nix-bundle \
+    #    '(builtins.getFlake "git+file:{{ root }}").packages.${builtins.currentSystem}.playwrightBrowsers' \
+    #   "/chromium_headless_shell-1155/chrome-linux/headless_shell"
 
     # NOTE: leaving it here for future reference if linus decies nested namespaces are cool
     # mkdir "{{ artifacts }}/.playwright/node/linux-x64"

--- a/scripts/startup/ozds-server-dev.sh
+++ b/scripts/startup/ozds-server-dev.sh
@@ -4,9 +4,6 @@ root="$(dirname "${BASH_SOURCE[0]}")"
 if [ -d "$root/playwright" ]; then
   mv "$root/playwright" "$root/.playwright"
 fi
-if [ -d "$root/.playwright/package/local-browsers" ]; then
-  mv "$root/.playwright/package/local-browsers" "$root/.playwright/package/.local-browsers"
-fi
 
 if [ -n "$DIRENV_DIR" ]; then
   # NOTE: chromium is already bundled and this would lead to a double bundle to which linux says hard nope
@@ -26,8 +23,18 @@ cp -f "$root/appsettings.Development.json" "$root/appsettings.Production.json"
 
 export DEBUG=pw:api,pw:server
 export PLAYWRIGHT_BROWSERS_PATH="$root/.playwright/package/.local-browsers"
-printf "Playwright node version: %s\n" "$(bash -c "$PLAYWRIGHT_NODEJS_PATH -v")"
-printf "Playwright chromium version: %s\n" "$(bash -c "$PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-1155/chrome-linux/headless_shell --version")"
+
+if ! compgen -G "$PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-*" > /dev/null; then
+  echo "Installing Playwright chromium-headless-shell into $PLAYWRIGHT_BROWSERS_PATH..."
+  mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
+  "$PLAYWRIGHT_NODEJS_PATH" "$root/.playwright/package/cli.js" install --with-deps chromium-headless-shell
+fi
+
+printf "Playwright node version: %s\n" "$("$PLAYWRIGHT_NODEJS_PATH" -v)"
+chrome="$(compgen -G "$PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-*/chrome-linux/headless_shell" | head -n1)"
+if [ -n "$chrome" ]; then
+  printf "Playwright chromium version: %s\n" "$("$chrome" --version)"
+fi
 
 dll="$root/Ozds.Server.dll"
 cd "$root" || exit

--- a/scripts/startup/ozds-server.sh
+++ b/scripts/startup/ozds-server.sh
@@ -4,12 +4,21 @@ root="$(dirname "${BASH_SOURCE[0]}")"
 if [ -d "$root/playwright" ]; then
   mv "$root/playwright" "$root/.playwright"
 fi
-if [ -d "$root/.playwright/package/local-browsers" ]; then
-  mv "$root/.playwright/package/local-browsers" "$root/.playwright/package/.local-browsers"
-fi
 
 export PLAYWRIGHT_BROWSERS_PATH="$root/.playwright/package/.local-browsers"
 export PLAYWRIGHT_NODEJS_PATH="$root/.playwright/node/linux-x64/node"
+
+if ! compgen -G "$PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-*" > /dev/null; then
+  echo "Installing Playwright chromium-headless-shell into $PLAYWRIGHT_BROWSERS_PATH..."
+  mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
+  "$PLAYWRIGHT_NODEJS_PATH" "$root/.playwright/package/cli.js" install --with-deps chromium-headless-shell
+fi
+
+printf "Playwright node version: %s\n" "$("$PLAYWRIGHT_NODEJS_PATH" -v)"
+chrome="$(compgen -G "$PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-*/chrome-linux/headless_shell" | head -n1)"
+if [ -n "$chrome" ]; then
+  printf "Playwright chromium version: %s\n" "$("$chrome" --version)"
+fi
 
 dll="$root/Ozds.Server.dll"
 cd "$root" || exit

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17251,7 +17251,7 @@
         No results
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 132 column 16
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 131 column 16
       </Metadata>
       <Value>
         No results

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17251,7 +17251,7 @@
         No results
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 132 column 16
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 131 column 16
       </Metadata>
       <Value>
         Nema rezultata

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
@@ -72,7 +72,6 @@
                       Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search"
                       Margin="Margin.Dense"
-                      AutoFocus="true"
                       Class="ozds-searchable-select__search"/>
       </div>
        <div


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #318 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description
- Install Playwright `chromium-headless-shell` at server startup in
  `ozds-server.sh` and `ozds-server-dev.sh` when the browser directory is
  missing, instead of bundling it into the publish artifact via `nix-bundle`
- Disabled the `nix-bundle` Playwright browser step in `justfile publish`
  since browsers are now fetched on first startup
- Removed the `local-browsers` → `.local-browsers` rename step from both
  startup scripts, as `PLAYWRIGHT_BROWSERS_PATH` now points directly at
  `.local-browsers` and the runtime install creates the directory itself
- Chromium version printout in startup scripts now resolves the
  `chromium_headless_shell-*` path via `compgen` so it works regardless of
  the installed browser build number

## Testing

Tests have been done with localized builds using `just publish` and after that running the `./ozds-server-dev` shell script in WSL environment.

