### PR TITLE
Search function at chart selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - `MeasurementLineChart` wraps the chart and its empty-state placeholder in a
   fixed-height container so chart re-renders no longer shift the chart-control
   selection fields above it
+- `MudTooltip` overlays in `MeasurementChartControls` no longer block pointer
+  events on the underlying fields; added a global
+  `.mud-tooltip { pointer-events: none; }` rule and set `ShowOnFocus="false"` on
+  the measure, phase, and multiplier tooltips so they no longer intercept clicks
+  or steal focus
+- `SelectField` dropdown no longer opens and immediately closes when clicked;
+  removed the wrapper `<div @onpointerup="() => _inner.OpenMenu()">` and the
+  `MudSelect _inner` ref that double-toggled the menu against `MudSelect`'s own
+  click handling
 
 ### Added
 
@@ -58,6 +67,25 @@ and adheres to [Semantic Versioning](https://semver.org/).
   attributes
 - Translations `No measurement locations/meters are selected for display` and
   `No measurement location or meter selected` in `en.xml` and `hr.xml`
+- `SearchableSelectField<T>` component in `Ozds.Client.Components.Fields`, a
+  custom dropdown built on `MudPopover`, `MudList`, and `MudTextField`,
+  providing search-as-you-type filtering with a case-sensitivity toggle, single-
+  and multi-selection over arbitrary `ICollection<T>` collections, optional
+  `ItemTemplate`, full keyboard navigation (ArrowUp/Down/Home/End to move the
+  highlight, Enter to select, Escape to close, Tab to swap focus between search
+  and list), a highlighted-row state with primary-tinted background and
+  auto-scroll-into-view, plus per-render caching of the filtered list
+  (invalidated on search/case/`Items` changes) and a `HashSet`-backed
+  selected-value lookup for O(n) multi-selection rendering
+- Collocated `searchable-select-field.js` ES module loaded on first render via
+  `IJSRuntime.InvokeAsync<IJSObjectReference>("import", ...)` and released on
+  `IAsyncDisposable.DisposeAsync`, exposing a single `scrollItemIntoView(id)`
+  helper that calls `scrollIntoView({ block: 'nearest', behavior: 'instant' })`
+- `ozds-searchable-select__item--highlighted` style in `app.css` using
+  `--mud-palette-primary-hover` background and `--mud-palette-primary` text to
+  match MudBlazor's primary-selected visual treatment, with selector specificity
+  bumped via `.mud-list-item-clickable` so it wins over the default hover
+  background
 
 ## [1.8.4] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - `MeasurementChartControls` disables the Measure, Phase, Multiplier,
   Resolution, and Refresh fields when no measurement location or meter is
   selected via a local `isNothingSelected` flag
+- `MeasurementChartControls` now uses the new `SearchableSelectField` instead of
+  plain `MudSelect` for both meters and measurement locations, with consistent
+  `MudTooltip` wrappers showing the full list of current selections; the
+  `OnMeasurementLocationsChanged` and `OnMetersChanged` callbacks now receive
+  `IMeasurementLocation`/`IMeter` instances directly instead of resolving them
+  from string ids
+- `MeasurementLineChart` wraps the chart and its empty-state placeholder in a
+  fixed-height container so chart re-renders no longer shift the chart-control
+  selection fields above it
 
 ### Added
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,6 @@
     <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
     <PackageVersion Include="MudBlazor" Version="8.6.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
-    <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.3.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Tizzani.MudBlazor.HtmlEditor" Version="2.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,10 +10,7 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion
-      Include="Altibiz.DependencyInjection.Extensions"
-      Version="1.0.10"
-    />
+    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -25,75 +22,28 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Design"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.Proxies"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.EntityFrameworkCore.InMemory"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.NamingConventions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="EFCore.BulkExtensions"
-      Version="$(EntityFrameworkCoreVersion)"
-    />
-    <PackageVersion
-      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
-      Version="8.0.4"
-    />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion
-      Include="Quartz.Serialization.SystemTextJson"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.DependencyInjection"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="Quartz.Extensions.Hosting"
-      Version="$(QuartzVersion)"
-    />
-    <PackageVersion
-      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
-      Version="0.5.1"
-    />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion
-      Include="MassTransit.RabbitMQ"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.Azure.ServiceBus.Core"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="MassTransit.EntityFrameworkCore"
-      Version="$(MassTransitVersion)"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
-      Version="8.0.17"
-    />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Authentication.Cookies"
-      Version="2.3.0"
-    />
-    <PackageVersion
-      Include="Novell.Directory.Ldap.NETStandard"
-      Version="3.6.0"
-    />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
+    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
     <PackageVersion Include="MudBlazor" Version="8.6.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
+    <PackageVersion Include="CodeBeam.MudBlazor.Extensions" Version="8.3.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Tizzani.MudBlazor.HtmlEditor" Version="2.3.0" />
@@ -104,10 +54,7 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.Mvc.Testing"
-      Version="8.0.17"
-    />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,10 @@
     <MassTransitVersion>8.2.2</MassTransitVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Altibiz.DependencyInjection.Extensions" Version="1.0.10" />
+    <PackageVersion
+      Include="Altibiz.DependencyInjection.Extensions"
+      Version="1.0.10"
+    />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
@@ -22,25 +25,73 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.50.0" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.NamingConventions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="EFCore.BulkExtensions" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Design"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.Proxies"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.EntityFrameworkCore.InMemory"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.NamingConventions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="EFCore.BulkExtensions"
+      Version="$(EntityFrameworkCoreVersion)"
+    />
+    <PackageVersion
+      Include="Npgsql.EntityFrameworkCore.PostgreSQL"
+      Version="8.0.4"
+    />
     <PackageVersion Include="Z.EntityFramework.Plus.EFCore" Version="8.101.2" />
     <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
+    <PackageVersion
+      Include="Quartz.Serialization.SystemTextJson"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.DependencyInjection"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="Quartz.Extensions.Hosting"
+      Version="$(QuartzVersion)"
+    />
+    <PackageVersion
+      Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL"
+      Version="0.5.1"
+    />
     <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="$(MassTransitVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
-    <PackageVersion Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+    <PackageVersion
+      Include="MassTransit.RabbitMQ"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.Azure.ServiceBus.Core"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="MassTransit.EntityFrameworkCore"
+      Version="$(MassTransitVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"
+      Version="8.0.17"
+    />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Authentication.Cookies"
+      Version="2.3.0"
+    />
+    <PackageVersion
+      Include="Novell.Directory.Ldap.NETStandard"
+      Version="3.6.0"
+    />
     <PackageVersion Include="MudBlazor" Version="8.6.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="5.0.1" />
@@ -53,7 +104,10 @@
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Testcontainers" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion
+      Include="Microsoft.AspNetCore.Mvc.Testing"
+      Version="8.0.17"
+    />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17240,7 +17240,7 @@
         No measurement locations/meters are selected for display
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 12 column 40
       </Metadata>
       <Value>
         No measurement locations or meters are selected for display
@@ -17251,7 +17251,7 @@
         No results
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 133 column 16
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 132 column 16
       </Metadata>
       <Value>
         No results
@@ -17709,8 +17709,8 @@
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementDonutChart.razor' line 65 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementGaugeChart.razor' line 63 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 74 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 76 column 9
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 12 column 40
       </Metadata>
       <Value>
         Phase total

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -6515,7 +6515,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 15 column 10
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 15 column 10
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 16 column 10
       </Metadata>
       <Value>
         Chart controls
@@ -14146,7 +14146,7 @@
         Measure
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 70 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 62 column 19
       </Metadata>
       <Value>
         Measure
@@ -14209,7 +14209,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 22 column 19
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 29 column 21
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 26 column 21
       </Metadata>
       <Value>
         Measurement points
@@ -15378,7 +15378,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 40 column 19
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 48 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 44 column 21
       </Metadata>
       <Value>
         Meters
@@ -16467,7 +16467,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 64 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 86 column 19
       </Metadata>
       <Value>
         Multiplier
@@ -16478,7 +16478,7 @@
         Multiply the selected time unit to get wanted span of time
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 89 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 81 column 71
       </Metadata>
       <Value>
         Multiply the selected time unit to get the desired time span
@@ -17248,6 +17248,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        No results
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 133 column 16
+      </Metadata>
+      <Value>
+        No results
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         None
       </Key>
       <Metadata>
@@ -17685,7 +17696,7 @@
         Phase
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 83 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 75 column 19
       </Metadata>
       <Value>
         Phase
@@ -17698,7 +17709,7 @@
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementDonutChart.razor' line 65 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementGaugeChart.razor' line 63 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 71 column 9
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 74 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
       </Metadata>
       <Value>
@@ -17710,7 +17721,7 @@
         Phase(s) for given measure, if empty, display sum of all phases
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 78 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 70 column 72
       </Metadata>
       <Value>
         Phase(s) for given measurement; if empty, display sum of all phases
@@ -19845,8 +19856,8 @@
         Refresh
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 119 column 21
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 128 column 23
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 111 column 21
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 120 column 23
       </Metadata>
       <Value>
         Refresh
@@ -20333,7 +20344,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 57 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 107 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 99 column 19
       </Metadata>
       <Value>
         Resolution
@@ -20675,6 +20686,7 @@
         Search
       </Key>
       <Metadata>
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 69 column 37
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 66 column 50
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 180 column 29
       </Metadata>
@@ -22742,7 +22754,7 @@
         or new measurement comes in
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 113 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 105 column 51
       </Metadata>
       <Value>
         Toggle auto-refresh, updates display when parameters change or new
@@ -23427,7 +23439,7 @@
         Unit of time used in defining the span of time for the display
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 102 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 51
       </Metadata>
       <Value>
         Time unit for display span

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -6514,7 +6514,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 15 column 10
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 15 column 10
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 16 column 10
       </Metadata>
       <Value>
         Postavke grafa
@@ -14145,7 +14145,7 @@
         Measure
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 70 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 62 column 19
       </Metadata>
       <Value>
         Mjera
@@ -14208,7 +14208,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 22 column 19
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 29 column 21
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 26 column 21
       </Metadata>
       <Value>
         Obračunska mjerna mjesta
@@ -15377,7 +15377,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 40 column 19
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 48 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 44 column 21
       </Metadata>
       <Value>
         Brojila
@@ -16466,7 +16466,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 64 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 86 column 19
       </Metadata>
       <Value>
         Množitelj
@@ -16477,7 +16477,7 @@
         Multiply the selected time unit to get wanted span of time
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 89 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 81 column 71
       </Metadata>
       <Value>
         Pomnožite odabranu vremensku jedinicu da dobijete željeni vremenski
@@ -17248,6 +17248,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        No results
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 133 column 16
+      </Metadata>
+      <Value>
+        Nema rezultata
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         None
       </Key>
       <Metadata>
@@ -17733,7 +17744,7 @@
         Phase
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 83 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 75 column 19
       </Metadata>
       <Value>
         Faza
@@ -17746,7 +17757,7 @@
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementDonutChart.razor' line 65 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementGaugeChart.razor' line 63 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 71 column 9
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 74 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
       </Metadata>
       <Value>
@@ -17758,7 +17769,7 @@
         Phase(s) for given measure, if empty, display sum of all phases
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 78 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 70 column 72
       </Metadata>
       <Value>
         Faza(e) za određeno mjerenje, ako je prazno, prikazuje zbroj svih faza
@@ -19889,8 +19900,8 @@
         Refresh
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 119 column 21
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 128 column 23
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 111 column 21
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 120 column 23
       </Metadata>
       <Value>
         Osvježi
@@ -20377,7 +20388,7 @@
       </Key>
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Financial/FinancialChartControls.razor' line 57 column 17
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 107 column 19
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 99 column 19
       </Metadata>
       <Value>
         Rezolucija
@@ -20719,6 +20730,7 @@
         Search
       </Key>
       <Metadata>
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 69 column 37
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 66 column 50
         From file 'Ozds.Client/Components/Streaming/MappedTable.razor' line 180 column 29
       </Metadata>
@@ -22788,7 +22800,7 @@
         or new measurement comes in
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 113 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 105 column 51
       </Metadata>
       <Value>
         Dinamičko osvježavanje, osvježava prikaz nakon promjene parametra ili
@@ -23473,7 +23485,7 @@
         Unit of time used in defining the span of time for the display
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 102 column 51
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor' line 94 column 51
       </Metadata>
       <Value>
         Jedinica vremena korištena za definiranje vremenskog raspona prikaza

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17240,7 +17240,7 @@
         No measurement locations/meters are selected for display
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 12 column 40
       </Metadata>
       <Value>
         Nije odabrano nijedno mjerno mjesto ili brojilo za prikaz
@@ -17251,7 +17251,7 @@
         No results
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 133 column 16
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 132 column 16
       </Metadata>
       <Value>
         Nema rezultata
@@ -17757,8 +17757,8 @@
       <Metadata>
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementDonutChart.razor' line 65 column 9
         From file 'Ozds.Client/Components/Charts/Measurements/MeasurementGaugeChart.razor' line 63 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 74 column 9
-        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 11 column 38
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 76 column 9
+        From file 'Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor' line 12 column 40
       </Metadata>
       <Value>
         Zbroj faza

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Components;
-using MudBlazor;
 using Ozds.Business.Aggregation;
 using Ozds.Business.Models.Abstractions;
 using Ozds.Business.Models.Enums;
@@ -16,8 +15,6 @@ public partial class MeasurementChartControls : OzdsComponentBase
 {
   private readonly MeasurementChartParameters _parameters = new();
   private bool _initParamsSet = false;
-
-  private MudSelect<string> _select = default!;
 
   [Parameter]
   public List<IMeter> Meters { get; set; } = new();
@@ -154,22 +151,16 @@ public partial class MeasurementChartControls : OzdsComponentBase
   }
 
   private async Task OnMeasurementLocationsChanged(
-    IEnumerable<string> measurementLocationIds
+    IEnumerable<IMeasurementLocation> measurementLocations
   )
   {
-    _parameters.MeasurementLocations = MeasurementLocations
-      .Where(measurementLocation =>
-        measurementLocationIds.Contains(measurementLocation.Id)
-      )
-      .ToHashSet();
+    _parameters.MeasurementLocations = measurementLocations.ToHashSet();
     await Fetch(forcedRefresh: true);
   }
 
-  private async Task OnMetersChanged(IEnumerable<string> meterIds)
+  private async Task OnMetersChanged(IEnumerable<IMeter> meters)
   {
-    _parameters.Meters = Meters
-      .Where(meter => meterIds.Contains(meter.Id))
-      .ToHashSet();
+    _parameters.Meters = meters.ToHashSet();
     await Fetch(forcedRefresh: true);
   }
 
@@ -363,7 +354,7 @@ public partial class MeasurementChartControls : OzdsComponentBase
     InvokeAsync(StateHasChanged);
   }
 
