### PR TITLE
Select field improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- `SearchableSelectField<T>` now combines its dropdown list with `MudVirtualize`
+  instead of a `MudList` + `@foreach`, so dropdowns with thousands of items
+  render only the visible window plus an additional buffer of 6 rows for more
+  smooth transitions without loading
+- `SearchableSelectField<T>` filtered-items cache now stores
+  `List<(int Index, T Value)>` tuples directly, removing the per-render list
+  projection in the razor
+- internal text field now adds `AutoFocus` parameter so the user can start
+  typing as soon as the dropdown opens
+- `.ozds-searchable-select__list-wrap` now sets `overscroll-behavior: none` so
+  wheel scrolling inside the dropdown no longer chains to the page beneath
+- `SearchableSelectField<T>` keyboard scroll alignment no longer relies on
+  `document.getElementById` against per-item ids, since `MudVirtualize` is used,
+  now it uses fixed list item heights times index of the next highlighted item
+
 ## [1.8.5] - 2026-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - `SearchableSelectField<T>` keyboard scroll alignment no longer relies on
   `document.getElementById` against per-item ids, since `MudVirtualize` is used,
   now it uses fixed list item heights times index of the next highlighted item
+- `SearchableSelectField<T>` now inherits `OzdsComponentBase` instead of
+  implementing `IAsyncDisposable` directly
 
 ## [1.8.5] - 2026-05-13
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -206,3 +206,4 @@ words:
   - isexec
   - sbyte
   - compgen
+  - overscroll

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -207,3 +207,4 @@ words:
   - sbyte
   - compgen
   - overscroll
+  - overscan

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17251,7 +17251,7 @@
         No results
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 131 column 16
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 136 column 16
       </Metadata>
       <Value>
         No results

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17251,7 +17251,7 @@
         No results
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 131 column 16
+        From file 'Ozds.Client/Components/Fields/SearchableSelectField.razor' line 136 column 16
       </Metadata>
       <Value>
         Nema rezultata

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -6,6 +6,8 @@ using MudBlazor;
 
 namespace Ozds.Client.Components.Fields;
 
+// TODO: current toggle will not refresh internal list of selected items
+// in the future enable default behavior that will update the internal list
 public partial class SearchableSelectField<T> : IAsyncDisposable
 {
   private const string ModulePath =
@@ -85,6 +87,9 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   [Parameter]
   public string MaxPopoverHeight { get; set; } = "320px";
 
+  [Parameter]
+  public float ItemSize { get; set; } = 36f;
+
   [Parameter(CaptureUnmatchedValues = true)]
   public IDictionary<string, object>? AdditionalAttributes { get; set; }
 
@@ -101,7 +106,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   private MudTextField<string> _searchField = default!;
   private ElementReference _elementsField = default!;
 
-  private IReadOnlyList<T>? _filteredItemsCache;
+  private List<(int Index, T Value)>? _filteredItemsCache;
   private ICollection<T>? _previousItems;
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -203,7 +208,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
           && _highlightedIndex < filtered.Count
         )
         {
-          await ToggleItem(filtered[_highlightedIndex]);
+          await ToggleItem(filtered[_highlightedIndex].Value);
         }
         break;
     }
@@ -224,7 +229,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   private bool HasSelection =>
     MultiSelection ? SelectedValues?.Any() == true : Value is not null;
 
-  private IReadOnlyList<T> GetFilteredItems()
+  private List<(int Index, T Value)> GetFilteredItems()
   {
     return _filteredItemsCache ??= ComputeFilteredItems();
   }
@@ -234,11 +239,13 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     _filteredItemsCache = null;
   }
 
-  private IReadOnlyList<T> ComputeFilteredItems()
+  private List<(int Index, T Value)> ComputeFilteredItems()
   {
     if (string.IsNullOrWhiteSpace(_search))
     {
-      return Items is IReadOnlyList<T> list ? list : Items.ToList();
+      return Items
+        .Select((value, index) => (index, value))
+        .ToList();
     }
 
     var comparison = _caseSensitive
@@ -251,6 +258,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
         var text = GetDisplayText(item);
         return text.Contains(_search, comparison);
       })
+      .Select((value, index) => (index, value))
       .ToList();
   }
 
