### PR TITLE
325 after dropping all of the items from chart multiselect chart starts to glitch out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and adheres to [Semantic Versioning](https://semver.org/).
   empty selection (no measurement locations and no meters) first and otherwise
   renders the `ApexChart`, relying on ApexCharts' built-in no-data state when
   `Measurements.Items` is empty; the previous `if (items.Count == 0)` fallback
-  in `GetItems()` and the `Series` fallback to `Parameters.Measurements.Items`
-  when no meter/location is supplied have been removed
+  in `GetItems()` has been removed, and the `Series` fallback to
+  `Parameters.Measurements.Items` when no meter/location is supplied has been
+  dropped (the empty-selection branch makes that case unreachable)
 - `MeasurementChartHeader` now displays a translated empty-state message in
   place of the measure/unit/time-span text when no measurement location or meter
   is selected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and adheres to [Semantic Versioning](https://semver.org/).
   T1/T2 active energy sub-columns through `SubColumn(...)` with 2-decimal
   formatting via `NumericString(..., 2)` for display while keeping the raw
   decimal expression as the label source
+- `MeasurementLineChart` reorders its conditional rendering to check for an
+  empty selection (no measurement locations and no meters) first and otherwise
+  renders the `ApexChart`, relying on ApexCharts' built-in no-data state when
+  `Measurements.Items` is empty; the previous `if (items.Count == 0)` fallback
+  in `GetItems()` and the `Series` fallback to `Parameters.Measurements.Items`
+  when no meter/location is supplied have been removed
+- `MeasurementChartHeader` now displays a translated empty-state message in
+  place of the measure/unit/time-span text when no measurement location or
+  meter is selected
+- `MeasurementChartControls` disables the Measure, Phase, Multiplier,
+  Resolution, and Refresh fields when no measurement location or meter is
+  selected via a local `isNothingSelected` flag
 
 ### Added
 
@@ -31,6 +43,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - `SubColumn(...)` helper overloads on `OzdsColumnsComponentBase` for building
   `GroupedSubColumn` items either from a single expression or from a separate
   value/label expression pair
+- `Disabled` parameter on `EnumPicker` and `MultiEnumPicker`, forwarded to the
+  inner `SelectField` and propagated to MudBlazor's `MudSelect` via captured
+  attributes
+- Translations `No measurement locations/meters are selected for display` and
+  `No measurement location or meter selected` in `en.xml` and `hr.xml`
 
 ## [1.8.4] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
   in `GetItems()` and the `Series` fallback to `Parameters.Measurements.Items`
   when no meter/location is supplied have been removed
 - `MeasurementChartHeader` now displays a translated empty-state message in
-  place of the measure/unit/time-span text when no measurement location or
-  meter is selected
+  place of the measure/unit/time-span text when no measurement location or meter
+  is selected
 - `MeasurementChartControls` disables the Measure, Phase, Multiplier,
   Resolution, and Refresh fields when no measurement location or meter is
   selected via a local `isNothingSelected` flag

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -14146,7 +14146,7 @@
         Measure
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 66 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 70 column 19
       </Metadata>
       <Value>
         Measure
@@ -16467,7 +16467,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 64 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 87 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 19
       </Metadata>
       <Value>
         Multiplier
@@ -16478,7 +16478,7 @@
         Multiply the selected time unit to get wanted span of time
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 82 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 89 column 51
       </Metadata>
       <Value>
         Multiply the selected time unit to get the desired time span
@@ -17229,7 +17229,7 @@
         No measurement location or meter selected
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 12 column 18
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 12 column 8
       </Metadata>
       <Value>
         No measurement location or meter selected
@@ -17248,22 +17248,11 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
-        No measurements found with given graph settings
-      </Key>
-      <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 16 column 38
-      </Metadata>
-      <Value>
-        No measurements found with the selected graph settings
-      </Value>
-    </TranslationDictionaryItem>
-    <TranslationDictionaryItem>
-      <Key>
         None
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 25 column 12
-        From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 26 column 12
+        From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 26 column 12
+        From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 27 column 12
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
@@ -17625,7 +17614,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartHeader.razor' line 26 column 10
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 32 column 10
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 40 column 14
       </Metadata>
       <Value>
         over the last
@@ -17696,7 +17685,7 @@
         Phase
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 77 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 83 column 19
       </Metadata>
       <Value>
         Phase
@@ -17709,8 +17698,8 @@
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementDonutChart.razor' line 65 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementGaugeChart.razor' line 63 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 70 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 45 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 71 column 9
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
       </Metadata>
       <Value>
         Phase total
@@ -17721,7 +17710,7 @@
         Phase(s) for given measure, if empty, display sum of all phases
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 72 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 78 column 51
       </Metadata>
       <Value>
         Phase(s) for given measurement; if empty, display sum of all phases
@@ -19856,8 +19845,8 @@
         Refresh
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 110 column 21
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 118 column 23
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 119 column 21
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 128 column 23
       </Metadata>
       <Value>
         Refresh
@@ -20344,7 +20333,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 57 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 99 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 107 column 19
       </Metadata>
       <Value>
         Resolution
@@ -22753,7 +22742,7 @@
         or new measurement comes in
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 104 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 113 column 51
       </Metadata>
       <Value>
         Toggle auto-refresh, updates display when parameters change or new
@@ -23438,7 +23427,7 @@
         Unit of time used in defining the span of time for the display
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 102 column 51
       </Metadata>
       <Value>
         Time unit for display span

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17226,10 +17226,32 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        No measurement location or meter selected
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 12 column 18
+      </Metadata>
+      <Value>
+        No measurement location or meter selected
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        No measurement locations/meters are selected for display
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
+      </Metadata>
+      <Value>
+        No measurement locations or meters are selected for display
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         No measurements found with given graph settings
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 45 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 16 column 38
       </Metadata>
       <Value>
         No measurements found with the selected graph settings

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17226,10 +17226,32 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        No measurement location or meter selected
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 12 column 18
+      </Metadata>
+      <Value>
+        Nije odabrano mjerno mjesto ili brojilo
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        No measurement locations/meters are selected for display
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
+      </Metadata>
+      <Value>
+        Nije odabrano nijedno mjerno mjesto ili brojilo za prikaz
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         No measurements found with given graph settings
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 45 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 16 column 38
       </Metadata>
       <Value>
         Nema pronađenih mjerenja s danim postavkama grafa

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -14145,7 +14145,7 @@
         Measure
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 66 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 70 column 19
       </Metadata>
       <Value>
         Mjera
@@ -16466,7 +16466,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 64 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 87 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 19
       </Metadata>
       <Value>
         Množitelj
@@ -16477,7 +16477,7 @@
         Multiply the selected time unit to get wanted span of time
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 82 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 89 column 51
       </Metadata>
       <Value>
         Pomnožite odabranu vremensku jedinicu da dobijete željeni vremenski
@@ -17229,7 +17229,7 @@
         No measurement location or meter selected
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 12 column 18
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 12 column 8
       </Metadata>
       <Value>
         Nije odabrano mjerno mjesto ili brojilo
@@ -17248,22 +17248,11 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
-        No measurements found with given graph settings
-      </Key>
-      <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 16 column 38
-      </Metadata>
-      <Value>
-        Nema pronađenih mjerenja s danim postavkama grafa
-      </Value>
-    </TranslationDictionaryItem>
-    <TranslationDictionaryItem>
-      <Key>
         None
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 25 column 12
-        From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 26 column 12
+        From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 26 column 12
+        From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 27 column 12
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
@@ -17625,7 +17614,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartHeader.razor' line 26 column 10
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 32 column 10
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor' line 40 column 14
       </Metadata>
       <Value>
         u posljednjih
@@ -17744,7 +17733,7 @@
         Phase
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 77 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 83 column 19
       </Metadata>
       <Value>
         Faza
@@ -17757,8 +17746,8 @@
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementDonutChart.razor' line 65 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementGaugeChart.razor' line 63 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 70 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 45 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 71 column 9
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
       </Metadata>
       <Value>
         Zbroj faza
@@ -17769,7 +17758,7 @@
         Phase(s) for given measure, if empty, display sum of all phases
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 72 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 78 column 51
       </Metadata>
       <Value>
         Faza(e) za određeno mjerenje, ako je prazno, prikazuje zbroj svih faza
@@ -19900,8 +19889,8 @@
         Refresh
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 110 column 21
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 118 column 23
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 119 column 21
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 128 column 23
       </Metadata>
       <Value>
         Osvježi
@@ -20388,7 +20377,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 57 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 99 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 107 column 19
       </Metadata>
       <Value>
         Rezolucija
@@ -22799,7 +22788,7 @@
         or new measurement comes in
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 104 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 113 column 51
       </Metadata>
       <Value>
         Dinamičko osvježavanje, osvježava prikaz nakon promjene parametra ili
@@ -23484,7 +23473,7 @@
         Unit of time used in defining the span of time for the display
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 102 column 51
       </Metadata>
       <Value>
         Jedinica vremena korištena za definiranje vremenskog raspona prikaza

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor
@@ -58,6 +58,10 @@
         </MudSelect>
       </MudItem>
     }
+    @{
+      var isNothingSelected = _parameters.MeasurementLocations.Count == 0
+        && _parameters.Meters.Count == 0;
+    }
     <MudItem xs="12" sm="6" md="4">
       <MudTooltip RootClass="wide-tooltip" Text="Select type of measure">
         <EnumPicker
@@ -65,7 +69,9 @@
           @bind-Value="@_parameters.Measure"
           Title="@Translate("Measure")"
           Values="@Measures()"
-          Label="@(x => Translate(x.ToString()))"/>
+          Label="@(x => Translate(x.ToString()))"
+          Disabled="@isNothingSelected"
+          />
       </MudTooltip>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
@@ -75,7 +81,8 @@
           Value="@_parameters.Phases"
           ValueChanged="@(e => _parameters.Phases = e.ToHashSet())"
           Title="@Translate("Phase")"
-          Label="@(x => Translate(x.ToString()))"/>
+          Label="@(x => Translate(x.ToString()))"
+          Disabled="@isNothingSelected"/>
       </MudTooltip>
     </MudItem>
     <MudItem xs="12" sm="6" md="1">
@@ -87,7 +94,8 @@
           Label="@Translate("Multiplier")"
           Min="1"
           Max="@_parameters.Resolution.MaxMultiplier()"
-          Step="1"/>
+          Step="1"
+          Disabled="@isNothingSelected"/>
       </MudTooltip>
     </MudItem>
     <MudItem xs="12" sm="6" md="1">
@@ -97,7 +105,8 @@
           Value="@_parameters.Resolution"
           ValueChanged="@OnResolutionChanged"
           Title="@Translate("Resolution")"
-          Label="@(x => Translate(x.ToString()))"/>
+          Label="@(x => Translate(x.ToString()))"
+          Disabled="@isNothingSelected"/>
       </MudTooltip>
     </MudItem>
     <MudItem xs="12" md="10">
@@ -107,7 +116,8 @@
             T="bool"
             Value="@_parameters.Refresh"
             ValueChanged="@OnRefreshChanged"
-            Label="@Translate("Refresh")"/>
+            Label="@Translate("Refresh")"
+            Disabled="@isNothingSelected"/>
         </MudHidden>
         <MudHidden Breakpoint="Breakpoint.SmAndDown">
           <div class="d-flex justify-end pe-4">
@@ -115,7 +125,8 @@
               T="bool"
               Value="@_parameters.Refresh"
               ValueChanged="@OnRefreshChanged"
-              Label="@Translate("Refresh")"/>
+              Label="@Translate("Refresh")"
+              Disabled="@isNothingSelected"/>
           </div>
         </MudHidden>
       </MudTooltip>

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor
@@ -6,34 +6,44 @@
 
 <div class="d-flex justify-center">
   <MudText>
-    @if (Parameters.Meters.Count() == 1)
+    @if (Parameters.Meters.Count == 0
+      && Parameters.MeasurementLocations.Count == 0)
     {
-      @Translate(Parameters.Meters.FirstOrDefault()!.Title)
-      <Fragment>
-        &nbsp;
-      </Fragment>
+      @Translate("No measurement location or meter selected")
     }
-    @if (Parameters.MeasurementLocations.Count() == 1)
-    {
-      @Translate(Parameters.MeasurementLocations.FirstOrDefault()!.Title)
-      <Fragment>
-        &nbsp;
-      </Fragment>
-    }
-    @Translate(Parameters.Measure.ToString())
-    &nbsp;
-    &lbrack;
-    @Translate(Parameters.Measure.ToUnit())
-    &rbrack;
-    &nbsp;
-    @if (Parameters.Operator != OperatorModel.Last)
+    else
     {
       <Fragment>
-        @Translate("over the last")
+        @if (Parameters.Meters.Count() == 1)
+        {
+          @Translate(Parameters.Meters.FirstOrDefault()!.Title)
+          <Fragment>
+            &nbsp;
+          </Fragment>
+        }
+        @if (Parameters.MeasurementLocations.Count() == 1)
+        {
+          @Translate(Parameters.MeasurementLocations.FirstOrDefault()!.Title)
+          <Fragment>
+            &nbsp;
+          </Fragment>
+        }
+        @Translate(Parameters.Measure.ToString())
         &nbsp;
-        @(Parameters.Multiplier == 1 ? "" : Parameters.Multiplier.ToString())
+        &lbrack;
+        @Translate(Parameters.Measure.ToUnit())
+        &rbrack;
         &nbsp;
-        @Translate(Parameters.Resolution.ToString())
+        @if (Parameters.Operator != OperatorModel.Last)
+        {
+          <Fragment>
+            @Translate("over the last")
+            &nbsp;
+            @(Parameters.Multiplier == 1 ? "" : Parameters.Multiplier.ToString())
+            &nbsp;
+            @Translate(Parameters.Resolution.ToString())
+          </Fragment>
+        }
       </Fragment>
     }
   </MudText>

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartHeader.razor
@@ -14,14 +14,14 @@
     else
     {
       <Fragment>
-        @if (Parameters.Meters.Count() == 1)
+        @if (Parameters.Meters.Count == 1)
         {
           @Translate(Parameters.Meters.FirstOrDefault()!.Title)
           <Fragment>
             &nbsp;
           </Fragment>
         }
-        @if (Parameters.MeasurementLocations.Count() == 1)
+        @if (Parameters.MeasurementLocations.Count == 1)
         {
           @Translate(Parameters.MeasurementLocations.FirstOrDefault()!.Title)
           <Fragment>

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
@@ -47,7 +47,6 @@ else
 }
 
 @code {
-
   private RenderFragment Series(
     string color,
     IMeter? meter = null,
@@ -55,16 +54,17 @@ else
     PhaseModel? phase = null
   )
   {
+    // NOTE: If both are null then this method even won't run,
+    // so no need to make a ternary check
+    // for reference check upper chart if statement
     var measurements = meter is { } measurementMeter
       ? Parameters.Measurements.Items
         .Where(x => x.MeterId == measurementMeter.Id)
         .ToList()
-      : measurementLocation is { } measurementMeasurementLocation
-        ? Parameters.Measurements.Items
-          .Where(x =>
-            x.MeasurementLocationId == measurementMeasurementLocation?.Id)
-          .ToList()
-        : new List<IMeasurement>();
+      : Parameters.Measurements.Items
+        .Where(x =>
+          x.MeasurementLocationId == measurementLocation?.Id)
+        .ToList();
 
     var phaseName = phase is { } selectedPhase
       ? Translate(selectedPhase.ToString())
@@ -98,5 +98,4 @@ else
 
     return items;
   }
-
 }

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
@@ -3,9 +3,15 @@
 @using Ozds.Business.Models.Abstractions
 @using Ozds.Business.Models.Enums
 @inherits Ozds.Client.Components.Base.OzdsComponentBase
-@if (Parameters.MeasurementLocations.Count > 0
-  || Parameters.Meters.Count > 0
-  || Parameters.Measurements.Items.Count > 0)
+
+@if (Parameters.MeasurementLocations.Count == 0
+  && Parameters.Meters.Count == 0)
+{
+  <div style="height:300px; display: grid; align-items: center;">
+    <h2 style="text-align: center;">@Translate("No measurement locations/meters are selected for display")</h2>
+  </div>
+}
+else
 {
   <ApexChart
     XAxisType="@XAxisType.Datetime"
@@ -39,12 +45,6 @@
     }
   </ApexChart>
 }
-else
-{
-  <div style="height:300px; display: grid; align-items: center;">
-    <h2 style="text-align: center;">@Translate("No measurements found with given graph settings")</h2>
-  </div>
-}
 
 @code {
 
@@ -64,7 +64,8 @@ else
           .Where(x =>
             x.MeasurementLocationId == measurementMeasurementLocation?.Id)
           .ToList()
-        : Parameters.Measurements.Items;
+        : new List<IMeasurement>();
+
     var phaseName = phase is { } selectedPhase
       ? Translate(selectedPhase.ToString())
       : Translate("Phase sum");
@@ -94,11 +95,6 @@ else
           .OrderBy(x => x.Id)
           .Select((x, i) => ((IMeter?)null, (IMeasurementLocation?)x, i)))
       .ToList();
-
-    if (items.Count == 0)
-    {
-      items.Add((null, null, 0));
-    }
 
     return items;
   }

