### PR TITLE
252 add specific window or collapse notificationsevents long content messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,31 +11,25 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- `ClipboardService` (scoped) wrapping the browser `navigator.clipboard`
-  read/write over JS interop
-- `CopyButton` component (a `MudIconButton`) that copies its `Text` to the
-  clipboard via `ClipboardService`, with a `Size` parameter (defaults to
-  `Medium`) and `OnCopied` / `OnCopyFailed` callbacks
-- `ScrollablePreField<T>` helper on `OzdsDetailsComponentBase`, a wrapper around
-  `DetailsField` + `MudPaper` that renders preformatted content (notification
-  bodies, event JSON payloads) inside a fixed-height, vertically-scrollable,
-  horizontally-resizable card topped by a slightly darker `MudToolBar` header
-  that holds left-aligned expand/collapse and `CopyButton` triggers
-- `MaxWidth` parameter on `DetailsField` (defaults to `36rem`) so callers can
-  opt into a wider layout
-- `WrapText` bool parameter on `ScrollablePreField` (forwarded by both
-  `ScrollablePreField` helper overloads via `wrapText`, default `false`) that
-  switches the content `<pre>` from horizontal scroll to soft-wrap
+- `ClipboardService` (scoped) wrapping `navigator.clipboard` over JS interop
+- `CopyButton` component (a `MudIconButton`) that copies its `Text` via
+  `ClipboardService`, with `Size`, `OnCopied`, and `OnCopyFailed` parameters
+- `ScrollablePreField<T>` helper on `OzdsDetailsComponentBase` that renders
+  preformatted content in a `MudPaper` card with a `MudToolBar` header (line
+  count, expand/collapse, copy) over a scrollable, line-numbered code block
+- `ScrollablePreField.razor.css` scoped stylesheet (first Blazor CSS isolation
+  file in the project; wired up via `Ozds.Client.styles.css` in `_AppLayout`)
+- `line` / `lines` translations for the line count
+- `MaxWidth` parameter on `DetailsField` (defaults to `36rem`)
+- `WrapText` parameter on `ScrollablePreField` (default `false`) to soft-wrap
+  content instead of scrolling horizontally
 
 ### Changed
 
-- `NotificationDetails` now renders `Content` via the new `ScrollablePreField`,
-  with `maxHeight: 400` and `wrapText: true`
-- `EventDetails` now renders `Content` via `ScrollablePreField` with
-  `wrapText: true`
-- `ApiKeyPage` now shows a `CopyButton` next to the freshly created API key
-  token (the token keeps horizontal overflow) so it can be copied in one click
-  instead of being selected by hand
+- `NotificationDetails` renders `Content` via `ScrollablePreField`
+  (`maxHeight: 400`, `wrapText: true`)
+- `EventDetails` renders `Content` via `ScrollablePreField` (`wrapText: true`)
+- `ApiKeyPage` shows a `CopyButton` next to a freshly created API key token
 - `SearchableSelectField<T>` now combines its dropdown list with `MudVirtualize`
   instead of a `MudList` + `@foreach`, so dropdowns with thousands of items
   render only the visible window plus an additional buffer of 6 rows for more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,31 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `ClipboardService` (scoped) wrapping the browser `navigator.clipboard`
+  read/write over JS interop
+- `CopyButton` component (a `MudIconButton`) that copies its `Text` to the
+  clipboard via `ClipboardService`, with a `Size` parameter (defaults to
+  `Medium`) and `OnCopied` / `OnCopyFailed` callbacks
 - `ScrollablePreField<T>` helper on `OzdsDetailsComponentBase`, a wrapper around
   `DetailsField` + `MudPaper` that renders preformatted content (notification
   bodies, event JSON payloads) inside a fixed-height, vertically-scrollable,
-  horizontally-resizable card
+  horizontally-resizable card topped by a slightly darker `MudToolBar` header
+  that holds left-aligned expand/collapse and `CopyButton` triggers
 - `MaxWidth` parameter on `DetailsField` (defaults to `36rem`) so callers can
   opt into a wider layout
+- `WrapText` bool parameter on `ScrollablePreField` (forwarded by both
+  `ScrollablePreField` helper overloads via `wrapText`, default `false`) that
+  switches the content `<pre>` from horizontal scroll to soft-wrap
 
 ### Changed
 
-- `NotificationDetails` now renders `Content` via the new `ScrollablePreField`
-- `EventDetails` now renders `Content` via `ScrollablePreField`
+- `NotificationDetails` now renders `Content` via the new `ScrollablePreField`,
+  with `maxHeight: 400` and `wrapText: true`
+- `EventDetails` now renders `Content` via `ScrollablePreField` with
+  `wrapText: true`
+- `ApiKeyPage` now shows a `CopyButton` next to the freshly created API key
+  token (the token keeps horizontal overflow) so it can be copied in one click
+  instead of being selected by hand
 - `SearchableSelectField<T>` now combines its dropdown list with `MudVirtualize`
   instead of a `MudList` + `@foreach`, so dropdowns with thousands of items
   render only the visible window plus an additional buffer of 6 rows for more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,19 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- `ScrollablePreField<T>` helper on `OzdsDetailsComponentBase`, a wrapper around
+  `DetailsField` + `MudPaper` that renders preformatted content (notification
+  bodies, event JSON payloads) inside a fixed-height, vertically-scrollable,
+  horizontally-resizable card
+- `MaxWidth` parameter on `DetailsField` (defaults to `36rem`) so callers can
+  opt into a wider layout
+
 ### Changed
 
