### PR TITLE
Navigation responsivity breaks fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Fix, body offset on PDF export in `DocumentLayout.razor`: added
   `html, body { margin: 0; padding: 0 }` inside `@@media print` to neutralize
   Chromium's default 8px user-agent body margin during Playwright PDF rendering
+- Fix, full-screen navigation drawer leaking onto the page on scaled viewports
+  in `NavigationDrawer.razor`
+- Removed `MudDrawerContainer` from `MudDrawer` since it's supposed to be a
+  parent container for `MudDrawer` component
 
 ## [1.8.5] - 2026-05-13
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -208,3 +208,4 @@ words:
   - compgen
   - overscroll
   - overscan
+  - viewports

--- a/src/Ozds.Client/Components/Layout/NavigationDrawer.razor
+++ b/src/Ozds.Client/Components/Layout/NavigationDrawer.razor
@@ -4,7 +4,6 @@
 @using MudBlazor
 @implements IDisposable
 
-
 <MudDrawer
   Open="@LayoutState.IsNavigationDrawerOpen"
   OpenChanged="SetNavigationDrawerOpen"

--- a/src/Ozds.Client/Components/Layout/NavigationDrawer.razor
+++ b/src/Ozds.Client/Components/Layout/NavigationDrawer.razor
@@ -4,6 +4,7 @@
 @using MudBlazor
 @implements IDisposable
 
+
 <MudDrawer
   Open="@LayoutState.IsNavigationDrawerOpen"
   OpenChanged="SetNavigationDrawerOpen"
@@ -11,7 +12,7 @@
   Anchor="@LayoutState.DrawerAnchor"
   Variant="DrawerVariant.Temporary"
   ClipMode="DrawerClipMode.Never"
-  Style="height: 100vh;">
+  Style="height: 100dvh; --mud-drawer-content-height: 100dvh !important;">
   <MudDrawerHeader Style="padding-inline: 0;">
     <MudContainer
       MaxWidth="@MaxWidth"
@@ -32,7 +33,6 @@
       </MudButton>
     </MudContainer>
   </MudDrawerHeader>
-  <MudDrawerContainer>
     <MudNavMenu>
       <MudContainer
         MaxWidth="@MaxWidth"
@@ -44,7 +44,6 @@
         }
       </MudContainer>
     </MudNavMenu>
-  </MudDrawerContainer>
 </MudDrawer>
 
 @code {


### PR DESCRIPTION
# Task

@HrvojeJuric

Fixes #314 

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

### Changed

- Fix, full-screen navigation drawer leaking onto the page on scaled viewports
  in `NavigationDrawer.razor`
- Removed `MudDrawerContainer` from `MudDrawer` since it's supposed to be a
  parent container for `MudDrawer` component

## Testing

Just try scaling the website now while the navigation component is closed.