### PR TITLE
Decimal limit on newly added grouped columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- `GroupedColumn` on `OzdsColumnsComponentBase` no longer takes a top-level
+  `searchable` flag and is no longer generic; sub-columns are now passed as
+  `GroupedSubColumn` items via the new `SubColumn(...)` helpers, each with its
+  own optional `searchable` flag and an optional separate label expression
+- `MeterAnalysisColumns` and `MeasurementLocationAnalysisColumns` now render
+  T1/T2 active energy sub-columns through `SubColumn(...)` with 2-decimal
+  formatting via `NumericString(..., 2)` for display while keeping the raw
+  decimal expression as the label source
+
+### Added
+
+- `GroupedSubColumn` record on `OzdsColumnsComponentBase` carrying separate
+  value and label expressions plus a per-sub-column `searchable` flag
+- `SubColumn(...)` helper overloads on `OzdsColumnsComponentBase` for building
+  `GroupedSubColumn` items either from a single expression or from a separate
+  value/label expression pair
+
 ## [1.8.4] - 2026-04-24
 
 ### Changed

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -520,48 +520,54 @@
   protected sealed record GroupedSubColumn
   (
     Expression<Func<TModel, object?>> Value,
-    Expression<Func<TModel, object?>> Label
+    Expression<Func<TModel, object?>> Label,
+    bool searchable = false
   )
   {
     public GroupedSubColumn(
-      Expression<Func<TModel, object?>> expression
-    ) : this(expression, expression)
+      Expression<Func<TModel, object?>> expression,
+      bool searchable = false
+    ) : this(expression, expression, searchable)
     {
     }
   }
 
   protected GroupedSubColumn SubColumn(
     Expression<Func<TModel, object?>> value,
-    Expression<Func<TModel, object?>> label
+    Expression<Func<TModel, object?>> label,
+    bool searchable = false
   )
   {
-    return new GroupedSubColumn(value, label);
+    return new GroupedSubColumn(value, label, searchable);
   }
 
   protected GroupedSubColumn SubColumn(
-    Expression<Func<TModel, object?>> expression
+    Expression<Func<TModel, object?>> expression,
+    bool searchable = false
   )
   {
-    return new GroupedSubColumn(expression);
+    return new GroupedSubColumn(expression, searchable);
   }
 
   protected RenderFragment GroupedColumn(
     string groupKey,
-    bool searchable = false,
     params GroupedSubColumn[] columns
   )
   {
+    // TODO: this over here can provied a lot of recalculations of expressions,
+    // check out if this entire builder class can cache it's function compilations
     var columnDefinitions =
       columns.Select(x =>
         (
           next: x.Value,
           compiled: x.Value.Compile(),
-          label: Label(x.Label)
+          label: Label(x.Label),
+          searchable: x.searchable
         )).ToArray();
 
-    if (searchable)
+    foreach (var (next, compiled, _, searchable) in columnDefinitions)
     {
-      foreach (var (next, compiled, _) in columnDefinitions)
+      if (searchable)
       {
         RegisterSearchMapper(
           next,
@@ -582,7 +588,7 @@
               <b>@Translate(groupKey)</b>
             </MudText>
             <div style="@gridStyle">
-              @foreach (var (_, _, label) in columnDefinitions)
+              @foreach (var (_, _, label, _) in columnDefinitions)
               {
                 <MudText Typo="Typo.caption">
                   @Translate(label)
@@ -593,7 +599,7 @@
         </HeaderTemplate>
         <CellTemplate>
           <div style="@gridStyle">
-            @foreach (var (_, compiled, _) in columnDefinitions)
+            @foreach (var (_, compiled, _, _) in columnDefinitions)
             {
               <MudText>@Get(compiled)(context.Item)</MudText>
             }

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -517,41 +517,56 @@
         );
     }
 
+  protected sealed record GroupedColumnItem<T>(
+    Expression<Func<TModel, T?>> Value,
+    Expression<Func<TModel, object?>> Label
+  );
+
+  protected GroupedColumnItem<T> Group<T>(
+    Expression<Func<TModel, T?>> value,
+    Expression<Func<TModel, object?>> label
+  )
+  {
+    return new GroupedColumnItem<T>(value, label);
+  }
+
   protected RenderFragment GroupedColumn<T>(
     string groupKey,
     bool searchable = false,
-    params Expression<Func<TModel, T?>>[] nextExpressions
+    params GroupedColumnItem<T>[] columns
   )
   {
-    var compiledFunctions
-        = nextExpressions.Select(e => e.Compile()).ToArray();
+    var compiledValues = columns.Select(x => x.Value.Compile()).ToArray();
+    var labels = columns.Select(x => Label(x.Label)).ToArray();
 
     if (searchable)
     {
-      foreach (var (expr, func) in nextExpressions.Zip(compiledFunctions))
+      foreach (var column in columns)
       {
-        RegisterSearchMapper(expr, x => func(x)?.ToString());
+        var valueFunc = column.Value.Compile();
+        RegisterSearchMapper(
+          column.Value,
+          x => valueFunc(x)?.ToString()
+        );
       }
     }
 
-    var cols = nextExpressions.Length;
-    var gridStyle = $"display:grid;grid-template-columns:repeat({cols},1fr);gap:.5rem;text-align:left;width:100%";
+    var cols = columns.Length;
+    var gridStyle =
+      $"display:grid;grid-template-columns:repeat({cols},1fr);gap:.5rem;text-align:left;width:100%";
 
     return Nest(
-      @<TemplateColumn
-         T="TPrefix">
+      @<TemplateColumn T="TPrefix">
         <HeaderTemplate>
           <div style="display:flex;flex-direction:column;align-items:start;width:100%;">
             <MudText Typo="Typo.body1" Align="Align.Center" Style="width:100%;">
-              <b>
-                @Translate(groupKey)
-              </b>
+              <b>@Translate(groupKey)</b>
             </MudText>
             <div style="@gridStyle">
-              @foreach (var expr in nextExpressions)
+              @foreach (var label in labels)
               {
                 <MudText Typo="Typo.caption">
-                  @Translate(Label(expr))
+                  @Translate(label)
                 </MudText>
               }
             </div>
@@ -559,11 +574,9 @@
         </HeaderTemplate>
         <CellTemplate>
           <div style="@gridStyle">
-            @foreach (var func in compiledFunctions)
+            @foreach (var func in compiledValues)
             {
-              <MudText>
-                @Get(func)(context.Item)
-              </MudText>
+              <MudText>@Get(func)(context.Item)</MudText>
             }
           </div>
         </CellTemplate>

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -521,7 +521,7 @@
   (
     Expression<Func<TModel, object?>> Value,
     Expression<Func<TModel, object?>> Label,
-    bool searchable = false
+    bool Searchable = false
   )
   {
     public GroupedSubColumn(
@@ -532,7 +532,7 @@
     }
   }
 
-  protected GroupedSubColumn SubColumn(
+  protected static GroupedSubColumn SubColumn(
     Expression<Func<TModel, object?>> value,
     Expression<Func<TModel, object?>> label,
     bool searchable = false
@@ -541,7 +541,7 @@
     return new GroupedSubColumn(value, label, searchable);
   }
 
-  protected GroupedSubColumn SubColumn(
+  protected static GroupedSubColumn SubColumn(
     Expression<Func<TModel, object?>> expression,
     bool searchable = false
   )
@@ -554,7 +554,7 @@
     params GroupedSubColumn[] columns
   )
   {
-    // TODO: this over here has a lot of recalculations of expressions,
+    // NOTE: this over here has a lot of recalculations of expressions,
     // check out if this entire builder class can cache it's function compilations
     // it could prove efficient
     var columnDefinitions =
@@ -563,7 +563,7 @@
           next: x.Value,
           compiled: x.Value.Compile(),
           label: Label(x.Label),
-          searchable: x.searchable
+          searchable: x.Searchable
         )).ToArray();
 
     foreach (var (next, compiled, _, searchable) in columnDefinitions)

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -554,8 +554,9 @@
     params GroupedSubColumn[] columns
   )
   {
-    // TODO: this over here can provied a lot of recalculations of expressions,
+    // TODO: this over here has a lot of recalculations of expressions,
     // check out if this entire builder class can cache it's function compilations
+    // it could prove efficient
     var columnDefinitions =
       columns.Select(x =>
         (

--- a/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsColumnsComponentBase.razor
@@ -517,36 +517,55 @@
         );
     }
 
-  protected sealed record GroupedColumnItem<T>(
-    Expression<Func<TModel, T?>> Value,
+  protected sealed record GroupedSubColumn
+  (
+    Expression<Func<TModel, object?>> Value,
     Expression<Func<TModel, object?>> Label
-  );
+  )
+  {
+    public GroupedSubColumn(
+      Expression<Func<TModel, object?>> expression
+    ) : this(expression, expression)
+    {
+    }
+  }
 
-  protected GroupedColumnItem<T> Group<T>(
-    Expression<Func<TModel, T?>> value,
+  protected GroupedSubColumn SubColumn(
+    Expression<Func<TModel, object?>> value,
     Expression<Func<TModel, object?>> label
   )
   {
-    return new GroupedColumnItem<T>(value, label);
+    return new GroupedSubColumn(value, label);
   }
 
-  protected RenderFragment GroupedColumn<T>(
-    string groupKey,
-    bool searchable = false,
-    params GroupedColumnItem<T>[] columns
+  protected GroupedSubColumn SubColumn(
+    Expression<Func<TModel, object?>> expression
   )
   {
-    var compiledValues = columns.Select(x => x.Value.Compile()).ToArray();
-    var labels = columns.Select(x => Label(x.Label)).ToArray();
+    return new GroupedSubColumn(expression);
+  }
+
+  protected RenderFragment GroupedColumn(
+    string groupKey,
+    bool searchable = false,
+    params GroupedSubColumn[] columns
+  )
+  {
+    var columnDefinitions =
+      columns.Select(x =>
+        (
+          next: x.Value,
+          compiled: x.Value.Compile(),
+          label: Label(x.Label)
+        )).ToArray();
 
     if (searchable)
     {
-      foreach (var column in columns)
+      foreach (var (next, compiled, _) in columnDefinitions)
       {
-        var valueFunc = column.Value.Compile();
         RegisterSearchMapper(
-          column.Value,
-          x => valueFunc(x)?.ToString()
+          next,
+          x => compiled(x)?.ToString()
         );
       }
     }
@@ -563,7 +582,7 @@
               <b>@Translate(groupKey)</b>
             </MudText>
             <div style="@gridStyle">
-              @foreach (var label in labels)
+              @foreach (var (_, _, label) in columnDefinitions)
               {
                 <MudText Typo="Typo.caption">
                   @Translate(label)
@@ -574,9 +593,9 @@
         </HeaderTemplate>
         <CellTemplate>
           <div style="@gridStyle">
-            @foreach (var func in compiledValues)
+            @foreach (var (_, compiled, _) in columnDefinitions)
             {
-              <MudText>@Get(func)(context.Item)</MudText>
+              <MudText>@Get(compiled)(context.Item)</MudText>
             }
           </div>
         </CellTemplate>

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
@@ -13,15 +13,27 @@
 @GroupedColumn(
   "ActiveEnergyLastMonth",
   false,
-  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh,
-  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+  Group(
+    x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
+    x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+  ),
+  Group(
+    x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
+    x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+  )
 )
 
 @GroupedColumn(
   "ActiveEnergyThisMonth",
   false,
-  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh,
-  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+  Group(
+    x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
+    x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+  ),
+  Group(
+    x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
+    x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+  )
 )
 
 @Column(x => x.Analysis.LastMonthExpenses.Total_EUR)

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
@@ -12,7 +12,6 @@
 
 @GroupedColumn(
   "ActiveEnergyLastMonth",
-  false,
   SubColumn(
     x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
@@ -25,7 +24,6 @@
 
 @GroupedColumn(
   "ActiveEnergyThisMonth",
-  false,
   SubColumn(
     x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeasurementLocationAnalysisColumns.razor
@@ -13,11 +13,11 @@
 @GroupedColumn(
   "ActiveEnergyLastMonth",
   false,
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
   ),
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
     x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
   )
@@ -26,11 +26,11 @@
 @GroupedColumn(
   "ActiveEnergyThisMonth",
   false,
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
   ),
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
     x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
   )

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
@@ -11,11 +11,11 @@
 @GroupedColumn(
   "ActiveEnergyLastMonth",
   false,
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
   ),
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
     x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
   )
@@ -24,11 +24,11 @@
 @GroupedColumn(
   "ActiveEnergyThisMonth",
   false,
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
   ),
-  Group(
+  SubColumn(
     x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
     x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
   )

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
@@ -10,7 +10,6 @@
 
 @GroupedColumn(
   "ActiveEnergyLastMonth",
-  false,
   SubColumn(
     x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
@@ -23,7 +22,6 @@
 
 @GroupedColumn(
   "ActiveEnergyThisMonth",
-  false,
   SubColumn(
     x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
     x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh

--- a/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/Analyses/MeterAnalysisColumns.razor
@@ -11,15 +11,27 @@
 @GroupedColumn(
   "ActiveEnergyLastMonth",
   false,
-  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh,
-  x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+  Group(
+    x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
+    x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff1_kWh
+  ),
+  Group(
+    x => NumericString(x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
+    x => x.Analysis.LastMonthConsumption.ActiveEnergy_Tariff2_kWh
+  )
 )
 
 @GroupedColumn(
   "ActiveEnergyThisMonth",
   false,
-  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh,
-  x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+  Group(
+    x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh, 2),
+    x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff1_kWh
+  ),
+  Group(
+    x => NumericString(x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh, 2),
+    x => x.Analysis.ThisMonthConsumption.ActiveEnergy_Tariff2_kWh
+  )
 )
 
 @Column(x => x.Analysis.LastMonthExpenses.Total_EUR)


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #319 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- `GroupedColumn` on `OzdsColumnsComponentBase` no longer takes a top-level
  `searchable` flag and is no longer generic; sub-columns are now passed as
  `GroupedSubColumn` items via the new `SubColumn(...)` helpers, each with its
  own optional `searchable` flag and an optional separate label expression
- `MeterAnalysisColumns` and `MeasurementLocationAnalysisColumns` now render
  T1/T2 active energy sub-columns through `SubColumn(...)` with 2-decimal
  formatting via `NumericString(..., 2)` for display while keeping the raw
  decimal expression as the label source

### Added

- `GroupedSubColumn` record on `OzdsColumnsComponentBase` carrying separate
  value and label expressions plus a per-sub-column `searchable` flag
- `SubColumn(...)` helper overloads on `OzdsColumnsComponentBase` for building
  `GroupedSubColumn` items either from a single expression or from a separate
  value/label expression pair

## Testing

Localized server testing with command `just fake insert` to fill up values. Also try setting each column with searchable and see if you can get different results.