+- `NotificationDetails` now renders `Content` via the new `ScrollablePreField`
+- `EventDetails` now renders `Content` via `ScrollablePreField`
 - `SearchableSelectField<T>` now combines its dropdown list with `MudVirtualize`
   instead of a `MudList` + `@foreach`, so dropdowns with thousands of items
   render only the visible window plus an additional buffer of 6 rows for more

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -12975,6 +12975,28 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        line
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 36
+      </Metadata>
+      <Value>
+        line
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        lines
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 55
+      </Metadata>
+      <Value>
+        lines
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         List
       </Key>
       <Metadata>

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -12975,28 +12975,6 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
-        line
-      </Key>
-      <Metadata>
-        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 36
-      </Metadata>
-      <Value>
-        line
-      </Value>
-    </TranslationDictionaryItem>
-    <TranslationDictionaryItem>
-      <Key>
-        lines
-      </Key>
-      <Metadata>
-        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 55
-      </Metadata>
-      <Value>
-        lines
-      </Value>
-    </TranslationDictionaryItem>
-    <TranslationDictionaryItem>
-      <Key>
         List
       </Key>
       <Metadata>
@@ -17301,16 +17279,16 @@
         From file 'Ozds.Client/Components/Fields/ScrollablePreField.razor' line 8 column 13
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 214 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 270 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 295 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 321 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 342 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 363 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 382 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 406 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 444 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 200 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 218 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 274 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 299 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 325 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 346 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 367 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 386 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 410 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 448 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 204 column 36
       </Metadata>
       <Value>
         None

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17267,16 +17267,17 @@
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 183 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 239 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 264 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 290 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 311 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 332 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 351 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 375 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 413 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 169 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 176 column 26
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 211 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 267 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 292 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 318 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 339 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 360 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 379 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 403 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 441 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 197 column 36
       </Metadata>
       <Value>
         None

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -6917,6 +6917,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        Copy
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Buttons/CopyButton.razor' line 8 column 24
+      </Metadata>
+      <Value>
+        Copy
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         Count
       </Key>
       <Metadata>
@@ -17265,19 +17276,19 @@
         From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 26 column 12
         From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 27 column 12
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
+        From file 'Ozds.Client/Components/Fields/ScrollablePreField.razor' line 8 column 13
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 176 column 26
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 211 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 267 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 292 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 318 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 339 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 360 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 379 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 403 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 441 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 197 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 214 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 270 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 295 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 321 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 342 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 363 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 382 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 406 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 444 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 200 column 36
       </Metadata>
       <Value>
         None
