### PR TITLE
Updated packages AngleSharp and HtmlSanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Updated `AngleSharp` from version `0.17.0` to version `1.5.0` | `1.6.0`
+  (transitive dep within `HtmlSanitizer` lib)
+- Updated `HtmlSanitizer` from version `9.0.892` to `9.1.974`
 - Commented out translation step in `generate` workflow
 - New `MeasurementValidationResult` (sealed, extends `ValidationResult`)
   attaches the source `IMeter` and nullable `IMeasurementLocation` to each

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="CsvHelper" Version="31.0.3" />
     <PackageVersion Include="Tomlyn" Version="0.19.0" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.1.974" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />

--- a/scripts/flake/ozds/deps.json
+++ b/scripts/flake/ozds/deps.json
@@ -6,18 +6,18 @@
   },
   {
     "pname": "AngleSharp",
-    "version": "0.17.0",
-    "hash": "sha256-cQvLOL296TROZkL2nVLoLEuRaN5UfjFFJIzG0/JgYrg="
+    "version": "1.5.0",
+    "hash": "sha256-290+oGXJRDf3q06rRrcQmg3XbKYhgIa6xjn5vUJWRJ4="
   },
   {
     "pname": "AngleSharp",
-    "version": "0.17.1",
-    "hash": "sha256-8DLs4SGXeG4ilbAJ8H6KLjaK/GmaXizMEMc3P8ZrEQ0="
+    "version": "1.6.0",
+    "hash": "sha256-3T57sDeONAjzhGR/EcH2+626/CHsp5MrXSb802UREKc="
   },
   {
     "pname": "AngleSharp.Css",
-    "version": "0.17.0",
-    "hash": "sha256-sXzp9kY/rp3KauGNDpITkpjdgNoO0BdlC38SQYl0u2A="
+    "version": "1.0.0",
+    "hash": "sha256-hCsSNsEzIkmZf8TtFSLYqaRQbazsACrVQLCCLA4/mJs="
   },
   {
     "pname": "AppAny.Quartz.EntityFrameworkCore.Migrations",
@@ -141,8 +141,8 @@
   },
   {
     "pname": "HtmlSanitizer",
-    "version": "9.0.892",
-    "hash": "sha256-8ZVGH6RJ3QjgmwSGdVadS2pd3Tgq9IHXW7VHOX0slH0="
+    "version": "9.1.974",
+    "hash": "sha256-HPojw6iuMsc2G155X/gzkkb0PQLPB77rsIZLBiRyH0k="
   },
   {
     "pname": "Humanizer.Core",


### PR DESCRIPTION
# Task

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

`AngleSharp` version `0.17.0` was deprecated with security issues.

- Updated `AngleSharp` from version `0.17.0` to version `1.5.0` | `1.6.0`
  (transitive dep within `HtmlSanitizer` lib)
- Updated `HtmlSanitizer` from version `9.0.892` to `9.1.974`

## Testing

For now tests were run locally to see if everything builds correctly