### PR TITLE
Add meter and measurement location on event errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- New `MeasurementValidationResult` (sealed, extends `ValidationResult`)
+  attaches the source `IMeter` and nullable `IMeasurementLocation` to each
+  validation error so downstream consumers can attribute the error to its meter
+  and location
+- `MeasurementValidator` now wraps every underlying `ValidationResult` in a
+  `MeasurementValidationResult` carrying the meter and its resolved measurement
+  location
+- `IotPushHandler.FormatValidationResults` replaces the previous flat
+  `member: message` join used for both `MessengerEventModel.Content.Error` and
+  `MessengerNotificationModel.Content` - it groups `MeasurementValidationResult`
+  items by `(meter.Id, measurementLocation?.Title)`
 - `SearchableSelectField<T>` now combines its dropdown list with `MudVirtualize`
   instead of a `MudList` + `@foreach`, so dropdowns with thousands of items
   render only the visible window plus an additional buffer of 6 rows for more

--- a/src/Ozds.Business/Reactors/Implementations/IotPushReactor.cs
+++ b/src/Ozds.Business/Reactors/Implementations/IotPushReactor.cs
@@ -146,12 +146,7 @@ public class IotPushHandler(
       CategoryModel.MessengerPush,
     ];
     var error = validationResults is not null
-      ? string.Join(
-        "\n",
-        validationResults.Select(x =>
-          $"{x.MemberNames.First()}: {x.ErrorMessage}"
-        )
-      )
+      ? FormatValidationResults(validationResults)
       : null;
     @event.Content = CreateEventContent(eventArgs, messenger, error);
     @event.Level = validationResults is null
@@ -189,14 +184,56 @@ public class IotPushHandler(
     notification.Topics = [TopicModel.All, TopicModel.InvalidPush];
     notification.Summary = $"Messenger \"{messenger.Title}\" push failed";
     // NOTE: \n is ok here because we're storing it in the database
-    notification.Content = string.Join(
-      "\n",
-      validationResults.Select(x =>
-        $"{x.MemberNames.First()}: {x.ErrorMessage}"
-      )
-    );
+    notification.Content = FormatValidationResults(validationResults);
     notification.EventId = eventId;
     await modelMutations.Create(notification, cancellationToken);
+  }
+
+  private static string FormatValidationResults(
+    IEnumerable<ValidationResult> results
+  )
+  {
+    var lines = new List<string>();
+
+    var measurementValidationResults = new List<MeasurementValidationResult>();
+    var otherValidationResults = new List<ValidationResult>();
+
+    foreach (var result in results)
+    {
+      if (result is MeasurementValidationResult measurementResult)
+      {
+        measurementValidationResults.Add(measurementResult);
+      }
+      else
+      {
+        otherValidationResults.Add(result);
+      }
+    }
+
+    var grouped =
+      measurementValidationResults
+      .GroupBy(r => (r.Meter.Id, r.MeasurementLocation?.Title));
+
+    foreach (var group in grouped)
+    {
+      var location = string.IsNullOrWhiteSpace(group.Key.Title)
+        ? "<unknown location>"
+        : group.Key.Title;
+      lines.Add($"[meter: {group.Key.Id} | measurement location: {location}]");
+      foreach (var result in group)
+      {
+        var member = result.MemberNames.FirstOrDefault() ?? "?";
+        lines.Add($"  {member}: {result.ErrorMessage}");
+      }
+    }
+
+    foreach (var result in otherValidationResults)
+    {
+      var member = result.MemberNames.FirstOrDefault() ?? "?";
+      lines.Add($"{member}: {result.ErrorMessage}");
+    }
+
+    return string.Join("\n", lines);
   }
 
   private static JsonDocument CreateEventContent(

--- a/src/Ozds.Business/Reactors/Implementations/IotPushReactor.cs
+++ b/src/Ozds.Business/Reactors/Implementations/IotPushReactor.cs
@@ -210,9 +210,9 @@ public class IotPushHandler(
       }
     }
 