@@ -17977,7 +17988,7 @@
         Please copy this key (it won't be shown again):
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Pages/Administration/ApiKeyPage.razor' line 54 column 17
+        From file 'Ozds.Client/Pages/Administration/ApiKeyPage.razor' line 56 column 17
       </Metadata>
       <Value>
         Please copy this key (it will not be shown again):

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -12974,6 +12974,28 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        line
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 36
+      </Metadata>
+      <Value>
+        redak
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
+        lines
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 55
+      </Metadata>
+      <Value>
+        redaka
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         List
       </Key>
       <Metadata>

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17267,16 +17267,17 @@
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 183 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 239 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 264 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 290 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 311 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 332 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 351 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 375 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 413 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 169 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 176 column 26
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 211 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 267 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 292 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 318 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 339 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 360 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 379 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 403 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 441 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 197 column 36
       </Metadata>
       <Value>
         Nema

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -6916,6 +6916,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        Copy
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Buttons/CopyButton.razor' line 8 column 24
+      </Metadata>
+      <Value>
+        Kopiraj
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         Count
       </Key>
       <Metadata>
@@ -17265,19 +17276,19 @@
         From file 'Ozds.Client/Components/Fields/EnumPicker.razor' line 26 column 12
         From file 'Ozds.Client/Components/Fields/MultiEnumPicker.razor' line 27 column 12
         From file 'Ozds.Client/Components/Fields/PolymorphicIdField.razor' line 29 column 10
+        From file 'Ozds.Client/Components/Fields/ScrollablePreField.razor' line 8 column 13
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 176 column 26
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 211 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 267 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 292 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 318 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 339 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 360 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 379 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 403 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 441 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 197 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 214 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 270 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 295 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 321 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 342 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 363 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 382 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 406 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 444 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 200 column 36
       </Metadata>
       <Value>
         Nema
@@ -18025,7 +18036,7 @@
         Please copy this key (it won't be shown again):
       </Key>
       <Metadata>
-        From file 'Ozds.Client/Pages/Administration/ApiKeyPage.razor' line 54 column 17
+        From file 'Ozds.Client/Pages/Administration/ApiKeyPage.razor' line 56 column 17
       </Metadata>
       <Value>
         Molimo kopirajte ovaj ključ (neće biti prikazan ponovno):

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -12974,28 +12974,6 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
-        line
-      </Key>
-      <Metadata>
-        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 36
-      </Metadata>
-      <Value>
-        redak
-      </Value>
-    </TranslationDictionaryItem>
-    <TranslationDictionaryItem>
-      <Key>
-        lines
-      </Key>
-      <Metadata>
-        From file 'Ozds.Client/Components/Fields/ScrollablePreField.cs' line 51 column 55
-      </Metadata>
-      <Value>
-        redaka
-      </Value>
-    </TranslationDictionaryItem>
-    <TranslationDictionaryItem>
-      <Key>
         List
       </Key>
       <Metadata>
@@ -17301,16 +17279,16 @@
         From file 'Ozds.Client/Components/Fields/ScrollablePreField.razor' line 8 column 13
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 122 column 19
         From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 148 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 214 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 270 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 295 column 21
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 321 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 342 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 363 column 19
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 382 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 406 column 16
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 444 column 17
-        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 200 column 36
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 218 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 274 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 299 column 21
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 325 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 346 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 367 column 19
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 386 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 410 column 16
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 448 column 17
+        From file 'Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor' line 204 column 36
       </Metadata>
       <Value>
         Nema

--- a/src/Ozds.Client/Components/Buttons/CopyButton.cs
+++ b/src/Ozds.Client/Components/Buttons/CopyButton.cs
@@ -7,7 +7,6 @@ namespace Ozds.Client.Components.Buttons;
 
 public partial class CopyButton : OzdsComponentBase
 {
-
   [Parameter]
   public string? Text { get; set; }
 

--- a/src/Ozds.Client/Components/Buttons/CopyButton.cs
+++ b/src/Ozds.Client/Components/Buttons/CopyButton.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Ozds.Client.Components.Base;
+using Ozds.Client.Services;
+
+namespace Ozds.Client.Components.Buttons;
+
+public partial class CopyButton : OzdsComponentBase
+{
+
+  [Parameter]
+  public string? Text { get; set; }
+
+  [Parameter]
+  public Size Size { get; set; } = Size.Medium;
+
+  [Parameter]
+  public EventCallback OnCopied { get; set; }
+
+  [Parameter]
+  public EventCallback<Exception> OnCopyFailed { get; set; }
+
+  [Inject]
+  private ClipboardService ClipboardService { get; set; } = default!;
+
+  [Inject]
+  private ISnackbar Snackbar { get; set; } = default!;
+
+  private async Task Copy()
+  {
+    if (Text is null)
+    {
+      return;
+    }
+
+    try
+    {
+      await ClipboardService.WriteTextAsync(Text);
+      Snackbar.Add("Copied to clipboard", Severity.Success);
+      await OnCopied.InvokeAsync();
+    }
+    catch (Exception ex)
+    {
+      Snackbar.Add("Copy failed", Severity.Success);
+      await OnCopyFailed.InvokeAsync(ex);
+    }
+  }
+}

--- a/src/Ozds.Client/Components/Buttons/CopyButton.razor
+++ b/src/Ozds.Client/Components/Buttons/CopyButton.razor
@@ -1,0 +1,8 @@
+@namespace Ozds.Client.Components.Buttons
+@using MudBlazor
+@inherits Ozds.Client.Components.Base.OzdsComponentBase
+
+<MudIconButton Size="@Size"
+               Icon="@Icons.Material.Outlined.FileCopy"
+               OnClick="@Copy"
+               title="@Translate("Copy")"/>

--- a/src/Ozds.Client/Components/Fields/DetailsField.razor
+++ b/src/Ozds.Client/Components/Fields/DetailsField.razor
@@ -4,7 +4,7 @@
 @{
   RenderFragment innerBig = @<div
                                class="@("mt-2 d-flex flex-column " + Class)"
-                               style="@("max-width: 36rem; " + Style)">
+                               style="@($"max-width: {MaxWidth}; " + Style)">
                               <MudText Typo="Typo.body1">
                                 <b>@(Title)</b>:
                               </MudText>
@@ -15,7 +15,7 @@
 
   RenderFragment innerSmall = @<div
                                  class="@("mt-2 d-flex flex-row justify-space-between align-items-end " + Class)"
-                                 style="@("max-width: 36rem; " + Style)">
+                                 style="@($"max-width: {MaxWidth}; " + Style)">
                                 <MudText Typo="Typo.body1">
                                   <b>@(Title)</b>:
                                 </MudText>
@@ -58,5 +58,8 @@ else
 
   [Parameter]
   public bool LargeContent { get; set; }
+
+  [Parameter]
+  public string MaxWidth {get; set;} = "36rem";
 
 }

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
 using MudBlazor;
 using Ozds.Client.Components.Base;
 

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Ozds.Client.Components.Base;
+
+namespace Ozds.Client.Components.Fields;
+
+public partial class ScrollablePreField : OzdsComponentBase
+{
+  private bool _expanded;
+
+  [Parameter]
+  public string? Content { get; set; }
+
+  [Parameter]
+  public int MaxHeight { get; set; } = 600;
+
+  [Parameter]
+  public bool ShowLineNumbers { get; set; }
+
+  [Parameter]
+  public EventCallback<bool> ExpandedChanged { get; set; }
+
+  private string PaperStyle
+  {
+    get
+    {
+      return _expanded
+        ? "overflow-y: auto; overscroll-behavior: none;"
+        : $"max-height: {MaxHeight}px; overflow-y: auto; overscroll-behavior: none;";
+    }
+  }
+
+  private string ExpandIcon
+  {
+    get
+    {
+      return _expanded
+        ? Icons.Material.Filled.UnfoldLess
+        : Icons.Material.Filled.UnfoldMore;
+    }
+  }
+
+  private string ExpandTitle
+  {
+    get
+    {
+      return _expanded ? Translate("Collapse") : Translate("Expand");
+    }
+  }
+
+  private string LineNumbers
+  {
+    get
+    {
+      if (string.IsNullOrEmpty(Content))
+      {
+        return string.Empty;
+      }
+
+      var count = 1;
+      foreach (var c in Content)
+      {
+        if (c == '\n')
+        {
+          count++;
+        }
+      }
+
+      return string.Join('\n', Enumerable.Range(1, count));
+    }
+  }
+
+  private async Task ToggleExpanded()
+  {
+    _expanded = !_expanded;
+    await ExpandedChanged.InvokeAsync(_expanded);
+  }
+}

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor;
 using Ozds.Client.Components.Base;
 
@@ -15,12 +16,12 @@ public partial class ScrollablePreField : OzdsComponentBase
   public int MaxHeight { get; set; } = 600;
 
   [Parameter]
-  public bool ShowLineNumbers { get; set; }
+  public bool WrapText { get; set; }
 
   [Parameter]
   public EventCallback<bool> ExpandedChanged { get; set; }
 
-  private string PaperStyle
+  private string ScrollStyle
   {
     get
     {
@@ -29,6 +30,11 @@ public partial class ScrollablePreField : OzdsComponentBase
         : $"max-height: {MaxHeight}px; overflow-y: auto; overscroll-behavior: none;";
     }
   }
+
+  private static string HeaderStyle =>
+    "min-height: 48px;"
+    + " background-color: var(--mud-palette-background-gray);"
+    + " border-bottom: 1px solid var(--mud-palette-lines-default);";
 
   private string ExpandIcon
   {
@@ -45,28 +51,6 @@ public partial class ScrollablePreField : OzdsComponentBase
     get
     {
       return _expanded ? Translate("Collapse") : Translate("Expand");
-    }
-  }
-
-  private string LineNumbers
-  {
-    get
-    {
-      if (string.IsNullOrEmpty(Content))
-      {
-        return string.Empty;
-      }
-
-      var count = 1;
-      foreach (var c in Content)
-      {
-        if (c == '\n')
-        {
-          count++;
-        }
-      }
-
-      return string.Join('\n', Enumerable.Range(1, count));
     }
   }
 

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
@@ -48,10 +48,7 @@ public partial class ScrollablePreField : OzdsComponentBase
 
   private string ExpandTitle
   {
-    get
-    {
-      return _expanded ? Translate("Collapse") : Translate("Expand");
-    }
+    get { return _expanded ? Translate("Collapse") : Translate("Expand"); }
   }
 
   private async Task ToggleExpanded()

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.cs
@@ -18,22 +18,41 @@ public partial class ScrollablePreField : OzdsComponentBase
   public bool WrapText { get; set; }
 
   [Parameter]
+  public bool ShowLineNumbers { get; set; } = true;
+
+  [Parameter]
   public EventCallback<bool> ExpandedChanged { get; set; }
 
-  private string ScrollStyle
+  private string[] _lines = [];
+
+  private string[] Lines => _lines;
+
+  protected override void OnParametersSet()
+  {
+    _lines = Content is null
+      ? []
+      : Content.ReplaceLineEndings("\n").Split('\n');
+  }
+
+  private string ContainerVars
   {
     get
     {
-      return _expanded
-        ? "overflow-y: auto; overscroll-behavior: none;"
-        : $"max-height: {MaxHeight}px; overflow-y: auto; overscroll-behavior: none;";
+      var digits = Lines.Length.ToString().Length;
+      return $"overflow: hidden; --spf-max-height: {MaxHeight}px;"
+        + $" --spf-gutter: {digits}ch;";
     }
   }
 
-  private static string HeaderStyle =>
-    "min-height: 48px;"
-    + " background-color: var(--mud-palette-background-gray);"
-    + " border-bottom: 1px solid var(--mud-palette-lines-default);";
+  private string LineCountLabel
+  {
+    get
+    {
+      var count = Lines.Length;
+      var unit = count == 1 ? Translate("line") : Translate("lines");
+      return $"{count} {unit}";
+    }
+  }
 
   private string ExpandIcon
   {

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.razor
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.razor
@@ -9,31 +9,51 @@
 }
 else
 {
-  <MudPaper Elevation="1"
-            Class="d-flex flex-column"
-            Style="overflow: hidden;">
+  <MudPaper Elevation="1" Style="@ContainerVars">
     <MudToolBar Dense="true"
                 Gutters="false"
-                Class="px-1"
-                Style="@HeaderStyle">
+                Class="px-2"
+                Style="background-color: var(--mud-palette-background-gray);">
+      <MudIcon Icon="@Icons.Material.Outlined.Code"
+               Size="Size.Small"
+               Class="mr-2"
+               Style="color: var(--mud-palette-text-secondary);"/>
+      <MudText Typo="Typo.caption"
+               Style="color: var(--mud-palette-text-secondary);">
+        @LineCountLabel
+      </MudText>
+      <MudSpacer/>
       <MudTooltip Text="@ExpandTitle">
-        <MudIconButton Size="Size.Medium"
+        <MudIconButton Size="Size.Small"
                        Icon="@ExpandIcon"
                        OnClick="@ToggleExpanded"/>
       </MudTooltip>
-      <CopyButton Text="@Content"/>
+      <CopyButton Text="@Content"
+                  Size="Size.Small"/>
     </MudToolBar>
-    <div style="@ScrollStyle">
-      @if (WrapText)
-      {
-        <pre class="ma-0 pa-2"
-             style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;">@Content</pre>
-      }
-      else
-      {
-        <pre class="ma-0 pa-2"
-             style="white-space: pre; overflow-x: auto;">@Content</pre>
-      }
+    <div class="spf-scroll @(_expanded ? "spf-scroll--expanded" : null)"
+          style="overscroll-behavior: @(_expanded ? "auto" : "none");">
+      <div class="spf-code @(WrapText ? "spf-code--wrap" : "spf-code--nowrap")">
+        @if (ShowLineNumbers)
+        {
+          @for (var index = 0; index < Lines.Length; index++)
+          {
+            <div class="spf-line">
+              <span class="spf-num">@(index + 1)</span>
+              <pre class="spf-text">@Lines[index]</pre>
+            </div>
+          }
+        }
+        else
+        {
+          @foreach (var line in Lines)
+          {
+            <div class="spf-line">
+              <pre class="spf-text">@line</pre>
+            </div>
+          }
+        }
+      </div>
     </div>
   </MudPaper>
 }

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.razor
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.razor
@@ -1,5 +1,6 @@
 @namespace Ozds.Client.Components.Fields
 @using MudBlazor
+@using Ozds.Client.Components.Buttons
 @inherits Ozds.Client.Components.Base.OzdsComponentBase
 
 @if (Content is null)
@@ -9,29 +10,30 @@
 else
 {
   <MudPaper Elevation="1"
-            Class="pa-2"
-            Style="@PaperStyle">
-    <div style="position: sticky; top: 0; height: 0; z-index: 2; pointer-events: none;">
-      <div style="position: absolute; top: 0; right: 0; pointer-events: auto;">
-        <MudIconButton Size="Size.Small"
+            Class="d-flex flex-column"
+            Style="overflow: hidden;">
+    <MudToolBar Dense="true"
+                Gutters="false"
+                Class="px-1"
+                Style="@HeaderStyle">
+      <MudTooltip Text="@ExpandTitle">
+        <MudIconButton Size="Size.Medium"
                        Icon="@ExpandIcon"
-                       OnClick="@ToggleExpanded"
-                       title="@ExpandTitle"/>
-      </div>
-    </div>
-    @if (ShowLineNumbers)
-    {
-      <div class="d-flex">
-        <pre class="ma-0 mr-3 text-right"
-             style="color: var(--mud-palette-text-secondary); white-space: pre; user-select: none;">@LineNumbers</pre>
-        <pre class="ma-0 flex-grow-1"
+                       OnClick="@ToggleExpanded"/>
+      </MudTooltip>
+      <CopyButton Text="@Content"/>
+    </MudToolBar>
+    <div style="@ScrollStyle">
+      @if (WrapText)
+      {
+        <pre class="ma-0 pa-2"
+             style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;">@Content</pre>
+      }
+      else
+      {
+        <pre class="ma-0 pa-2"
              style="white-space: pre; overflow-x: auto;">@Content</pre>
-      </div>
-    }
-    else
-    {
-      <pre class="ma-0"
-           style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;">@Content</pre>
-    }
+      }
+    </div>
   </MudPaper>
 }

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.razor
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.razor
@@ -1,0 +1,37 @@
+@namespace Ozds.Client.Components.Fields
+@using MudBlazor
+@inherits Ozds.Client.Components.Base.OzdsComponentBase
+
+@if (Content is null)
+{
+  <MudText>@Translate("None")</MudText>
+}
+else
+{
+  <MudPaper Elevation="1"
+            Class="pa-2"
+            Style="@PaperStyle">
+    <div style="position: sticky; top: 0; height: 0; z-index: 2; pointer-events: none;">
+      <div style="position: absolute; top: 0; right: 0; pointer-events: auto;">
+        <MudIconButton Size="Size.Small"
+                       Icon="@ExpandIcon"
+                       OnClick="@ToggleExpanded"
+                       title="@ExpandTitle"/>
+      </div>
+    </div>
+    @if (ShowLineNumbers)
+    {
+      <div class="d-flex">
+        <pre class="ma-0 mr-3 text-right"
+             style="color: var(--mud-palette-text-secondary); white-space: pre; user-select: none;">@LineNumbers</pre>
+        <pre class="ma-0 flex-grow-1"
+             style="white-space: pre; overflow-x: auto;">@Content</pre>
+      </div>
+    }
+    else
+    {
+      <pre class="ma-0"
+           style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;">@Content</pre>
+    }
+  </MudPaper>
+}

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.razor.css
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.razor.css
@@ -13,8 +13,9 @@
   flex-direction: column;
   min-width: 100%;
   padding: 0.25rem 0;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
-    "Liberation Mono", Menlo, monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo,
+    monospace;
   font-size: 0.8125rem;
   line-height: 1.5;
   color: var(--mud-palette-text-primary);

--- a/src/Ozds.Client/Components/Fields/ScrollablePreField.razor.css
+++ b/src/Ozds.Client/Components/Fields/ScrollablePreField.razor.css
@@ -1,0 +1,67 @@
+.spf-scroll {
+  max-height: var(--spf-max-height, 600px);
+  overflow: auto;
+  border-top: 1px solid var(--mud-palette-lines-default);
+}
+
+.spf-scroll--expanded {
+  max-height: none;
+}
+
+.spf-code {
+  display: flex;
+  flex-direction: column;
+  min-width: 100%;
+  padding: 0.25rem 0;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
+    "Liberation Mono", Menlo, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--mud-palette-text-primary);
+}
+
+.spf-code--nowrap {
+  width: max-content;
+}
+
+.spf-code--wrap {
+  width: 100%;
+}
+
+.spf-line {
+  display: flex;
+  align-items: stretch;
+}
+
+.spf-num {
+  flex: 0 0 auto;
+  box-sizing: content-box;
+  width: var(--spf-gutter, 2ch);
+  min-width: 2ch;
+  padding: 0 0.75rem;
+  text-align: right;
+  color: var(--mud-palette-text-disabled);
+  user-select: none;
+  position: sticky;
+  left: 0;
+  background-color: var(--mud-palette-surface);
+  border-right: 1px solid var(--mud-palette-lines-default);
+}
+
+.spf-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 1.5em;
+  margin: 0;
+  padding: 0 0.75rem;
+}
+
+.spf-code--wrap .spf-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.spf-code--nowrap .spf-text {
+  white-space: pre;
+}

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor.css
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor.css
@@ -47,6 +47,10 @@
   cursor: pointer;
 }
 
