### PR TITLE
1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## [1.8.5] - 2026-05-13
+
 ### Changed
 
 - Refactored `ShouldClamp` helper in `MeasurementProcedureCompiler` to check
@@ -81,11 +83,6 @@ and adheres to [Semantic Versioning](https://semver.org/).
   `IJSRuntime.InvokeAsync<IJSObjectReference>("import", ...)` and released on
   `IAsyncDisposable.DisposeAsync`, exposing a single `scrollItemIntoView(id)`
   helper that calls `scrollIntoView({ block: 'nearest', behavior: 'instant' })`
-- `ozds-searchable-select__item--highlighted` style in `app.css` using
-  `--mud-palette-primary-hover` background and `--mud-palette-primary` text to
-  match MudBlazor's primary-selected visual treatment, with selector specificity
-  bumped via `.mud-list-item-clickable` so it wins over the default hover
-  background
 
 ## [1.8.4] - 2026-04-24
 
@@ -852,6 +849,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - init
 
+[1.8.5]: https://github.com/altibiz/ozds/compare/1.8.4...1.8.5
 [1.8.4]: https://github.com/altibiz/ozds/compare/1.8.3...1.8.4
 [1.8.3]: https://github.com/altibiz/ozds/compare/1.8.2...1.8.3
 [1.8.2]: https://github.com/altibiz/ozds/compare/1.8.1...1.8.2


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description
### Changed

- Refactored `ShouldClamp` helper in `MeasurementProcedureCompiler` to check
  positively for floating-point CLR types (`decimal`, `float`, `double`) instead
  of negatively excluding the eight integer types (`byte`, `sbyte`, `short`,
  `ushort`, `int`, `uint`, `long`, `ulong`) for improved readability
- `GroupedColumn` on `OzdsColumnsComponentBase` no longer takes a top-level
  `searchable` flag and is no longer generic; sub-columns are now passed as
  `GroupedSubColumn` items via the new `SubColumn(...)` helpers, each with its
  own optional `searchable` flag and an optional separate label expression
- `MeterAnalysisColumns` and `MeasurementLocationAnalysisColumns` now render
  T1/T2 active energy sub-columns through `SubColumn(...)` with 2-decimal
  formatting via `NumericString(..., 2)` for display while keeping the raw
  decimal expression as the label source
- `MeasurementLineChart` reorders its conditional rendering to check for an
  empty selection (no measurement locations and no meters) first and otherwise
  renders the `ApexChart`, relying on ApexCharts' built-in no-data state when
  `Measurements.Items` is empty; the previous `if (items.Count == 0)` fallback
  in `GetItems()` has been removed, and the `Series` fallback to
  `Parameters.Measurements.Items` when no meter/location is supplied has been
  dropped (the empty-selection branch makes that case unreachable)
- `MeasurementChartHeader` now displays a translated empty-state message in
  place of the measure/unit/time-span text when no measurement location or meter
  is selected
- `MeasurementChartControls` disables the Measure, Phase, Multiplier,
  Resolution, and Refresh fields when no measurement location or meter is
  selected via a local `isNothingSelected` flag
- `MeasurementChartControls` now uses the new `SearchableSelectField` instead of
  plain `MudSelect` for both meters and measurement locations, with consistent
  `MudTooltip` wrappers showing the full list of current selections; the
  `OnMeasurementLocationsChanged` and `OnMetersChanged` callbacks now receive
  `IMeasurementLocation`/`IMeter` instances directly instead of resolving them
  from string ids
- `MeasurementLineChart` wraps the chart and its empty-state placeholder in a
  fixed-height container so chart re-renders no longer shift the chart-control
  selection fields above it
- `MudTooltip` overlays in `MeasurementChartControls` no longer block pointer
  events on the underlying fields; added a global
  `.mud-tooltip { pointer-events: none; }` rule and set `ShowOnFocus="false"` on
  the measure, phase, and multiplier tooltips so they no longer intercept clicks
  or steal focus
- `SelectField` dropdown no longer opens and immediately closes when clicked;
  removed the wrapper `<div @onpointerup="() => _inner.OpenMenu()">` and the
  `MudSelect _inner` ref that double-toggled the menu against `MudSelect`'s own
  click handling

### Added

- `GroupedSubColumn` record on `OzdsColumnsComponentBase` carrying separate
  value and label expressions plus a per-sub-column `searchable` flag
- `SubColumn(...)` helper overloads on `OzdsColumnsComponentBase` for building
  `GroupedSubColumn` items either from a single expression or from a separate
  value/label expression pair
- `Disabled` parameter on `EnumPicker` and `MultiEnumPicker`, forwarded to the
  inner `SelectField` and propagated to MudBlazor's `MudSelect` via captured
  attributes
- Translations `No measurement locations/meters are selected for display` and
  `No measurement location or meter selected` in `en.xml` and `hr.xml`
- `SearchableSelectField<T>` component in `Ozds.Client.Components.Fields`, a
  custom dropdown built on `MudPopover`, `MudList`, and `MudTextField`,
  providing search-as-you-type filtering with a case-sensitivity toggle, single-
  and multi-selection over arbitrary `ICollection<T>` collections, optional
  `ItemTemplate`, full keyboard navigation (ArrowUp/Down/Home/End to move the
  highlight, Enter to select, Escape to close, Tab to swap focus between search
  and list), a highlighted-row state with primary-tinted background and
  auto-scroll-into-view, plus per-render caching of the filtered list
  (invalidated on search/case/`Items` changes) and a `HashSet`-backed
  selected-value lookup for O(n) multi-selection rendering
- Collocated `searchable-select-field.js` ES module loaded on first render via
  `IJSRuntime.InvokeAsync<IJSObjectReference>("import", ...)` and released on
  `IAsyncDisposable.DisposeAsync`, exposing a single `scrollItemIntoView(id)`
  helper that calls `scrollIntoView({ block: 'nearest', behavior: 'instant' })`