-    var grouped =
-      measurementValidationResults
-      .GroupBy(r => (r.Meter.Id, r.MeasurementLocation?.Title));
+    var grouped = measurementValidationResults.GroupBy(r =>
+      (r.Meter.Id, r.MeasurementLocation?.Title)
+    );
 
     foreach (var group in grouped)
     {

--- a/src/Ozds.Business/Validation/Implementations/MeasurementValidator.cs
+++ b/src/Ozds.Business/Validation/Implementations/MeasurementValidator.cs
@@ -8,7 +8,6 @@ namespace Ozds.Business.Validation.Implementations;
 public class MeasurementValidator(IServiceProvider serviceProvider)
   : ConcreteModelValidator<IMeasurement>(serviceProvider)
 {
-
   public override async Task<List<ValidationResult>> ValidateAsync(
     IMeasurement model,
     CancellationToken cancellationToken
@@ -43,9 +42,7 @@ public class MeasurementValidator(IServiceProvider serviceProvider)
 
     var validationContext = new ValidationContext(model, serviceProvider, null);
 
-    var validationResults = validator
-      .Validate(validationContext)
-      .ToList();
+    var validationResults = validator.Validate(validationContext).ToList();
 
     if (validationResults.Count == 0)
     {
@@ -53,21 +50,18 @@ public class MeasurementValidator(IServiceProvider serviceProvider)
     }
 
     var measurementLocationQueries =
-        scope.ServiceProvider.GetRequiredService<MeasurementLocationQueries>();
+      scope.ServiceProvider.GetRequiredService<MeasurementLocationQueries>();
 
-    var measurementLocation = await measurementLocationQueries
-      .ReadByMeterId(
-        model.MeterId,
-        cancellationToken
-      );
+    var measurementLocation = await measurementLocationQueries.ReadByMeterId(
+      model.MeterId,
+      cancellationToken
+    );
 
     return validationResults
-      .Select(result => (ValidationResult)
-        new MeasurementValidationResult(
-          result,
-          meter,
-          measurementLocation
-        )
-      ).ToList();
+      .Select(result =>
+        (ValidationResult)
+          new MeasurementValidationResult(result, meter, measurementLocation)
+      )
+      .ToList();
   }
 }

--- a/src/Ozds.Business/Validation/Implementations/MeasurementValidator.cs
+++ b/src/Ozds.Business/Validation/Implementations/MeasurementValidator.cs
@@ -8,12 +8,14 @@ namespace Ozds.Business.Validation.Implementations;
 public class MeasurementValidator(IServiceProvider serviceProvider)
   : ConcreteModelValidator<IMeasurement>(serviceProvider)
 {
+
   public override async Task<List<ValidationResult>> ValidateAsync(
     IMeasurement model,
     CancellationToken cancellationToken
   )
   {
     await using var scope = serviceProvider.CreateAsyncScope();
+
     var trackableQueries =
       scope.ServiceProvider.GetRequiredService<TrackableQueries>();
 
@@ -24,7 +26,7 @@ public class MeasurementValidator(IServiceProvider serviceProvider)
     if (meter is null)
     {
       throw new InvalidOperationException(
-        $"Meter not found for meter {model.MeterId}"
+        $"Meter not found for id {model.MeterId}"
       );
     }
 
@@ -40,6 +42,32 @@ public class MeasurementValidator(IServiceProvider serviceProvider)
     }
 
     var validationContext = new ValidationContext(model, serviceProvider, null);
-    return validator.Validate(validationContext).ToList();
+
+    var validationResults = validator
+      .Validate(validationContext)
+      .ToList();
+
+    if (validationResults.Count == 0)
+    {
+      return validationResults;
+    }
+
+    var measurementLocationQueries =
+        scope.ServiceProvider.GetRequiredService<MeasurementLocationQueries>();
+
+    var measurementLocation = await measurementLocationQueries
+      .ReadByMeterId(
+        model.MeterId,
+        cancellationToken
+      );
+
+    return validationResults
+      .Select(result => (ValidationResult)
+        new MeasurementValidationResult(
+          result,
+          meter,
+          measurementLocation
+        )
+      ).ToList();
   }
 }

--- a/src/Ozds.Business/Validation/MeasurementValidationResult.cs
+++ b/src/Ozds.Business/Validation/MeasurementValidationResult.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Ozds.Business.Models.Abstractions;
+
+namespace Ozds.Business.Validation;
+
+public sealed class MeasurementValidationResult : ValidationResult
+{
+  public MeasurementValidationResult(
+    ValidationResult source,
+    IMeter meter,
+    IMeasurementLocation? measurementLocation
+  )
+    : base(source.ErrorMessage, source.MemberNames)
+  {
+    Meter = meter;
+    MeasurementLocation = measurementLocation;
+  }
+
+  public IMeter Meter { get; }
+
+  public IMeasurementLocation? MeasurementLocation { get; }
+}


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

Fixes #340

## Description

Client states that the notifications (both on web application and in email notifications - specific for describing invalid push, they should be named under meter/measurement-location which could identify where the invalid push is even coming from). 

Problem further explained in issue no. #340.

What this PR tries to resolve:

It implements new type of validation result which might describe measurements better in detail. `MeasurementValidationResult` is a sealed class that inherits `ValidationResult` and is used to store `IMeter` and `IMeasurementLocation` holders for objects which hold more information about meter and measurement location which produced this validation error. Also changed is `IoTPushReactor` which now groups validations based on meter and measurement location and formats accordingly.

The result of this new formatting is image bellow:

<img width="768" height="407" alt="image" src="https://github.com/user-attachments/assets/a278b998-f460-4e84-b3c7-7c8650ac5cc5" />

### Changed

- New `MeasurementValidationResult` (sealed, extends `ValidationResult`)
  attaches the source `IMeter` and nullable `IMeasurementLocation` to each
  validation error so downstream consumers can attribute the error to its meter
  and location
- `MeasurementValidator` now wraps every underlying `ValidationResult` in a
  `MeasurementValidationResult` carrying the meter and its resolved measurement
  location
- `IotPushHandler.FormatValidationResults` replaces the previous flat
  `member: message` join used for both `MessengerEventModel.Content.Error` and
  `MessengerNotificationModel.Content` - it groups `MeasurementValidationResult`
  items by `(meter.Id, measurementLocation?.Title)`

## Testing

Currently there is also implementation of nushell scripts which would enable to push sentinels into the localized development environment. Until then you can try to manually trigger this with your custom IoT push onto the localized backend and observe the different way of storing notification message.