-.ozds-searchable-select__trigger ::deep .ozds-searchable-select__field--open .mud-input-adornment-end .mud-icon-root {
+.ozds-searchable-select__trigger
+  ::deep
+  .ozds-searchable-select__field--open
+  .mud-input-adornment-end
+  .mud-icon-root {
   transform: rotate(180deg);
 }

--- a/src/Ozds.Client/Components/Fields/SearchableSelectField.razor.css
+++ b/src/Ozds.Client/Components/Fields/SearchableSelectField.razor.css
@@ -1,0 +1,52 @@
+/* SearchableSelectField scoped styles.
+   Only the trigger/field markup lives in this component's DOM subtree,
+   so only those rules can be scoped here. The popover content
+   (__paper, __list-wrap, __item--selected, ...) is teleported out by
+   MudPopoverProvider, beyond the reach of scoped CSS / ::deep, so those
+   rules remain global in app.css. */
+
+.ozds-searchable-select {
+  position: relative;
+  width: 100%;
+}
+
+.ozds-searchable-select__trigger {
+  cursor: pointer;
+}
+
+.ozds-searchable-select__content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 19px;
+}
+
+.ozds-searchable-select__placeholder {
+  color: var(--mud-palette-text-secondary);
+}
+
+.ozds-searchable-select__value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.ozds-searchable-select__clear {
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-20%);
+  margin-left: auto;
+  z-index: 1;
+}
+
+.ozds-searchable-select__trigger ::deep .mud-input-control,
+.ozds-searchable-select__trigger ::deep .mud-input,
+.ozds-searchable-select__trigger ::deep .mud-input-slot {
+  cursor: pointer;
+}
+
+.ozds-searchable-select__trigger ::deep .ozds-searchable-select__field--open .mud-input-adornment-end .mud-icon-root {
+  transform: rotate(180deg);
+}

