### PR TITLE
Measurement procedure compilation optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Refactored `ShouldClamp` helper in `MeasurementProcedureCompiler` to check
+  positively for floating-point CLR types (`decimal`, `float`, `double`) instead
+  of negatively excluding the eight integer types (`byte`, `sbyte`, `short`,
+  `ushort`, `int`, `uint`, `long`, `ulong`) for improved readability
+
 ## [1.8.4] - 2026-04-24
 
 ### Changed

--- a/src/Ozds.Data/Procedures/Compilers/MeasurementProcedureCompiler.cs
+++ b/src/Ozds.Data/Procedures/Compilers/MeasurementProcedureCompiler.cs
@@ -318,14 +318,9 @@ public static class MeasurementProcedureCompiler
         GetPropertyClrType(context, aggregateType, propertyName)
       ) ?? GetPropertyClrType(context, aggregateType, propertyName);
 
-    return clrType != typeof(byte)
-      && clrType != typeof(sbyte)
-      && clrType != typeof(short)
-      && clrType != typeof(ushort)
-      && clrType != typeof(int)
-      && clrType != typeof(uint)
-      && clrType != typeof(long)
-      && clrType != typeof(ulong);
+    return clrType == typeof(decimal)
+      || clrType == typeof(float)
+      || clrType == typeof(double);
   }
 
   private static string UpsertAverage(


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- Refactored `ShouldClamp` helper in `MeasurementProcedureCompiler` to check
  positively for floating-point CLR types (`decimal`, `float`, `double`) instead
  of negatively excluding the eight integer types (`byte`, `sbyte`, `short`,
  `ushort`, `int`, `uint`, `long`, `ulong`) for improved readability
