### PR TITLE
333 generated pdfs of network user invoice bills are of centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and adheres to [Semantic Versioning](https://semver.org/).
   now it uses fixed list item heights times index of the next highlighted item
 - `SearchableSelectField<T>` now inherits `OzdsComponentBase` instead of
   implementing `IAsyncDisposable` directly
+- Fix, PDF document layout misalignment in `DocumentLayout.razor`: added
+  `box-sizing: border-box`
+- Fix, body offset on PDF export in `DocumentLayout.razor`: added
+  `html, body { margin: 0; padding: 0 }` inside `@@media print` to neutralize
+  Chromium's default 8px user-agent body margin during Playwright PDF rendering
 
 ## [1.8.5] - 2026-05-13
 

--- a/src/Ozds.Document/Components/DocumentLayout.razor
+++ b/src/Ozds.Document/Components/DocumentLayout.razor
@@ -40,6 +40,7 @@
   * {
     font-family: 'Roboto';
     font-size: 11pt;
+    box-sizing: border-box;
   }
 
   p, a, strong, span, td, th {
@@ -117,6 +118,10 @@
   @@media print {
     .page-break {
       display: none;
+    }
+    html, body {
+      margin: 0;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
# Task

Fixes #333 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- Fix, PDF document layout misalignment in `DocumentLayout.razor`: added
  `box-sizing: border-box`
- Fix, body offset on PDF export in `DocumentLayout.razor`: added
  `html, body { margin: 0; padding: 0 }` inside `@@media print` to neutralize
  Chromium's default 8px user-agent body margin during Playwright PDF rendering

## Testing

Local testing with generating network user invoice PDFs, user to notice how the documents are now aligned correctly and do not have empty space on page.