--- a/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
@@ -166,7 +166,7 @@
   protected RenderFragment ScrollablePreField<T>(
     Expression<Func<TModel, T?>> next,
     int maxHeight = 600,
-    bool showLineNumbers = false
+    bool wrapText = false
   )
   {
     var nextFunc = next.Compile();
@@ -174,14 +174,14 @@
     return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
              <ScrollablePreField Content="@value?.ToString()"
                                  MaxHeight="@maxHeight"
-                                 ShowLineNumbers="@showLineNumbers"/>
+                                 WrapText="@wrapText"/>
            </DetailsField>;
   }
 
   protected RenderFragment ScrollablePreField(
     Expression<Func<TModel, JsonDocument?>> next,
     int maxHeight = 600,
-    bool showLineNumbers = false
+    bool wrapText = false
   )
   {
     var nextFunc = next.Compile();
@@ -189,7 +189,7 @@
     return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
              <ScrollablePreField Content="@JsonString(value)"
                                  MaxHeight="@maxHeight"
-                                 ShowLineNumbers="@showLineNumbers"/>
+                                 WrapText="@wrapText"/>
            </DetailsField>;
   }
 

--- a/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
@@ -165,28 +165,31 @@
 
   protected RenderFragment ScrollablePreField<T>(
     Expression<Func<TModel, T?>> next,
-    int maxHeight = 600
+    int maxHeight = 600,
+    bool showLineNumbers = false
   )
   {
     var nextFunc = next.Compile();
     var value = nextFunc(Model);
     return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
-            @if (value is null)
-             {
-               <MudText>@Translate("None")</MudText>
-             }
-             else
-             {
-               <MudPaper Elevation="1"
-                         Class="pa-2"
-                         Style="@($"max-height:{maxHeight}px; overflow-y:auto; overscroll-behavior: none;")">
-                 <pre
-                 class="ma-0"
-                 style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;">
-                  @value
-                 </pre>
-               </MudPaper>
-             }
+             <ScrollablePreField Content="@value?.ToString()"
+                                 MaxHeight="@maxHeight"
+                                 ShowLineNumbers="@showLineNumbers"/>
+           </DetailsField>;
+  }
+
+  protected RenderFragment ScrollablePreField(
+    Expression<Func<TModel, JsonDocument?>> next,
+    int maxHeight = 600,
+    bool showLineNumbers = false
+  )
+  {
+    var nextFunc = next.Compile();
+    var value = nextFunc(Model);
+    return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
+             <ScrollablePreField Content="@JsonString(value)"
+                                 MaxHeight="@maxHeight"
+                                 ShowLineNumbers="@showLineNumbers"/>
            </DetailsField>;
   }
 