--- a/src/Ozds.Client/Components/Fields/EnumPicker.cs
+++ b/src/Ozds.Client/Components/Fields/EnumPicker.cs
@@ -25,4 +25,7 @@ public partial class EnumPicker<T> : OzdsComponentBase
 
   [Parameter]
   public IEnumerable Values { get; set; } = typeof(T).GetNullableEnumValues();
+
+  [Parameter]
+  public bool Disabled { get; set; }
 }

--- a/src/Ozds.Client/Components/Fields/EnumPicker.razor
+++ b/src/Ozds.Client/Components/Fields/EnumPicker.razor
@@ -8,7 +8,8 @@
   Label="@Title"
   Value="@Value"
   ValueChanged="@ValueChanged"
-  For="For">
+  For="For"
+  Disabled="@Disabled">
   @foreach (var item in Values)
   {
     var typed = (T)item;

--- a/src/Ozds.Client/Components/Fields/MultiEnumPicker.cs
+++ b/src/Ozds.Client/Components/Fields/MultiEnumPicker.cs
@@ -24,4 +24,7 @@ public partial class MultiEnumPicker<T> : OzdsComponentBase
 
   [Parameter]
   public IEnumerable Values { get; set; } = Enum.GetValues(typeof(T));
+
+  [Parameter]
+  public bool Disabled { get; set; }
 }