-  private string UpdateSelectDisplay()
+  private string UpdateSelectDisplayMeasurementLocations()
   {
     var ids = _parameters.MeasurementLocations.Select(x => x.Id).ToList();
     return ids.Count == 1

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.razor
@@ -2,6 +2,7 @@
 
 @namespace Ozds.Client.Components.Charts
 @using MudBlazor
+@using Ozds.Business.Models.Abstractions
 @using Ozds.Business.Models.Enums
 @using Ozds.Client.Components.Fields
 @inherits Ozds.Client.Components.Base.OzdsComponentBase
@@ -16,46 +17,37 @@
   <MudGrid Spacing="2" Justify="Justify.Center">
     @if (MeasurementLocations.Count > 1)
     {
-      <MudItem
-        xs="12"
-        @onpointerup="() => _select.OpenMenu()"
-        md="4">
+      <MudItem xs="12" md="4">
         <MudTooltip RootClass="wide-tooltip"
                     Text="@(_parameters.MeasurementLocations.Count > 1 ? string.Join(", ", _parameters.MeasurementLocations.Select(m => m.Title)) : "")">
-          <MudSelect
-            @ref="_select"
-            Text="@UpdateSelectDisplay()"
-            T="string"
+          <SearchableSelectField
+            T="IMeasurementLocation"
+            Text="@UpdateSelectDisplayMeasurementLocations()"
             Label="@Translate("Measurement locations")"
-            SelectedValues="@(_parameters.MeasurementLocations.Select(measurementLocation => measurementLocation.Id))"
+            SelectedValues="@_parameters.MeasurementLocations"
+            Items="@MeasurementLocations"
             SelectedValuesChanged="@OnMeasurementLocationsChanged"
-            MultiSelection>
-            @foreach (var measurementLocation in MeasurementLocations)
-            {
-              <MudSelectItem Value="@measurementLocation.Id">
-                @measurementLocation.Title
-              </MudSelectItem>
-            }
-          </MudSelect>
+            ToStringFunc="@(i => i?.Title ?? string.Empty)"
+            MultiSelection
+            Clearable
+            />
         </MudTooltip>
       </MudItem>
     }
     else if (Meters.Count > 1)
     {
       <MudItem xs="12" md="4">
-        <MudSelect
-          T="string"
-          Label="@Translate("Meters")"
-          SelectedValues="@(_parameters.Meters.Select(meter => meter.Id))"
-          SelectedValuesChanged="@OnMetersChanged"
-          MultiSelection>
-          @foreach (var meter in Meters)
-          {
-            <MudSelectItem Value="@meter.Id">
-              @meter.Id
-            </MudSelectItem>
-          }
-        </MudSelect>
+        <MudTooltip RootClass="wide-tooltip"
+                    Text="@(_parameters.Meters.Count > 1 ? string.Join(", ", _parameters.Meters.Select(m => m.Id)) : "")">
+          <SearchableSelectField
+            T="IMeter"
+            Label="@Translate("Meters")"
+            SelectedValues="@_parameters.Meters"
+            Items="@Meters"
+            SelectedValuesChanged="@OnMetersChanged"
+            ToStringFunc="@(m => m?.Id ?? string.Empty)"
+            MultiSelection/>
+          </MudTooltip>
       </MudItem>
     }
     @{
@@ -63,7 +55,7 @@
         && _parameters.Meters.Count == 0;
     }
     <MudItem xs="12" sm="6" md="4">
-      <MudTooltip RootClass="wide-tooltip" Text="Select type of measure">
+      <MudTooltip RootClass="wide-tooltip" ShowOnFocus="false" Text="Select type of measure">
         <EnumPicker
           T="MeasureModel"
           @bind-Value="@_parameters.Measure"
@@ -75,7 +67,7 @@
       </MudTooltip>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
-      <MudTooltip RootClass="wide-tooltip" Text="@Translate("Phase(s) for given measure, if empty, display sum of all phases")">
+       <MudTooltip RootClass="wide-tooltip" ShowOnFocus="false" Text="@Translate("Phase(s) for given measure, if empty, display sum of all phases")">
         <MultiEnumPicker
           T="PhaseModel"
           Value="@_parameters.Phases"
@@ -86,7 +78,7 @@
       </MudTooltip>
     </MudItem>
     <MudItem xs="12" sm="6" md="1">
-      <MudTooltip RootClass="wide-tooltip" Text="@Translate("Multiply the selected time unit to get wanted span of time")">
+      <MudTooltip RootClass="wide-tooltip" ShowOnFocus="false" Text="@Translate("Multiply the selected time unit to get wanted span of time")">
         <MudNumericField
           T="int"
           Value="@_parameters.Multiplier"
@@ -137,5 +129,8 @@
 <style>
   .wide-tooltip {
     width: 100%;
+  }
+  .mud-tooltip {
+     pointer-events: none;
   }
 </style>

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
@@ -22,24 +22,27 @@ else
     {
       if (Parameters.Phases.Count == 0)
       {
-        @(
-        Series(
-          PhaseModel.L1.ToColor(i),
-          meter,
-          measurementLocation
-        ))
-      }
-      else
-      {
-        foreach (var phase in Parameters.Phases.OrderBy(x => x))
+        if (Parameters.Phases.Count == 0)
         {
           @(
           Series(
-            phase.ToColor(i),
+            PhaseModel.L1.ToColor(i),
             meter,
-            measurementLocation,
-            phase
+            measurementLocation
           ))
+        }
+        else
+        {
+          foreach (var phase in Parameters.Phases.OrderBy(x => x))
+          {
+            @(
+            Series(
+              phase.ToColor(i),
+              meter,
+              measurementLocation,
+              phase
+            ))
+          }
         }
       }
     }

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.razor
@@ -4,50 +4,52 @@
 @using Ozds.Business.Models.Enums
 @inherits Ozds.Client.Components.Base.OzdsComponentBase
 
-@if (Parameters.MeasurementLocations.Count == 0
-  && Parameters.Meters.Count == 0)
-{
-  <div style="height:300px; display: grid; align-items: center;">
-    <h2 style="text-align: center;">@Translate("No measurement locations/meters are selected for display")</h2>
-  </div>
-}
-else
-{
-  <ApexChart
-    XAxisType="@XAxisType.Datetime"
-    Options="@_options"
-    Height="@Height"
-    @ref="@_chart">
-    @foreach (var (meter, measurementLocation, i) in GetItems())
-    {
-      if (Parameters.Phases.Count == 0)
+<div style="height:@(Height)px">
+  @if (Parameters.MeasurementLocations.Count == 0
+    && Parameters.Meters.Count == 0)
+  {
+    <div style="height:100%; display: grid; align-items: center;">
+      <h2 style="text-align: center;">@Translate("No measurement locations/meters are selected for display")</h2>
+    </div>
+  }
+  else
+  {
+    <ApexChart
+      XAxisType="@XAxisType.Datetime"
+      Options="@_options"
+      Height="@Height"
+      @ref="@_chart">
+      @foreach (var (meter, measurementLocation, i) in GetItems())
       {
         if (Parameters.Phases.Count == 0)
         {
-          @(
-          Series(
-            PhaseModel.L1.ToColor(i),
-            meter,
-            measurementLocation
-          ))
-        }
-        else
-        {
-          foreach (var phase in Parameters.Phases.OrderBy(x => x))
+          if (Parameters.Phases.Count == 0)
           {
             @(
             Series(
-              phase.ToColor(i),
+              PhaseModel.L1.ToColor(i),
               meter,
-              measurementLocation,
-              phase
+              measurementLocation
             ))
+          }
+          else
+          {
+            foreach (var phase in Parameters.Phases.OrderBy(x => x))
+            {
+              @(
+              Series(
+                phase.ToColor(i),
+                meter,
+                measurementLocation,
+                phase
+              ))
+            }
           }
         }
       }
-    }
-  </ApexChart>
-}
+    </ApexChart>
+  }
+</div>
 
 @code {
   private RenderFragment Series(

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -1,11 +1,18 @@
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor;
 
 namespace Ozds.Client.Components.Fields;
 
-public partial class SearchableSelectField<T>
+public partial class SearchableSelectField<T> : IAsyncDisposable
 {
+  private const string ModulePath =
+    "/js/components/searchable-select-field/searchable-select-field.js";
+
+  private readonly string _instanceId = Guid.NewGuid().ToString("N");
+
   [Parameter]
   public string? Label { get; set; }
 
@@ -81,13 +88,119 @@ public partial class SearchableSelectField<T>
   [Parameter(CaptureUnmatchedValues = true)]
   public IDictionary<string, object>? AdditionalAttributes { get; set; }
 
+  [Inject]
+  private IJSRuntime JS { get; set; } = default!;
+
+  private IJSObjectReference? _module;
+
   private bool _open;
   private string _search = string.Empty;
   private bool _caseSensitive = true;
+  private int _highlightedIndex = 0;
+
+  private MudTextField<string> _searchField = default!;
+  private ElementReference _elementsField = default!;
+
+  private IReadOnlyList<T>? _filteredItemsCache;
+  private ICollection<T>? _previousItems;
+
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    if (firstRender)
+    {
+      _module = await JS.InvokeAsync<IJSObjectReference>("import", ModulePath);
+    }
+  }
+
+  protected override void OnParametersSet()
+  {
+    base.OnParametersSet();
+    // NOTE: this should be further addressed
+    // in future useMemo clone implementation
+    if (!ReferenceEquals(_previousItems, Items))
+    {
+      _previousItems = Items;
+      InvalidateFilteredCache();
+    }
+  }
+
+  private string GetItemId(int index) =>
+    $"ozds-ss-item-{_instanceId}-{index}";
+
+  private async Task SetHighlightedIndexAsync(int index)
+  {
+    var count = GetFilteredItems().Count;
+    _highlightedIndex = Math.Clamp(index, 0, count - 1);
+
+    if (_module is not null)
+    {
+      await _module.InvokeVoidAsync(
+        "scrollItemIntoView",
+        GetItemId(_highlightedIndex));
+    }
+  }
+
+  private void OnSearchChanged(string value)
+  {
+    _highlightedIndex = 0;
+    _search = value;
+    InvalidateFilteredCache();
+  }
+
+  private async Task HandleKeyDownSearch(KeyboardEventArgs e)
+  {
+    switch (e.Key)
+    {
+      case "Tab":
+      case "ArrowDown":
+        await SetHighlightedIndexAsync(0);
+        await _elementsField.FocusAsync();
+        break;
+      case "Escape":
+        Close();
+        break;
+    }
+  }
+
+  private async Task HandleKeyDownPopover(KeyboardEventArgs e)
+  {
+    switch (e.Key)
+    {
+      case "Tab":
+        await _searchField.FocusAsync();
+        break;
+      case "Escape":
+        Close();
+        break;
+      case "ArrowDown":
+        await SetHighlightedIndexAsync(_highlightedIndex + 1);
+        break;
+      case "ArrowUp":
+        await SetHighlightedIndexAsync(_highlightedIndex - 1);
+        break;
+      case "Home":
+        await SetHighlightedIndexAsync(0);
+        break;
+      case "End":
+        await SetHighlightedIndexAsync(int.MaxValue);
+        break;
+      case "Enter":
+        var filtered = GetFilteredItems();
+        if (filtered.Count > 0
+          && _highlightedIndex >= 0
+          && _highlightedIndex < filtered.Count)
+        {
+          await ToggleItem(filtered[_highlightedIndex]);
+        }
+        break;
+    }
+  }
 
   private void OnCaseSensitiveToggle()
   {
+    _highlightedIndex = 0;
     _caseSensitive = !_caseSensitive;
+    InvalidateFilteredCache();
   }
 
   private IReadOnlyList<T> GetSelectedValuesList()
@@ -99,6 +212,16 @@ public partial class SearchableSelectField<T>
     MultiSelection ? SelectedValues?.Any() == true : Value is not null;
 
   private IReadOnlyList<T> GetFilteredItems()
+  {
+    return _filteredItemsCache ??= ComputeFilteredItems();
+  }
+
+  private void InvalidateFilteredCache()
+  {
+    _filteredItemsCache = null;
+  }
+
+  private IReadOnlyList<T> ComputeFilteredItems()
   {
     if (string.IsNullOrWhiteSpace(_search))
     {
@@ -145,9 +268,11 @@ public partial class SearchableSelectField<T>
   private void ToggleOpen()
   {
     _open = !_open;
+    _highlightedIndex = 0;
     if (_open)
     {
       _search = string.Empty;
+      InvalidateFilteredCache();
     }
   }
 
@@ -206,7 +331,7 @@ public partial class SearchableSelectField<T>
     }
   }
 
-  private string GetItemClass(bool selected)
+  private string GetItemClass(bool selected, bool highlighted)
   {
     var classes = new List<string>
     {
@@ -226,6 +351,18 @@ public partial class SearchableSelectField<T>
       }
     }
 
+    if (highlighted)
+    {
+      classes.Add("ozds-searchable-select__item--highlighted");
+    }
+
     return string.Join(" ", classes);
+  }
+  public async ValueTask DisposeAsync()
+  {
+    if (_module is not null)
+    {
+      await _module.DisposeAsync();
+    }
   }
 }

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -124,8 +124,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     }
   }
 