--- a/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
@@ -159,6 +159,34 @@
           @nextFunc(Model)
         </pre>
              </MudText>
+           </DetailsField>
+        ;
+    }
+
+  protected RenderFragment ScrollablePreField<T>(
+    Expression<Func<TModel, T?>> next,
+    int maxHeight = 600
+  )
+  {
+    var nextFunc = next.Compile();
+    var value = nextFunc(Model);
+    return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
+            @if (value is null)
+             {
+               <MudText>@Translate("None")</MudText>
+             }
+             else
+             {
+               <MudPaper Elevation="1"
+                         Class="pa-2"
+                         Style="@($"max-height:{maxHeight}px; overflow-y:auto; overscroll-behavior: none;")">
+                 <pre
+                 class="ma-0"
+                 style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;">
+                  @value
+                 </pre>
+               </MudPaper>
+             }
            </DetailsField>;
   }
 

--- a/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
+++ b/src/Ozds.Client/Components/Models/Base/OzdsDetailsComponentBase.razor
@@ -166,7 +166,8 @@
   protected RenderFragment ScrollablePreField<T>(
     Expression<Func<TModel, T?>> next,
     int maxHeight = 600,
-    bool wrapText = false
+    bool wrapText = false,
+    bool showLineNumbers = true
   )
   {
     var nextFunc = next.Compile();
@@ -174,14 +175,16 @@
     return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
              <ScrollablePreField Content="@value?.ToString()"
                                  MaxHeight="@maxHeight"
-                                 WrapText="@wrapText"/>
+                                 WrapText="@wrapText"
+                                 ShowLineNumbers="@showLineNumbers"/>
            </DetailsField>;
   }
 
   protected RenderFragment ScrollablePreField(
     Expression<Func<TModel, JsonDocument?>> next,
     int maxHeight = 600,
-    bool wrapText = false
+    bool wrapText = false,
+    bool showLineNumbers = true
   )
   {
     var nextFunc = next.Compile();
@@ -189,7 +192,8 @@
     return @<DetailsField Title="@(Translate(Label(next)))" MaxWidth="100%" LargeContent>
              <ScrollablePreField Content="@JsonString(value)"
                                  MaxHeight="@maxHeight"
-                                 WrapText="@wrapText"/>
+                                 WrapText="@wrapText"
+                                 ShowLineNumbers="@showLineNumbers"/>
            </DetailsField>;
   }
 

