### PR TITLE
UseMemo like state guard for changes implementation

### DIFF
--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -8,6 +8,7 @@ using Ozds.Business.Observers.EventArgs;
 using Ozds.Business.Queries;
 using Ozds.Business.Queries.Abstractions;
 using Ozds.Client.Components.Base;
+using Ozds.Client.Services;
 
 namespace Ozds.Client.Components.Charts;
 
@@ -48,6 +49,9 @@ public partial class MeasurementChartControls : OzdsComponentBase
 
   [Inject]
   private TimeQueries TimeQueries { get; set; } = default!;
+
+  [Inject]
+  private StateGuard StateGuard { get; set; } = default!;
 
   protected override void OnInitialized()
   {
@@ -147,6 +151,20 @@ public partial class MeasurementChartControls : OzdsComponentBase
 
   protected override async Task OnParametersSetAsync()
   {
+    if (
+      !StateGuard.Changed(
+        [
+        Dep.SetEquality(_parameters.Meters),
+        Dep.SetEquality(_parameters.MeasurementLocations),
+        Dep.Of(_parameters.Resolution),
+        Dep.Of(_parameters.Multiplier),
+        ]
+      )
+    )
+    {
+      return;
+    }
+
     await Fetch();
   }
 

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementChartControls.cs
@@ -152,14 +152,12 @@ public partial class MeasurementChartControls : OzdsComponentBase
   protected override async Task OnParametersSetAsync()
   {
     if (
-      !StateGuard.Changed(
-        [
+      !StateGuard.Changed([
         Dep.SetEquality(_parameters.Meters),
         Dep.SetEquality(_parameters.MeasurementLocations),
         Dep.Of(_parameters.Resolution),
         Dep.Of(_parameters.Multiplier),
-        ]
-      )
+      ])
     )
     {
       return;

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.cs
@@ -6,6 +6,7 @@ using Ozds.Business.Models.Enums;
 using Ozds.Business.Queries;
 using Ozds.Client.Components.Base;
 using Ozds.Client.Extensions;
+using Ozds.Client.Services;
 using Ozds.Client.State;
 
 namespace Ozds.Client.Components.Charts;
@@ -31,6 +32,9 @@ public partial class MeasurementLineChart : OzdsComponentBase
   [Inject]
   private TimeQueries TimeQueries { get; set; } = default!;
 
+  [Inject]
+  private StateGuard StateGuard { get; set; } = default!;
+
   [Parameter]
   public MeasurementChartParameters Parameters { get; set; } = default!;
 
@@ -50,9 +54,17 @@ public partial class MeasurementLineChart : OzdsComponentBase
 
   protected override async Task OnParametersSetAsync()
   {
-    _options = CreateGraphOptions();
-    if (_chart is { } chart)
+
+    if (
+      StateGuard.Changed(
+        [
+          Dep.Of(Parameters.Measurements),
+        ]
+      )
+      && _chart is { } chart
+      )
     {
+      _options = CreateGraphOptions();
       await chart.UpdateSeriesAsync();
       await chart.UpdateOptionsAsync(false, true, false);
     }

--- a/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.cs
+++ b/src/Ozds.Client/Components/Charts/Measurements/MeasurementLineChart.cs
@@ -54,15 +54,10 @@ public partial class MeasurementLineChart : OzdsComponentBase
 
   protected override async Task OnParametersSetAsync()
   {
-
     if (
-      StateGuard.Changed(
-        [
-          Dep.Of(Parameters.Measurements),
-        ]
-      )
+      StateGuard.Changed([Dep.Of(Parameters.Measurements)])
       && _chart is { } chart
-      )
+    )
     {
       _options = CreateGraphOptions();
       await chart.UpdateSeriesAsync();

--- a/src/Ozds.Client/Extensions/HostExtensions.cs
+++ b/src/Ozds.Client/Extensions/HostExtensions.cs
@@ -3,6 +3,7 @@ using Blazored.LocalStorage;
 using MudBlazor.Services;
 using Ozds.Client.Components.Models;
 using Ozds.Client.Components.Models.Abstractions;
+using Ozds.Client.Services;
 
 namespace Ozds.Client.Extensions;
 
@@ -16,6 +17,7 @@ public static class HostExtensions
     builder.AddBlazor();
     builder.AddLocalStorage();
     builder.AddUi();
+    builder.AddStateChangeGuard();
     return builder;
   }
 
@@ -73,6 +75,14 @@ public static class HostExtensions
   {
     builder.Services.AddBlazoredLocalStorage();
 
+    return builder;
+  }
+
+  private static IHostApplicationBuilder AddStateChangeGuard(
+    this IHostApplicationBuilder builder
+  )
+  {
+    builder.Services.AddTransient<StateGuard>();
     return builder;
   }
 }

--- a/src/Ozds.Client/Services/StateGuard.cs
+++ b/src/Ozds.Client/Services/StateGuard.cs
@@ -1,0 +1,125 @@
+using System.Runtime.CompilerServices;
+
+namespace Ozds.Client.Services;
+
+public sealed class StateGuard : IDisposable
+{
+  private readonly Dictionary<CallSite, Dep[]> _entries = new();
+
+  private bool _disposed;
+
+  public bool Changed(
+    Dep[] deps,
+    [CallerFilePath] string? filePath = null,
+    [CallerLineNumber] int lineNumber = 0
+  )
+  {
+    ObjectDisposedException.ThrowIf(_disposed, this);
+
+    var key = new CallSite(filePath, lineNumber);
+
+    if (
+      _entries.TryGetValue(key, out var prev)
+      && prev.Length == deps.Length
+      && DepsEqual(prev, deps)
+    )
+    {
+      return false;
+    }
+
+    _entries[key] = Snapshot(deps);
+    return true;
+  }
+
+  public void Dispose()
+  {
+    if (_disposed)
+    {
+      return;
+    }
+
+    _entries.Clear();
+    _disposed = true;
+  }
+
+  private static bool DepsEqual(Dep[] prev, Dep[] next)
+  {
+    for (var i = 0; i < prev.Length; i++)
+    {
+      if (!next[i].Comparer(prev[i].Value, next[i].Value))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static Dep[] Snapshot(Dep[] deps)
+  {
+    var copy = new Dep[deps.Length];
+    for (var i = 0; i < deps.Length; i++)
+    {
+      copy[i] = deps[i].WithSnapshottedValue();
+    }
+
+    return copy;
+  }
+
+  private readonly record struct CallSite(string? File, int Line);
+}
+
+public readonly struct Dep
+{
+
+  internal static readonly Func<object?, object?, bool> DefaultComparer =
+    static (a, b) => Equals(a, b);
+
+  internal readonly object? Value;
+
+  private readonly Func<object?, object?, bool>? _comparer;
+  private readonly Func<object?, object?>? _snapshot;
+
+  private Dep(
+    object? value,
+    Func<object?, object?, bool>? comparer,
+    Func<object?, object?>? snapshot
+  )
+  {
+    Value = value;
+    _comparer = comparer;
+    _snapshot = snapshot;
+  }
+
+  internal Func<object?, object?, bool> Comparer =>
+    _comparer ?? DefaultComparer;
+
+  public static Dep Of<T>(T value) => new(value, null, null);
+
+  public static Dep Of<T>(T value, Func<T?, T?, bool> equals) =>
+    new(value, (a, b) => equals((T?)a, (T?)b), null);
+
+  public static Dep Of<T>(T value, IEqualityComparer<T> comparer) =>
+    new(value, (a, b) => comparer.Equals((T)a!, (T)b!), null);
+
+  public static Dep SetEquality<T>(HashSet<T> value) =>
+    new(
+      value,
+      static (a, b) =>
+        (a is null) == (b is null)
+        && (a is null || ((HashSet<T>)a).SetEquals((HashSet<T>)b!)),
+      static v => new HashSet<T>((HashSet<T>)v!, ((HashSet<T>)v!).Comparer)
+    );
+
+  public static Dep SequenceEquality<T>(IEnumerable<T> value) =>
+    new(
+      value,
+      static (a, b) =>
+        (a is null) == (b is null)
+        && (a is null || ((IEnumerable<T>)a).SequenceEqual((IEnumerable<T>)b!)),
+      static v => ((IEnumerable<T>)v!).ToList()
+    );
+
+  internal Dep WithSnapshottedValue() =>
+    _snapshot is null ? this : new Dep(_snapshot(Value), _comparer, null);
+}

--- a/src/Ozds.Client/Services/StateGuard.cs
+++ b/src/Ozds.Client/Services/StateGuard.cs
@@ -71,7 +71,6 @@ public sealed class StateGuard : IDisposable
 
 public readonly struct Dep
 {
-
   internal static readonly Func<object?, object?, bool> DefaultComparer =
     static (a, b) => Equals(a, b);
 


### PR DESCRIPTION
# Task

@brunoAltinet 

- [x] I read `CONTRIBUTING.md`
- [ ] I modified `CHANGELOG.md`

## Description

### Index

The main issue this PR is here to address is the single implementation of the guard that will be able to prevent constant re-triggering of both rendering and costly operations on components with cascading parameters inherited from their parents or unguarded changes on it's own parameters. 

For an example take `MeasurementLineChart` as example. One of the properties set inside this component is `Parameters`. It's an outside information-bag class that is passed into `MeasurementLineComponent`  component as in `MeasurementChartControls.razor`:

```cs
<MeasurementChartHeader Parameters="_parameters"/>
```

This property consists of attributes that are vital to react upon if they change so the state of the chart follows the parameters set by it's user. The `MeasurementLineChart` component also consists of cascading parameters:

```cs
  [CascadingParameter]
  public Breakpoint Breakpoint { get; set; }

  [CascadingParameter]
  public ThemeState ThemeState { get; set; } = default!;
```

These are inherited from parent and may trigger `OnParameterChange()` or `OnParameterChangeAsync()` methods which may execute very expensive calculation or querying methods if left unattended. 

In context of this problem there really is one solution and this is to have a state change guard which will compare between two versions (previous and current) of variables and determine if the expensive calculations are worth to execute again.

But there are different levels of abstraction that one may take in implementing this solution.

#### No. 1 - lowest level - manually integrate simple guard into components

In this project this has already been done. Example in `AnalysisStateProvider`:

```cs
 protected override void OnParametersSet()
 {
   if (
     _previousRepresentativeId == RepresentativeState.Representative.Id
     && _previousLocationId == LocationState.Location?.Id
   )
   {
     return;
   }

   _previousRepresentativeId = RepresentativeState.Representative.Id;
   _previousLocationId = LocationState.Location?.Id;

   ResetNoRender();
 }
``` 

It's a simple if-else gater which prevents expensive recalculation if properties stay the same. 

Now this is what I would've originally gone with if there weren't a lot of checks needed for `MeasurementLineChart` (especially in options sector) and possible future integrations including having to write all of this boilerplate for other unused charts which might eventually be used in the future.  This example is the most simple one with least overhead added into the code but a lot of boilerplate variables needed to check which might pollute the look of code on more serious offenders (`MeasurementLineChart`, `MeasurementChartControls`).


#### No 2. - medium abstraction level - current PR's `StateGuard` implementation

This is essentially just the previous entry but with extra layer of abstraction which is supposed to make this checks more "Fire-and-forget".

The `StateGuard` itself is implemented as a Service. It was integrated as a transient service since because of SignalR connections bend a little lifetimes of services (Scoped is essentially Singleton on it's SignalR circuit). 

```
  private static IHostApplicationBuilder AddStateChangeGuard(
    this IHostApplicationBuilder builder
  )
  {
    builder.Services.AddTransient<StateGuard>();
    return builder;
  }
```

Essentially the need to actually manage and initialize the guard object has been outsourced to service provider and now it only needs to be injected into components in `Ozds.Client` project.

```cs
  [Inject]
  private StateGuard StateGuard { get; set; } = default!;
```

The whole guard itself was modeled after React's `useMemo()` hook. It uses attributes `[CallerFilePath]` & `[CallerLineNumber]` which are resolved at compile time and determine key inside the Dictionary which holds the information about saved attributes in wrappers `Dep` (short for dependencies).

This type of implementation ensures that the user of this guard only needs to call the function they want which is provided by the guard service. While `Dep` class can be further modified to provide more types of "comparators" for exising object.

This still will add more overhead and won't exactly be smaller than the previous method but it will keep the component code much smaller since most of the variable initialization and holding will be outsourced to the guard service. 

Down below is example of usage of guard service to prevent accidental trigger of Fetch() query inside `MeasurementChartControls`:

```cs
protected override async Task OnParametersSetAsync()
{
  if (
    !StateGuard.Changed(
      [
      Dep.SetEquality(_parameters.Meters),
      Dep.SetEquality(_parameters.MeasurementLocations),
      Dep.Of(_parameters.Resolution),
      Dep.Of(_parameters.Multiplier),
      ]
    )
  )
  {
    return;
  }

  await Fetch();
}
```

NOTE: my implementation is just a prototype and may be prone to changes based on further testing ahead that I need to do

#### No 3. - high abstraction level - MudBlazor's `ParameterState`

MudBlazor introduced a per-parameter change-tracking mechanism as `ParameterState` Instead of a guard the component calls into, the framework itself drives parameter dispatch: every tracked parameter is registered once, and the base class is responsible for diffing the previous and current value of each parameter on every `SetParametersAsync`, then routing only the actually changed parameters to your handlers.

The idea is that the component never sees OnParametersSet/OnParametersSetAsync at all, it handlers fire on specific deltas, not on the Blazor component lifecycle event.

This one sounds nice but the problem is that it would require a little bigger refactor of the base component class along with some of the methods and overrides that the `ParameterState` provides. 

This isn't much of a problem as is the limited scope of usage. `ParameterState` cannot concatenate change events and is used only on parameters - in short, if you have multiple parameters which cause same method or even logic to fire you would need to construct a separate method which is used as a gating mechanism so it won't fire on each parameter change if they all happen at the same time. 


## Testing

Testing can be done in full on local environment. Usually you can implement the guard on the offending `OnParametersSet(Async)` and check the program flow with break points (if your IDE supports it). 