-  private string GetItemId(int index) =>
-    $"ozds-ss-item-{_instanceId}-{index}";
+  private string GetItemId(int index) => $"ozds-ss-item-{_instanceId}-{index}";
 
   private async Task SetHighlightedIndexAsync(int index)
   {
@@ -136,7 +135,8 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     {
       await _module.InvokeVoidAsync(
         "scrollItemIntoView",
-        GetItemId(_highlightedIndex));
+        GetItemId(_highlightedIndex)
+      );
     }
   }
 
@@ -186,9 +186,11 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
         break;
       case "Enter":
         var filtered = GetFilteredItems();
-        if (filtered.Count > 0
+        if (
+          filtered.Count > 0
           && _highlightedIndex >= 0
-          && _highlightedIndex < filtered.Count)
+          && _highlightedIndex < filtered.Count
+        )
         {
           await ToggleItem(filtered[_highlightedIndex]);
         }
@@ -232,11 +234,13 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
       ? StringComparison.Ordinal
       : StringComparison.OrdinalIgnoreCase;
 
-    return Items.Where(item =>
-    {
-      var text = GetDisplayText(item);
-      return text.Contains(_search, comparison);
-    }).ToList();
+    return Items
+      .Where(item =>
+      {
+        var text = GetDisplayText(item);
+        return text.Contains(_search, comparison);
+      })
+      .ToList();
   }
 
   private string GetDisplayText(T? item)