--- a/src/Ozds.Client/Components/Models/Implementations/System/Events/EventDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/System/Events/EventDetails.razor
@@ -10,6 +10,6 @@
 
 @Field(x => x.Level)
 
-@Field(x => x.Content)
+@ScrollablePreField(x => x.Content)
 
 @Field(x => x.Categories)

--- a/src/Ozds.Client/Components/Models/Implementations/System/Events/EventDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/System/Events/EventDetails.razor
@@ -10,6 +10,6 @@
 
 @Field(x => x.Level)
 
-@ScrollablePreField(x => x.Content)
+@ScrollablePreField(x => x.Content, wrapText: true)
 
 @Field(x => x.Categories)

--- a/src/Ozds.Client/Components/Models/Implementations/System/Notifications/NotificationDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/System/Notifications/NotificationDetails.razor
@@ -8,7 +8,7 @@
 
 @Field(x => x.Summary)
 
-@PreField(x => x.Content)
+@ScrollablePreField(x => x.Content)
 
 @Sub()
 

--- a/src/Ozds.Client/Components/Models/Implementations/System/Notifications/NotificationDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/System/Notifications/NotificationDetails.razor
@@ -8,7 +8,7 @@
 
 @Field(x => x.Summary)
 
-@ScrollablePreField(x => x.Content)
+@ScrollablePreField(x => x.Content, 400, true)
 
 @Sub()
 

--- a/src/Ozds.Client/Components/Models/Implementations/System/Notifications/NotificationDetails.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/System/Notifications/NotificationDetails.razor
@@ -8,7 +8,7 @@
 
 @Field(x => x.Summary)
 
-@ScrollablePreField(x => x.Content, 400, true)
+@ScrollablePreField(x => x.Content, 400, wrapText: true)
 
 @Sub()
 

--- a/src/Ozds.Client/Extensions/HostExtensions.cs
+++ b/src/Ozds.Client/Extensions/HostExtensions.cs
@@ -79,8 +79,8 @@ public static class HostExtensions
   }
 
   private static IHostApplicationBuilder AddLocalServices(
-     this IHostApplicationBuilder builder
-    )
+    this IHostApplicationBuilder builder
+  )
   {
     builder.Services.AddScoped<ClipboardService>();
     return builder;

--- a/src/Ozds.Client/Extensions/HostExtensions.cs
+++ b/src/Ozds.Client/Extensions/HostExtensions.cs
@@ -3,6 +3,7 @@ using Blazored.LocalStorage;
 using MudBlazor.Services;
 using Ozds.Client.Components.Models;
 using Ozds.Client.Components.Models.Abstractions;
+using Ozds.Client.Services;
 
 namespace Ozds.Client.Extensions;
 
@@ -16,6 +17,7 @@ public static class HostExtensions
     builder.AddBlazor();
     builder.AddLocalStorage();
     builder.AddUi();
+    builder.AddLocalServices();
     return builder;
   }
 
@@ -73,6 +75,14 @@ public static class HostExtensions
   {
     builder.Services.AddBlazoredLocalStorage();
 
+    return builder;
+  }
+
+  private static IHostApplicationBuilder AddLocalServices(
+     this IHostApplicationBuilder builder
+    )
+  {
+    builder.Services.AddScoped<ClipboardService>();
     return builder;
   }
 }

--- a/src/Ozds.Client/Pages/Administration/ApiKeyPage.razor
+++ b/src/Ozds.Client/Pages/Administration/ApiKeyPage.razor
@@ -6,6 +6,7 @@
 @using Ozds.Business.Models
 @using Ozds.Business.Models.Enums
 @using Ozds.Business.Models.Joins
+@using Ozds.Client.Components.Buttons
 @using Ozds.Client.Components.Streaming
 @inherits Ozds.Client.Components.Models.Base.OzdsIdentifiableModelPageComponentBase<Ozds.Business.Models.ApiKeyModel>
 
@@ -48,14 +49,17 @@
     }
 
     var apiKeyManager = ScopedServices.GetRequiredService<ApiKeyManager>();