@@ -310,6 +318,9 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   {
     if (MultiSelection)
     {
+      // TODO: this may pull some overhead due to cloning the list
+      // both on method and then casting it into list again
+      // in future if need be, create optimization patch for this component
       var list = GetSelectedValuesList().ToList();
 
       var index = list.FindIndex(v =>
@@ -360,6 +371,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
 
   private string GetItemClass(bool selected, bool highlighted)
   {
+    // TODO: this could use string builder in the future
     var classes = new List<string> { "ozds-searchable-select__item" };
     if (!string.IsNullOrEmpty(ItemClass))
     {

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -241,9 +241,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   {
     if (string.IsNullOrWhiteSpace(_search))
     {
-      return Items
-        .Select((value, index) => (index, value))
-        .ToList();
+      return Items.Select((value, index) => (index, value)).ToList();
     }
 
     var comparison = _caseSensitive

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -3,12 +3,13 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using MudBlazor;
+using Ozds.Client.Components.Base;
 
 namespace Ozds.Client.Components.Fields;
 
 // TODO: current toggle will not refresh internal list of selected items
 // in the future enable default behavior that will update the internal list
-public partial class SearchableSelectField<T> : IAsyncDisposable
+public partial class SearchableSelectField<T> : OzdsComponentBase
 {
   private const string ModulePath =
     "/js/components/searchable-select-field/searchable-select-field.js";
@@ -111,7 +112,11 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   {
     if (firstRender)
     {
-      _module = await JS.InvokeAsync<IJSObjectReference>("import", ModulePath);
+      _module = await JS.InvokeAsync<IJSObjectReference>(
+        "import",
+        CancellationToken,
+        ModulePath
+      );
     }
   }
 
@@ -147,6 +152,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     {
       await _module.InvokeVoidAsync(
         "scrollIndexIntoView",
+        CancellationToken,
         _elementsField,
         _highlightedIndex,
         ItemSize
@@ -391,18 +397,27 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     return string.Join(" ", classes);
   }
 
-  public async ValueTask DisposeAsync()
+  protected override void Dispose(bool disposing)
   {
-    if (_module is null)
+    if (IsDisposed)
     {
       return;
     }
 
-    // NOTE: this catch is here because the disconnected exception
-    // does not signify an actual error in this case and can be safely ignored
+    if (disposing && _module is { } module)
+    {
+      _module = null;
+      _ = DisposeModuleAsync(module);
+    }
+
+    base.Dispose(disposing);
+  }
+
+  private static async Task DisposeModuleAsync(IJSObjectReference module)
+  {
     try
     {
-      await _module.DisposeAsync();
+      await module.DisposeAsync();
     }
     catch (JSDisconnectedException)
     {

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.cs
@@ -13,8 +13,6 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   private const string ModulePath =
     "/js/components/searchable-select-field/searchable-select-field.js";
 
-  private readonly string _instanceId = Guid.NewGuid().ToString("N");
-
   [Parameter]
   public string? Label { get; set; }
 
@@ -88,7 +86,7 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
   public string MaxPopoverHeight { get; set; } = "320px";
 
   [Parameter]
-  public float ItemSize { get; set; } = 36f;
+  public float ItemSize { get; set; } = 56f;
 
   [Parameter(CaptureUnmatchedValues = true)]
   public IDictionary<string, object>? AdditionalAttributes { get; set; }
@@ -129,8 +127,6 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     }
   }
 
-  private string GetItemId(int index) => $"ozds-ss-item-{_instanceId}-{index}";
-
   private void SetHighlightedIndex(int index)
   {
     var count = GetFilteredItems().Count;
@@ -150,8 +146,10 @@ public partial class SearchableSelectField<T> : IAsyncDisposable
     if (_module is not null && _highlightedIndex >= 0)
     {
       await _module.InvokeVoidAsync(
-        "scrollItemIntoView",
-        GetItemId(_highlightedIndex)
+        "scrollIndexIntoView",
+        _elementsField,
+        _highlightedIndex,
+        ItemSize
       );
     }
   }

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
@@ -72,6 +72,7 @@
                       Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search"
                       Margin="Margin.Dense"
+                      AutoFocus
                       Class="ozds-searchable-select__search"/>
       </div>
        <div
@@ -90,39 +91,44 @@
               }
             : null;
         }
-        @if (cachedFilteredItems.Any())
+        @if (cachedFilteredItems.Count > 0)
         {
-          <MudList T="T" Dense="@Dense" Class="ozds-searchable-select__list" >
-            @foreach (var (idx, item) in cachedFilteredItems.Index())
-            {
-              var selected = MultiSelection ? selectedSet!.Contains(item) : IsSelected(item);
-              var highlighted = idx == _highlightedIndex;
-
-              <MudListItem T="T"
-                           id="@GetItemId(idx)"
-                           OnClick="@(() => ToggleItem(item, idx))"
-                           Class="@GetItemClass(selected, highlighted)">
-                <div class="d-flex align-center ozds-searchable-select__item-content">
-                  @if (MultiSelection)
-                  {
-                    <MudCheckBox T="bool"
-                                 Value="selected"
-                                 ReadOnly="true"
-                                 Dense="true"
-                                 Class="mr-2 ozds-searchable-select__item-check"/>
-                  }
-                  @if (ItemTemplate is not null)
-                  {
-                    @ItemTemplate(item)
-                  }
-                  else
-                  {
-                    <span class="ozds-searchable-select__item-text">@GetDisplayText(item)</span>
-                  }
-                </div>
-              </MudListItem>
+          <MudVirtualize T="(int Index, T Value)"
+                         Items="@cachedFilteredItems"
+                         ItemSize="@ItemSize"
+                         OverscanCount="6"
+                         Context="entry"
+                         Enabled="true">
+            @{
+              var selected = MultiSelection
+                ? selectedSet!.Contains(entry.Value)
+                : IsSelected(entry.Value);
+              var highlighted = entry.Index == _highlightedIndex;
             }
-          </MudList>
+            <MudListItem T="T"
+                         id="@GetItemId(entry.Index)"
+                         OnClick="@(() => ToggleItem(entry.Value, entry.Index))"
+                         Class="@GetItemClass(selected, highlighted)">
+              <div class="d-flex align-center ozds-searchable-select__item-content">
+                @if (MultiSelection)
+                {
+                  <MudCheckBox T="bool"
+                               Value="selected"
+                               ReadOnly="true"
+                               Dense="true"
+                               Class="mr-2 ozds-searchable-select__item-check"/>
+                }
+                @if (ItemTemplate is not null)
+                {
+                  @ItemTemplate(entry.Value)
+                }
+                else
+                {
+                  <span class="ozds-searchable-select__item-text">@GetDisplayText(entry.Value)</span>
+                }
+              </div>
+            </MudListItem>
+          </MudVirtualize>
         }
         else
         {

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor
@@ -106,7 +106,6 @@
               var highlighted = entry.Index == _highlightedIndex;
             }
             <MudListItem T="T"
-                         id="@GetItemId(entry.Index)"
                          OnClick="@(() => ToggleItem(entry.Value, entry.Index))"
                          Class="@GetItemClass(selected, highlighted)">
               <div class="d-flex align-center ozds-searchable-select__item-content">

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -57,6 +57,7 @@
 
 .ozds-searchable-select__list-wrap {
   overflow-y: auto;
+  overscroll-behavior: none;
   flex: 1 1 auto;
   min-height: 0;
 }

--- a/src/Ozds.Server/wwwroot/js/components/searchable-select-field/searchable-select-field.js
+++ b/src/Ozds.Server/wwwroot/js/components/searchable-select-field/searchable-select-field.js
@@ -1,6 +1,14 @@
-export function scrollItemIntoView(id) {
-  document.getElementById(id)?.scrollIntoView({
-    block: "nearest",
-    behavior: "instant",
-  });
+export function scrollIndexIntoView(wrap, index, itemSize) {
+  if (!wrap) {
+    return;
+  }
+  const targetTop = index * itemSize;
+  const targetBottom = targetTop + itemSize;
+  const viewTop = wrap.scrollTop;
+  const viewBottom = viewTop + wrap.clientHeight;
+  if (targetTop < viewTop) {
+    wrap.scrollTop = targetTop;
+  } else if (targetBottom > viewBottom) {
+    wrap.scrollTop = targetBottom - wrap.clientHeight;
+  }
 }


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #332

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

I've changed the typical `@foreach` rendering with one using `MudVirtualize` this now prevents the select from loading the large amounts of data and displacing it on popover menu open/close.

For scroll issues - simple fix with  `overscroll-behavior: none` which prevents scroll from attaching to another component with scroll property that is parent of the specific component with this style definition.

### Changed

- `SearchableSelectField<T>` now combines its dropdown list with `MudVirtualize`
  instead of a `MudList` + `@foreach`, so dropdowns with thousands of items
  render only the visible window plus an additional buffer of 6 rows for more
  smooth transitions without loading
- `SearchableSelectField<T>` filtered-items cache now stores
  `List<(int Index, T Value)>` tuples directly, removing the per-render list
  projection in the razor
- internal text field now adds `AutoFocus` parameter so the user can start
  typing as soon as the dropdown opens
- `.ozds-searchable-select__list-wrap` now sets `overscroll-behavior: none` so
  wheel scrolling inside the dropdown no longer chains to the page beneath
- `SearchableSelectField<T>` keyboard scroll alignment no longer relies on
  `document.getElementById` against per-item ids, since `MudVirtualize` is used,
  now it uses fixed list item heights times index of the next highlighted item

## Testing

Testing frontend on local instance with custom created `SearchableSelectField` component with 2000+ items (it gathers about same delay as 100+ items on normal azure web app server). I recommend you to just create version of component in chart controls with 2000+ int type items just to test the latency of the popover component.