@@ -258,8 +262,8 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   {
     if (MultiSelection)
     {
-      return GetSelectedValuesList().Any(v =>
-        EqualityComparer<T>.Default.Equals(v, item));
+      return GetSelectedValuesList()
+        .Any(v => EqualityComparer<T>.Default.Equals(v, item));
     }
 
     return EqualityComparer<T?>.Default.Equals(Value, item);
@@ -287,7 +291,8 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     {
       var list = GetSelectedValuesList().ToList();
       var index = list.FindIndex(v =>
-        EqualityComparer<T>.Default.Equals(v, item));
+        EqualityComparer<T>.Default.Equals(v, item)
+      );
       if (index >= 0)
       {
         list.RemoveAt(index);
@@ -333,10 +338,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
 
   private string GetItemClass(bool selected, bool highlighted)
   {
-    var classes = new List<string>
-    {
-      "ozds-searchable-select__item",
-    };
+    var classes = new List<string> { "ozds-searchable-select__item" };
     if (!string.IsNullOrEmpty(ItemClass))
     {
       classes.Add(ItemClass);
@@ -358,6 +360,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
 
     return string.Join(" ", classes);
   }
+
   public async ValueTask DisposeAsync()
   {
     if (_module is not null)

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -1,0 +1,231 @@
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Ozds.Client.Components.Fields;
+
+public partial class SearchableSelectField<T>
+{
+  [Parameter]
+  public string? Label { get; set; }
+
+  [Parameter]
+  public string? Placeholder { get; set; }
+
+  [Parameter]
+  public T? Value { get; set; }
+
+  [Parameter]
+  public EventCallback<T?> ValueChanged { get; set; }
+
+  [Parameter]
+  public IEnumerable<T>? SelectedValues { get; set; }
+
+  [Parameter]
+  public EventCallback<IEnumerable<T>> SelectedValuesChanged { get; set; }
+
+  [Parameter]
+  public bool MultiSelection { get; set; }
+
+  [Parameter]
+  public Expression<Func<T>>? For { get; set; }
+
+  [Parameter]
+  public string? Text { get; set; }
+
+  [Parameter]
+  public Origin AnchorOrigin { get; set; } = Origin.BottomCenter;
+
+  [Parameter]
+  public Origin TransformOrigin { get; set; } = Origin.TopCenter;
+
+  [Parameter]
+  public ICollection<T> Items { get; set; } = Array.Empty<T>();
+
+  [Parameter]
+  public Func<T?, string?>? ToStringFunc { get; set; }
+
+  [Parameter]
+  public RenderFragment<T>? ItemTemplate { get; set; }
+
+  [Parameter]
+  public Variant Variant { get; set; } = Variant.Text;
+
+  [Parameter]
+  public Margin Margin { get; set; } = Margin.None;
+
+  [Parameter]
+  public bool Dense { get; set; } = true;
+
+  [Parameter]
+  public bool Clearable { get; set; }
+
+  [Parameter]
+  public string? Class { get; set; }
+
+  [Parameter]
+  public string? Style { get; set; }
+
+  [Parameter]
+  public string? PopoverClass { get; set; }
+
+  [Parameter]
+  public string? ItemClass { get; set; }
+
+  [Parameter]
+  public string? SelectedItemClass { get; set; }
+
+  [Parameter]
+  public string MaxPopoverHeight { get; set; } = "320px";
+
+  [Parameter(CaptureUnmatchedValues = true)]
+  public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+  private bool _open;
+  private string _search = string.Empty;
+  private bool _caseSensitive = true;
+
+  private void OnCaseSensitiveToggle()
+  {
+    _caseSensitive = !_caseSensitive;
+  }
+
+  private IReadOnlyList<T> GetSelectedValuesList()
+  {
+    return SelectedValues?.ToList() ?? new List<T>();
+  }
+
+  private bool HasSelection =>
+    MultiSelection ? SelectedValues?.Any() == true : Value is not null;
+
+  private IReadOnlyList<T> GetFilteredItems()
+  {
+    if (string.IsNullOrWhiteSpace(_search))
+    {
+      return Items is IReadOnlyList<T> list ? list : Items.ToList();
+    }
+
+    var comparison = _caseSensitive
+      ? StringComparison.Ordinal
+      : StringComparison.OrdinalIgnoreCase;
+
+    return Items.Where(item =>
+    {
+      var text = GetDisplayText(item);
+      return text.Contains(_search, comparison);
+    }).ToList();
+  }
+
+  private string GetDisplayText(T? item)
+  {
+    if (item is null)
+    {
+      return string.Empty;
+    }
+
+    if (ToStringFunc is not null)
+    {
+      return ToStringFunc(item) ?? string.Empty;
+    }
+
+    return item.ToString() ?? string.Empty;
+  }
+
+  private bool IsSelected(T item)
+  {
+    if (MultiSelection)
+    {
+      return GetSelectedValuesList().Any(v =>
+        EqualityComparer<T>.Default.Equals(v, item));
+    }
+
+    return EqualityComparer<T?>.Default.Equals(Value, item);
+  }
+
+  private void ToggleOpen()
+  {
+    _open = !_open;
+    if (_open)
+    {
+      _search = string.Empty;
+    }
+  }
+
+  private void Close()
+  {
+    _open = false;
+  }
+
+  private async Task ToggleItem(T item)
+  {
+    if (MultiSelection)
+    {
+      var list = GetSelectedValuesList().ToList();
+      var index = list.FindIndex(v =>
+        EqualityComparer<T>.Default.Equals(v, item));
+      if (index >= 0)
+      {
+        list.RemoveAt(index);
+      }
+      else
+      {
+        list.Add(item);
+      }
+
+      if (SelectedValuesChanged.HasDelegate)
+      {
+        await SelectedValuesChanged.InvokeAsync(list);
+      }
+    }
+    else
+    {
+      if (ValueChanged.HasDelegate)
+      {
+        await ValueChanged.InvokeAsync(item);
+      }
+
+      Close();
+    }
+  }
+
+  private async Task ClearAll()
+  {
+    if (MultiSelection)
+    {
+      if (SelectedValuesChanged.HasDelegate)
+      {
+        await SelectedValuesChanged.InvokeAsync(Array.Empty<T>());
+      }
+    }
+    else
+    {
+      if (ValueChanged.HasDelegate)
+      {
+        await ValueChanged.InvokeAsync(default);
+      }
+    }
+  }
+
+  private string GetItemClass(bool selected)
+  {
+    var classes = new List<string>
+    {
+      "ozds-searchable-select__item",
+    };
+    if (!string.IsNullOrEmpty(ItemClass))
+    {
+      classes.Add(ItemClass);
+    }
+
+    if (selected)
+    {
+      classes.Add("ozds-searchable-select__item--selected");
+      if (!string.IsNullOrEmpty(SelectedItemClass))
+      {
+        classes.Add(SelectedItemClass);
+      }
+    }
+
+    return string.Join(" ", classes);
+  }
+}

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -387,7 +387,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   {
     if (_module is null)
     {
-        return;
+      return;
     }
 
     // NOTE: this catch is here because the disconnected exception

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -126,12 +126,23 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
 
   private string GetItemId(int index) => $"ozds-ss-item-{_instanceId}-{index}";
 
-  private async Task SetHighlightedIndexAsync(int index)
+  private void SetHighlightedIndex(int index)
   {
     var count = GetFilteredItems().Count;
-    _highlightedIndex = Math.Clamp(index, 0, count - 1);
+    if (count == 0)
+    {
+      _highlightedIndex = 0;
+      return;
+    }
 
-    if (_module is not null)
+    _highlightedIndex = Math.Clamp(index, 0, count - 1);
+  }
+
+  private async Task SetHighlightedIndexWithScrollAlignment(int index)
+  {
+    SetHighlightedIndex(index);
+
+    if (_module is not null && _highlightedIndex >= 0)
     {
       await _module.InvokeVoidAsync(
         "scrollItemIntoView",
@@ -153,7 +164,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     {
       case "Tab":
       case "ArrowDown":
-        await SetHighlightedIndexAsync(0);
+        await SetHighlightedIndexWithScrollAlignment(0);
         await _elementsField.FocusAsync();
         break;
       case "Escape":
@@ -173,16 +184,16 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
         Close();
         break;
       case "ArrowDown":
-        await SetHighlightedIndexAsync(_highlightedIndex + 1);
+        await SetHighlightedIndexWithScrollAlignment(_highlightedIndex + 1);
         break;
       case "ArrowUp":
-        await SetHighlightedIndexAsync(_highlightedIndex - 1);
+        await SetHighlightedIndexWithScrollAlignment(_highlightedIndex - 1);
         break;
       case "Home":
-        await SetHighlightedIndexAsync(0);
+        await SetHighlightedIndexWithScrollAlignment(0);
         break;
       case "End":
-        await SetHighlightedIndexAsync(int.MaxValue);
+        await SetHighlightedIndexWithScrollAlignment(int.MaxValue);
         break;
       case "Enter":
         var filtered = GetFilteredItems();
@@ -285,11 +296,22 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     _open = false;
   }
 
+  // NOTE: for current select sizes this closure callback style
+  // should be acceptable
+  // in future if need be, reconstruct this to use event.target
+  // so it does not need to save closure per item
+  private Task ToggleItem(T item, int elementIndex)
+  {
+    SetHighlightedIndex(elementIndex);
+    return ToggleItem(item);
+  }
+
   private async Task ToggleItem(T item)
   {
     if (MultiSelection)
     {
       var list = GetSelectedValuesList().ToList();
+
       var index = list.FindIndex(v =>
         EqualityComparer<T>.Default.Equals(v, item)
       );
@@ -355,7 +377,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
 
     if (highlighted)
     {
-      classes.Add("ozds-searchable-select__item--highlighted");
+      classes.Add("mud-primary-text mud-primary-hover");
     }
 
     return string.Join(" ", classes);
@@ -363,9 +385,20 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
 
   public async ValueTask DisposeAsync()
   {
-    if (_module is not null)
+    if (_module is null)
+    {
+        return;
+    }
+
+    // NOTE: this catch is here because the disconnected exception
+    // does not signify an actual error in this case and can be safely ignored
+    try
     {
       await _module.DisposeAsync();
+    }
+    catch (JSDisconnectedException)
+    {
+      // Ignore: Blazor circuit/browser already disconnected.
     }
   }
 }

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
@@ -1,0 +1,123 @@
+@namespace Ozds.Client.Components.Fields
+@using MudBlazor
+@inherits Ozds.Client.Components.Base.OzdsComponentBase
+@typeparam T
+
+<div class="@($"ozds-searchable-select {Class}".Trim())" style="@Style">
+  <div class="ozds-searchable-select__trigger" @onclick="ToggleOpen">
+    <MudField Label="@Label"
+              Variant="@Variant"
+              Margin="@Margin"
+              InnerPadding="true"
+              Adornment="Adornment.End"
+              AdornmentIcon="@Icons.Material.Filled.ArrowDropDown"
+              Class="@($"ozds-searchable-select__field {(_open ? "ozds-searchable-select__field--open" : string.Empty)}".Trim())"
+              Style="cursor:pointer;width:100%;">
+      <div class="ozds-searchable-select__content">
+        @if (!HasSelection)
+        {
+          <span class="ozds-searchable-select__placeholder">
+            @Placeholder
+          </span>
+        }
+        else if (MultiSelection)
+        {
+          <span class="ozds-searchable-select__value">@Text</span>
+        }
+        else
+        {
+          <span class="ozds-searchable-select__value">@GetDisplayText(Value)</span>
+        }
+      </div>
+    </MudField>
+  </div>
+
+  @if (Clearable && HasSelection)
+  {
+    <div class="ozds-searchable-select__clear"
+         @onpointerup="ClearAll"
+         @onpointerup:stopPropagation="true">
+      <MudIconButton Icon="@Icons.Material.Filled.Clear"
+                     Size="Size.Small"
+                     Variant="Variant.Text"
+                     />
+    </div>
+  }
+
+  <MudPopover Open="_open"
+              AnchorOrigin="@AnchorOrigin"
+              TransformOrigin="@TransformOrigin"
+              RelativeWidth="DropdownWidth.Relative"
+              Paper="false"
+              Class="@($"ozds-searchable-select__popover {PopoverClass}".Trim())">
+    <MudPaper Class="ozds-searchable-select__paper"
+              Elevation="8"
+              Style="@($"max-height:{MaxPopoverHeight};")">
+      <div class="d-flex flex-row align-center ozds-searchable-select__search-wrap pa-2">
+        <MudIconButton Icon="@Icons.Material.Filled.TextFields"
+                       Color="@(_caseSensitive ? Color.Primary : Color.Default)"
+                       OnClick="@OnCaseSensitiveToggle"
+                       Size="Size.Medium"/>
+        <MudTextField @bind-Value="_search"
+                      Placeholder="@Translate("Search")"
+                      Immediate="true"
+                      Variant="Variant.Text"
+                      Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search"
+                      Margin="Margin.Dense"
+                      AutoFocus="true"
+                      Class="ozds-searchable-select__search"/>
+      </div>
+      <div class="ozds-searchable-select__list-wrap">
+        @{
+          var cachedFilteredItems = GetFilteredItems();
+        }
+        @if (cachedFilteredItems.Any())
+        {
+          <MudList T="T" Dense="@Dense" Class="ozds-searchable-select__list">
+            @foreach (var item in cachedFilteredItems)
+            {
+              var selected = IsSelected(item);
+              <MudListItem T="T"
+                           Value="item"
+                           OnClick="@(() => ToggleItem(item))"
+                           Class="@GetItemClass(selected)">
+                <div class="d-flex align-center ozds-searchable-select__item-content">
+                  @if (MultiSelection)
+                  {
+                    <MudCheckBox T="bool"
+                                 Value="selected"
+                                 ReadOnly="true"
+                                 Dense="true"
+                                 Class="mr-2 ozds-searchable-select__item-check"/>
+                  }
+                  @if (ItemTemplate is not null)
+                  {
+                    @ItemTemplate(item)
+                  }
+                  else
+                  {
+                    <span class="ozds-searchable-select__item-text">@GetDisplayText(item)</span>
+                  }
+                </div>
+              </MudListItem>
+            }
+          </MudList>
+        }
+        else
+        {
+          <div class="pa-3 ozds-searchable-select__empty">
+            <MudText Color="Color.Secondary" Typo="Typo.body2">
+              @Translate("No results")
+            </MudText>
+          </div>
+        }
+      </div>
+    </MudPaper>
+  </MudPopover>
+
+  <MudOverlay Visible="_open"
+              OnClick="Close"
+              LockScroll="false"
+              Class="ozds-searchable-select__overlay"/>
+</div>

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
@@ -51,6 +51,7 @@
               Paper="false"
               Class="@($"ozds-searchable-select__popover {PopoverClass}".Trim())">
     <MudPaper Class="ozds-searchable-select__paper"
+              tabindex="-1"
               Elevation="8"
               Style="@($"max-height:{MaxPopoverHeight};")">
       <div class="d-flex flex-row align-center ozds-searchable-select__search-wrap pa-2">
@@ -58,7 +59,13 @@
                        Color="@(_caseSensitive ? Color.Primary : Color.Default)"
                        OnClick="@OnCaseSensitiveToggle"
                        Size="Size.Medium"/>
-        <MudTextField @bind-Value="_search"
+        <MudTextField
+                      @ref="_searchField"
+                      T="string"
+                      Value="_search"
+                      DebounceInterval="150"
+                      OnKeyDown="HandleKeyDownSearch"
+                      ValueChanged="OnSearchChanged"
                       Placeholder="@Translate("Search")"
                       Immediate="true"
                       Variant="Variant.Text"
@@ -68,20 +75,35 @@
                       AutoFocus="true"
                       Class="ozds-searchable-select__search"/>
       </div>
-      <div class="ozds-searchable-select__list-wrap">
+       <div
+         @ref="_elementsField"
+         @onkeydown="HandleKeyDownPopover"
+         @onkeydown:preventDefault="true"
+         class="ozds-searchable-select__list-wrap">
         @{
           var cachedFilteredItems = GetFilteredItems();
+          var selectedSet = MultiSelection
+            ? SelectedValues switch
+              {
+                null => new HashSet<T>(),
+                HashSet<T> set => set,
+                _ => new HashSet<T>(SelectedValues)
+              }
+            : null;
         }
         @if (cachedFilteredItems.Any())
         {
-          <MudList T="T" Dense="@Dense" Class="ozds-searchable-select__list">
-            @foreach (var item in cachedFilteredItems)
+          <MudList T="T" Dense="@Dense" Class="ozds-searchable-select__list" >
+            @foreach (var (idx, item) in cachedFilteredItems.Index())
             {
-              var selected = IsSelected(item);
+              var selected = MultiSelection ? selectedSet!.Contains(item) : IsSelected(item);
+              var highlighted = idx == _highlightedIndex;
+
               <MudListItem T="T"
                            Value="item"
+                           id="@GetItemId(idx)"
                            OnClick="@(() => ToggleItem(item))"
-                           Class="@GetItemClass(selected)">
+                           Class="@GetItemClass(selected, highlighted)">
                 <div class="d-flex align-center ozds-searchable-select__item-content">
                   @if (MultiSelection)
                   {

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
@@ -100,9 +100,8 @@
               var highlighted = idx == _highlightedIndex;
 
               <MudListItem T="T"
-                           Value="item"
                            id="@GetItemId(idx)"
-                           OnClick="@(() => ToggleItem(item))"
+                           OnClick="@(() => ToggleItem(item, idx))"
                            Class="@GetItemClass(selected, highlighted)">
                 <div class="d-flex align-center ozds-searchable-select__item-content">
                   @if (MultiSelection)

--- a/src/Ozds.Client/Components/Fields/SelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SelectField.cs
@@ -6,8 +6,6 @@ namespace Ozds.Client.Components.Fields;
 
 public partial class SelectField<T>
 {
-  private MudSelect<T> _inner = default!;
-
   [Parameter]
   public string Label { get; set; } = default!;
 

--- a/src/Ozds.Client/Components/Fields/SelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SelectField.razor
@@ -2,11 +2,10 @@
 @using MudBlazor
 @typeparam T
 
-<div @onpointerup="() => _inner.OpenMenu()">
+<div>
   @if (MultiSelection)
   {
     <MudSelect T="T"
-               @ref="_inner"
                Label="@Label"
                SelectedValues="@SelectedValues"
                SelectedValuesChanged="@SelectedValuesChanged"
@@ -20,7 +19,6 @@
   else
   {
     <MudSelect T="T"
-               @ref="_inner"
                Label="@Label"
                Value="@Value"
                ValueChanged="@ValueChanged"

--- a/src/Ozds.Server/Views/Shared/_AppLayout.cshtml
+++ b/src/Ozds.Server/Views/Shared/_AppLayout.cshtml
@@ -24,6 +24,7 @@
   <link href="/_content/MudBlazor.ThemeManager/MudBlazorThemeManager.css" rel="stylesheet" />
   <link href="/_content/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+  <link href="/css/app.css" rel="stylesheet" />
   <link rel="icon" type="image/png" href="/favicon.png">
 
   @(await Html.RenderComponentAsync<HeadOutlet>(RenderMode.Server))

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -65,6 +65,11 @@
   background-color: var(--mud-palette-action-default-hover);
 }
 
+.mud-list-item-clickable.ozds-searchable-select__item--highlighted {
+  background-color: var(--mud-palette-primary-hover);
+  color: var(--mud-palette-primary);
+}
+
 /* Clear button overlays the field so toggling it doesn't change
    the field's height — sits just to the left of the chevron. */
 .ozds-searchable-select__clear {

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -14,7 +14,7 @@
    SearchableSelectField
    src/Ozds.Client/Components/Fields/SearchableSelectField.razor
    A searchable single/multi-select dropdown built on
-   MudField + MudPopover. Mimics MudSelect, fully templatable.
+   MudField + MudPopover. Mimics MudSelect.
    Component style section START
    ------------------------------------------------------------ */
 

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -65,11 +65,6 @@
   background-color: var(--mud-palette-action-default-hover);
 }
 
-.mud-list-item-clickable.ozds-searchable-select__item--highlighted {
-  background-color: var(--mud-palette-primary-hover);
-  color: var(--mud-palette-primary);
-}
-
 /* Clear button overlays the field so toggling it doesn't change
    the field's height — sits just to the left of the chevron. */
 .ozds-searchable-select__clear {

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -1,0 +1,97 @@
+/* ============================================================
+   Ozds app stylesheet
+   Global, theme-aware custom CSS layered on top of MudBlazor.
+   - Vendor classes are only touched inside the "MudBlazor overrides"
+     fences of a component block.
+   - Naming: ozds-<component>__<element>--<modifier>
+   ============================================================ */
+
+/* ============================================================
+   Components
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   SearchableSelectField
+   src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+   A searchable single/multi-select dropdown built on
+   MudField + MudPopover. Mimics MudSelect, fully templatable.
+   Component style section START
+   ------------------------------------------------------------ */
+
+.ozds-searchable-select {
+  position: relative;
+  width: 100%;
+}
+
+.ozds-searchable-select__trigger {
+  cursor: pointer;
+}
+
+.ozds-searchable-select__content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 19px;
+}
+
+.ozds-searchable-select__placeholder {
+  color: var(--mud-palette-text-secondary);
+}
+
+.ozds-searchable-select__value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.ozds-searchable-select__clear {
+  margin-left: auto;
+}
+
+.ozds-searchable-select__paper {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ozds-searchable-select__list-wrap {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.ozds-searchable-select__item--selected {
+  background-color: var(--mud-palette-action-default-hover);
+}
+
+/* Clear button overlays the field so toggling it doesn't change
+   the field's height — sits just to the left of the chevron. */
+.ozds-searchable-select__clear {
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-20%);
+  z-index: 1;
+}
+
+/* Force pointer so the whole trigger feels
+   clickable */
+.ozds-searchable-select__field .mud-input-control,
+.ozds-searchable-select__field .mud-input,
+.ozds-searchable-select__field .mud-input-slot {
+  cursor: pointer;
+}
+
+/* Rotate MudField's end adornment (the chevron) when open. */
+.ozds-searchable-select__field--open
+  .mud-input-adornment-end
+  .mud-icon-root {
+  transform: rotate(180deg);
+}
+
+
+/* ------------------------------------------------------------
+   SearchableSelectField
+   Component style section END
+   ------------------------------------------------------------ */

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -89,12 +89,9 @@
 }
 
 /* Rotate MudField's end adornment (the chevron) when open. */
-.ozds-searchable-select__field--open
-  .mud-input-adornment-end
-  .mud-icon-root {
+.ozds-searchable-select__field--open .mud-input-adornment-end .mud-icon-root {
   transform: rotate(180deg);
 }
-
 
 /* ------------------------------------------------------------
    SearchableSelectField

--- a/src/Ozds.Server/wwwroot/js/components/searchable-select-field/searchable-select-field.js
+++ b/src/Ozds.Server/wwwroot/js/components/searchable-select-field/searchable-select-field.js
@@ -1,0 +1,6 @@
+export function scrollItemIntoView(id) {
+  document.getElementById(id)?.scrollIntoView({
+    block: 'nearest',
+    behavior: 'instant'
+  });
+}

--- a/src/Ozds.Server/wwwroot/js/components/searchable-select-field/searchable-select-field.js
+++ b/src/Ozds.Server/wwwroot/js/components/searchable-select-field/searchable-select-field.js
@@ -1,6 +1,6 @@
 export function scrollItemIntoView(id) {
   document.getElementById(id)?.scrollIntoView({
-    block: 'nearest',
-    behavior: 'instant'
+    block: "nearest",
+    behavior: "instant",
   });
 }


### PR DESCRIPTION
# Task

Fixes #213
Fixes #247
Fixes #327

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- `MeasurementChartControls` now uses the new `SearchableSelectField` instead of
  plain `MudSelect` for both meters and measurement locations, with consistent
  `MudTooltip` wrappers showing the full list of current selections; the
  `OnMeasurementLocationsChanged` and `OnMetersChanged` callbacks now receive
  `IMeasurementLocation`/`IMeter` instances directly instead of resolving them
  from string ids
- `MeasurementLineChart` wraps the chart and its empty-state placeholder in a
  fixed-height container so chart re-renders no longer shift the chart-control
  selection fields above it
- `MudTooltip` overlays in `MeasurementChartControls` no longer block pointer
  events on the underlying fields; added a global
  `.mud-tooltip { pointer-events: none; }` rule and set `ShowOnFocus="false"` on
  the measure, phase, and multiplier tooltips so they no longer intercept clicks
  or steal focus
- `SelectField` dropdown no longer opens and immediately closes when clicked;
  removed the wrapper `<div @onpointerup="() => _inner.OpenMenu()">` and the
  `MudSelect _inner` ref that double-toggled the menu against `MudSelect`'s own
  click handling

### Added

- `SearchableSelectField<T>` component in `Ozds.Client.Components.Fields`, a
  custom dropdown built on `MudPopover`, `MudList`, and `MudTextField`,
  providing search-as-you-type filtering with a case-sensitivity toggle, single-
  and multi-selection over arbitrary `ICollection<T>` collections, optional
  `ItemTemplate`, full keyboard navigation (ArrowUp/Down/Home/End to move the
  highlight, Enter to select, Escape to close, Tab to swap focus between search
  and list), a highlighted-row state with primary-tinted background and
  auto-scroll-into-view, plus per-render caching of the filtered list
  (invalidated on search/case/`Items` changes) and a `HashSet`-backed
  selected-value lookup for O(n) multi-selection rendering
- Collocated `searchable-select-field.js` ES module loaded on first render via
  `IJSRuntime.InvokeAsync<IJSObjectReference>("import", ...)` and released on
  `IAsyncDisposable.DisposeAsync`, exposing a single `scrollItemIntoView(id)`
  helper that calls `scrollIntoView({ block: 'nearest', behavior: 'instant' })`
- `ozds-searchable-select__item--highlighted` style in `app.css` using
  `--mud-palette-primary-hover` background and `--mud-palette-primary` text to
  match MudBlazor's primary-selected visual treatment, with selector specificity
  bumped via `.mud-list-item-clickable` so it wins over the default hover
  background


## Testing

Local testing on built and locally hosted frontend. Go to the dashboard and open the measurement chart controls tab and there you should see the new multi-select for measurement locations / meters.