+    var token = apiKeyManager.Tokenize(model);
 
     return @<MudText Class="mt-4">
              <p class="mb-2">
                @Translate("Please copy this key (it won't be shown again):")
              </p>
-             <pre>
-        @($"{apiKeyManager.Tokenize(model)}")
-      </pre>
+             <div class="d-flex align-center">
+               <pre class="ma-0 mr-2"
+                    style="flex: 1; min-width: 0; white-space: pre; overflow-x: auto;">@token</pre>
+               <CopyButton Text="@token"/>
+             </div>
            </MudText>;
   }
 

--- a/src/Ozds.Client/Services/ClipboardService.cs
+++ b/src/Ozds.Client/Services/ClipboardService.cs
@@ -1,0 +1,18 @@
+using Microsoft.JSInterop;
+
+namespace Ozds.Client.Services;
+
+public class ClipboardService(
+  IJSRuntime _jsRuntime
+)
+{
+  public ValueTask<string> ReadTextAsync()
+  {
+    return _jsRuntime.InvokeAsync<string>("navigator.clipboard.readText");
+  }
+
+  public ValueTask WriteTextAsync(string text)
+  {
+    return _jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+  }
+}

--- a/src/Ozds.Client/Services/ClipboardService.cs
+++ b/src/Ozds.Client/Services/ClipboardService.cs
@@ -2,9 +2,7 @@ using Microsoft.JSInterop;
 
 namespace Ozds.Client.Services;
 
-public class ClipboardService(
-  IJSRuntime _jsRuntime
-)
+public class ClipboardService(IJSRuntime _jsRuntime)
 {
   public ValueTask<string> ReadTextAsync()
   {

--- a/src/Ozds.Server/Views/Shared/_AppLayout.cshtml
+++ b/src/Ozds.Server/Views/Shared/_AppLayout.cshtml
@@ -25,6 +25,7 @@
   <link href="/_content/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
   <link href="/css/app.css" rel="stylesheet" />
+  <link href="/Ozds.Client.styles.css" rel="stylesheet" />
   <link rel="icon" type="image/png" href="/favicon.png">
 
   @(await Html.RenderComponentAsync<HeadOutlet>(RenderMode.Server))

--- a/src/Ozds.Server/wwwroot/css/app.css
+++ b/src/Ozds.Server/wwwroot/css/app.css
@@ -15,39 +15,13 @@
    src/Ozds.Client/Components/Fields/SearchableSelectField.razor
    A searchable single/multi-select dropdown built on
    MudField + MudPopover. Mimics MudSelect.
+
+   The trigger/field rules live in the component's scoped
+   SearchableSelectField.razor.css. Only the popover content rules
+   remain here: MudPopoverProvider teleports the popover out of the
+   component's DOM subtree, beyond the reach of scoped CSS / ::deep.
    Component style section START
    ------------------------------------------------------------ */
-
-.ozds-searchable-select {
-  position: relative;
-  width: 100%;
-}
-
-.ozds-searchable-select__trigger {
-  cursor: pointer;
-}
-
-.ozds-searchable-select__content {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  min-height: 19px;
-}
-
-.ozds-searchable-select__placeholder {
-  color: var(--mud-palette-text-secondary);
-}
-
-.ozds-searchable-select__value {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.ozds-searchable-select__clear {
-  margin-left: auto;
-}
 
 .ozds-searchable-select__paper {
   display: flex;
@@ -64,29 +38,6 @@
 
 .ozds-searchable-select__item--selected {
   background-color: var(--mud-palette-action-default-hover);
-}
-
-/* Clear button overlays the field so toggling it doesn't change
-   the field's height — sits just to the left of the chevron. */
-.ozds-searchable-select__clear {
-  position: absolute;
-  top: 50%;
-  right: 20px;
-  transform: translateY(-20%);
-  z-index: 1;
-}
-
-/* Force pointer so the whole trigger feels
-   clickable */
-.ozds-searchable-select__field .mud-input-control,
-.ozds-searchable-select__field .mud-input,
-.ozds-searchable-select__field .mud-input-slot {
-  cursor: pointer;
-}
-
-/* Rotate MudField's end adornment (the chevron) when open. */
-.ozds-searchable-select__field--open .mud-input-adornment-end .mud-icon-root {
-  transform: rotate(180deg);
 }
 
 /* ------------------------------------------------------------


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #252
Fixes #343 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Added

- `ScrollablePreField<T>` helper on `OzdsDetailsComponentBase`, a wrapper around
  `DetailsField` + `MudPaper` that renders preformatted content (notification
  bodies, event JSON payloads) inside a fixed-height, vertically-scrollable,
  horizontally-resizable card
- `MaxWidth` parameter on `DetailsField` (defaults to `36rem`) so callers can
  opt into a wider layout

### Changed

- `NotificationDetails` now renders `Content` via the new `ScrollablePreField`
- `EventDetails` now renders `Content` via `ScrollablePreField`

The scrollable window for now looks as: 

<img width="1252" height="798" alt="image" src="https://github.com/user-attachments/assets/960fc2b5-6778-4bca-8558-d3e2fa9e34d4" />

It has wrapping functionality implemented so that the message does not generate a message with huge horizontal overflow like the one depicted on the picture below:

<img width="697" height="420" alt="image" src="https://github.com/user-attachments/assets/31e88501-f894-4e78-891c-6db92749d43b" />

## Testing

Testing on local builds on frontend. User needs to enter page for notifications / events and observe new scrollable display for `<pre>` fields.