--- a/src/Ozds.Client/Components/Fields/MultiEnumPicker.razor
+++ b/src/Ozds.Client/Components/Fields/MultiEnumPicker.razor
@@ -9,7 +9,8 @@
   SelectedValues="@Value"
   SelectedValuesChanged="@ValueChanged"
   MultiSelection
-  For="For">
+  For="For"
+  Disabled="@Disabled">
   @foreach (var item in Values)
   {
     var typed = (T)item;


### PR DESCRIPTION
# Task

Fixes #325 

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Root cause

As explained in the `Appendix` section of, the issue is intentional letting of the added buffered measurements even though none of the available measurement locations nor meters are selected, which then messes up the display on the line chart. 

The buffered measurements are appended for all available meters and measurement locations in the `Refresh()` method of the `MeasurementChartControls.cs`, they are then later filtered for the selected under the `Series()` method in the `MeasurementLineChart.cs`, this implementation kinda splits logic for fetching on both chart and it's wrapper - chart controls. And again primary method in `MeasurementChartControls.cs` fetches by selected items rather than fetching all of them as in `Refresh()` method.

example: 

Typical read part of the `Fetch()` method that uses id bound queries from `Ozds.Business`

```cs
 var fromMeters = await queries.ReadByMeterIds(
   _parameters.Meters.Select(x => x.Id).ToList(),
   _parameters.Resolution,
   _parameters.Multiplier,
   CancellationToken,
   fromDate: fromDate,
   toDate: toDate
 );
 var fromMeasurementLocations = await queries.ReadByMeasurementLocationIds(
   _parameters.MeasurementLocations.Select(x => x.Id).ToList(),
   _parameters.Resolution,
   _parameters.Multiplier,
   CancellationToken,
   fromDate,
   toDate
 );
```

`OnMeasurementsBuffered()` method just appends measurements added onto the buffer which `Refresh()` just adds as the parameter measurements.  

```cs
Refresh(args.Measurements.ToList(), new List<IAggregate>());
```

The mixed measurements are then filtered out for chart in the `MeasurementLineChart.cs`.

```cs
var measurements = meter is { } measurementMeter
  ? Parameters.Measurements.Items
    .Where(x => x.MeterId == measurementMeter.Id)
    .ToList()
  : measurementLocation is { } measurementMeasurementLocation
    ? Parameters.Measurements.Items
      .Where(x =>
        x.MeasurementLocationId == measurementMeasurementLocation?.Id)
      .ToList()
    : Parameters.Measurements.Items;
```
Note the `Parameters.Measurements.Items` as a last ditch return. 

I've decided to remove this "feature" since it poses no significant gain and it's really hard to see why it would be even used other than for quick debugging on push. On production it displays stuff like this:

<img width="1386" height="398" alt="Snimka zaslona 2026-05-05 083835" src="https://github.com/user-attachments/assets/de153668-7a5d-474e-9bb6-ba9651cd2be4" />

Which gains no actual value to the viewer. 

Also since no `IMeter` nor `IMeasurementLocation` derived instances are processed or passed to the chart, it just passes default tuple with null values 

```cs
if (items.Count == 0)
{
  items.Add((null, null, 0));
}
```

this triggers measure type dropdown to not recieve any data, and it defaults to `ActivePower`.

<img width="445" height="92" alt="Snimka zaslona 2026-05-05 084112" src="https://github.com/user-attachments/assets/28cb5ea3-9700-48cc-8067-96b5ddf939cf" />

This also happens on this PR but it's not a problem since nothing will be processed nor displayed on the chart, and all of the possible selection fields are disabled if no meter or measurement location is selected.

#### I've would also like to propose in this PR to add issue onto backlog to determine if the chart side filtering onto buffered measurements is even needed, and if not, to switch logic onto `MeasurementChartControls.cs`.

### Changed

- `MeasurementLineChart` reorders its conditional rendering to check for an
  empty selection (no measurement locations and no meters) first and otherwise
  renders the `ApexChart`, relying on ApexCharts' built-in no-data state when
  `Measurements.Items` is empty; the previous `if (items.Count == 0)` fallback
  in `GetItems()` and the `Series` fallback to `Parameters.Measurements.Items`
  when no meter/location is supplied have been removed
- `MeasurementChartHeader` now displays a translated empty-state message in
  place of the measure/unit/time-span text when no measurement location or meter
  is selected
- `MeasurementChartControls` disables the Measure, Phase, Multiplier,
  Resolution, and Refresh fields when no measurement location or meter is
  selected via a local `isNothingSelected` flag

### Added

- `Disabled` parameter on `EnumPicker` and `MultiEnumPicker`, forwarded to the
  inner `SelectField` and propagated to MudBlazor's `MudSelect` via captured
  attributes
- Translations `No measurement locations/meters are selected for display` and
  `No measurement location or meter selected` in `en.xml` and `hr.xml`


## Testing


