### PR TITLE
341 notifications which are created when messenger push fails do not have title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
   in `NavigationDrawer.razor`
 - Removed `MudDrawerContainer` from `MudDrawer` since it's supposed to be a
   parent container for `MudDrawer` component
+- `IdentifiableColumns` now renders a localized `[No title exists]` placeholder
+  for items without a title instead
+- Fix, messenger push-failure notifications now set a `Title`
+  (`Messenger push failed`) in `IotPushHandler`
 
 ## [1.8.5] - 2026-05-13
 

--- a/src/Ozds.Assets/Assets/Translations/en.xml
+++ b/src/Ozds.Assets/Assets/Translations/en.xml
@@ -17259,6 +17259,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        No title exists
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Models/Implementations/IdentifiableColumns.razor' line 15 column 51
+      </Metadata>
+      <Value>
+        No title exists
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         None
       </Key>
       <Metadata>

--- a/src/Ozds.Assets/Assets/Translations/hr.xml
+++ b/src/Ozds.Assets/Assets/Translations/hr.xml
@@ -17259,6 +17259,17 @@
     </TranslationDictionaryItem>
     <TranslationDictionaryItem>
       <Key>
+        No title exists
+      </Key>
+      <Metadata>
+        From file 'Ozds.Client/Components/Models/Implementations/IdentifiableColumns.razor' line 15 column 51
+      </Metadata>
+      <Value>
+        Naslov ne postoji
+      </Value>
+    </TranslationDictionaryItem>
+    <TranslationDictionaryItem>
+      <Key>
         None
       </Key>
       <Metadata>

--- a/src/Ozds.Business/Reactors/Implementations/IotPushReactor.cs
+++ b/src/Ozds.Business/Reactors/Implementations/IotPushReactor.cs
@@ -184,6 +184,7 @@ public class IotPushHandler(
     }
 
     var notification = activator.Activate<MessengerNotificationModel>();
+    notification.Title = "Messenger push failed";
     notification.MessengerId = messenger.Id;
     notification.Timestamp = now;
     notification.Topics = [TopicModel.All, TopicModel.InvalidPush];

--- a/src/Ozds.Client/Components/Models/Implementations/IdentifiableColumns.razor
+++ b/src/Ozds.Client/Components/Models/Implementations/IdentifiableColumns.razor
@@ -12,7 +12,7 @@
     @if (Raw(context.Item) is { } model)
     {
       <MudLink Href="@(Provider.CreateLink(model))">
-        @model.Title
+        @(string.IsNullOrEmpty(model.Title) ? $"[{Translate("No title exists")}]" : model.Title)
       </MudLink>
     }
   </CellTemplate>


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #342 
Fixes #341 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed 

- `IdentifiableColumns` now renders a localized `[No title exists]` placeholder
  for items without a title instead
- Fix, messenger push-failure notifications now set a `Title`
  (`Messenger push failed`) in `IotPushHandler`

Now the notifications have title descriptor for failed messenger push (fail in validation step).

<img width="985" height="132" alt="image" src="https://github.com/user-attachments/assets/f64c4162-2e1b-44d1-97af-164ec44dcb7f" />

## Testing

Localized development env tests on frontend.


